### PR TITLE
support implicit .NET conversions on option types

### DIFF
--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -70,7 +70,14 @@ module VisitorPatterns =
         match exp.NodeType with
         | ExpressionType.Constant -> Some (exp :?> ConstantExpression)
         | _ -> None
-
+    
+    let (|Convert|_|) (exp: Expression) =
+        match exp.NodeType with
+        | ExpressionType.Convert ->
+            let unary = exp :?> UnaryExpression
+            Some (unary.Operand, unary.Type)
+        | _ -> None
+    
     let (|ArrayInit|_|) (exp: Expression) =
         match exp.NodeType with
         | ExpressionType.NewArrayInit -> 
@@ -183,6 +190,10 @@ module SqlPatterns =
                 // Option.Some
                 match opt.Arguments.[0] with
                 | Constant c -> Some c.Value
+                | Convert (arg,typ) ->
+                    match arg with
+                    | Constant c when typ.IsPrimitive -> Some c.Value  
+                    | _ -> None
                 | _ -> None
             else
                 // Option.None


### PR DESCRIPTION
currently the LINQ expression visitor runs into an exception when dealing with implicit numeric conversions.

since both of the following examples are valid F# i added support for these implicit conversions
```fsharp
// runs just fine
let query1 = 
    selectAsync HydraReader.Read (Create openContext) {
        for c in Sqlite.QueryUnitTests.errorLogTable do
        where (c.ErrorSeverity = Some 1L)
    }
```

```fsharp
// runs into an exception    
let query2 = 
    selectAsync HydraReader.Read (Create openContext) {
        for c in Sqlite.QueryUnitTests.errorLogTable do
        where (c.ErrorSeverity = Some 1)
    }
```
