### PR TITLE
Make it explicit that `conn.Open()` needs to be called

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ let errorLogTable =         table<dbo.ErrorLog>
 /// Opens a connection and creates a QueryContext that will generate SQL Server dialect queries
 let openContext() = 
     let compiler = SqlKata.Compilers.SqlServerCompiler()
-    let conn = openConnection()
+    let conn = new SqlConnection("Replace with your connection string")
+    conn.Open()
     new QueryContext(conn, compiler)
 ```
 


### PR DESCRIPTION
When I did the setup of SqlHydra in my project I read through the README and came up with this code:

```fs
[<RequireQualifiedAccess>]
module DbContext =

    open SqlHydra.Query
    open Microsoft.Data.SqlClient

    let create () =
        let compiler = SqlKata.Compilers.SqlServerCompiler()
        let conn = new SqlConnection("My connection string")
        new QueryContext(conn, compiler)

```

It was working fine as long as I used single used context via `Create DbContext.create` however when using re-usable connection via `Shared DbContext.create` I kept getting error because the connection was closed.

After looking in the tests, I discovered that you always called `conn.Open()` in this function.

This was not clear to me because of the obscure `openConnection()` function, I think making it explicit in the example can be an improvement.