### PR TITLE
Add cancellation token to query context

### DIFF
--- a/src/SqlHydra.Query/QueryContext.fs
+++ b/src/SqlHydra.Query/QueryContext.fs
@@ -147,9 +147,9 @@ type QueryContext(conn: DbConnection, compiler: SqlKata.Compilers.Compiler) =
             System.Convert.ChangeType(results, typeof<'InsertReturn>) :?> 'InsertReturn
 
     member this.InsertAsync<'T, 'InsertReturn when 'InsertReturn : struct> (query: InsertQuery<'T, 'InsertReturn>) = 
-        this.InsertAsync(CancellationToken.None, query)
+        this.InsertAsync(query, CancellationToken.None)
     
-    member this.InsertAsync<'T, 'InsertReturn when 'InsertReturn : struct> (cancellationToken: CancellationToken, query: InsertQuery<'T, 'InsertReturn>) = 
+    member this.InsertAsync<'T, 'InsertReturn when 'InsertReturn : struct> (query: InsertQuery<'T, 'InsertReturn>, cancellationToken: CancellationToken) = 
         async {
             use cmd = this.BuildCommand(query.ToKataQuery())
             // Did the user select an identity field?
@@ -175,9 +175,9 @@ type QueryContext(conn: DbConnection, compiler: SqlKata.Compilers.Compiler) =
         cmd.ExecuteNonQuery()
 
     member this.UpdateAsync (query: UpdateQuery<'T>) = 
-        this.UpdateAsync(CancellationToken.None, query)
+        this.UpdateAsync(query, CancellationToken.None)
     
-    member this.UpdateAsync (cancellationToken: CancellationToken, query: UpdateQuery<'T>) = 
+    member this.UpdateAsync (query: UpdateQuery<'T>, cancellationToken: CancellationToken) = 
         use cmd = this.BuildCommand(query.ToKataQuery())
         cmd.ExecuteNonQueryAsync(cancellationToken)
 
@@ -186,9 +186,9 @@ type QueryContext(conn: DbConnection, compiler: SqlKata.Compilers.Compiler) =
         cmd.ExecuteNonQuery()
 
     member this.DeleteAsync (query: DeleteQuery<'T>) = 
-        this.DeleteAsync(CancellationToken.None, query)
+        this.DeleteAsync(query, CancellationToken.None)
 
-    member this.DeleteAsync (cancellationToken: CancellationToken, query: DeleteQuery<'T>) = 
+    member this.DeleteAsync (query: DeleteQuery<'T>, cancellationToken: CancellationToken) = 
         use cmd = this.BuildCommand(query.ToKataQuery())
         cmd.ExecuteNonQueryAsync(cancellationToken)
 
@@ -199,9 +199,9 @@ type QueryContext(conn: DbConnection, compiler: SqlKata.Compilers.Compiler) =
         | _  as count -> count :?> int
 
     member this.CountAsync (query: SelectQuery<int>) = 
-        this.CountAsync(CancellationToken.None, query)
+        this.CountAsync(query, CancellationToken.None)
 
-    member this.CountAsync (cancellationToken: CancellationToken, query: SelectQuery<int>) = 
+    member this.CountAsync (query: SelectQuery<int>, cancellationToken: CancellationToken) = 
         async {
             use cmd = this.BuildCommand(query.ToKataQuery())
             let! count = cmd.ExecuteScalarAsync(cancellationToken) |> Async.AwaitTask


### PR DESCRIPTION
Adds cancellation token to all async methods in `QueryContext`, closes #19 .
Overloads didn't work for `ReadAsync` and `ReadOneAsync` since they are curried and it is not allowed with overloads (see [docs](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/members/methods#overloaded-methods)), so I had to create new methods that take cancellation token. I added `cancellationToken` as the last parameter for overloads (seems to conform with other `dotnet` libraries), but for curried methods it is next to last to allow piping queries as the last parameter.  

It does seem a bit weird to create new methods for cancellation, but if we were to change type signatures to tuples and have normal overloads it would be a breaking change. 

What are you thoughts, @JordanMarr ?