### PR TITLE
Allow comparisons with the column on the right

### DIFF
--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -137,11 +137,11 @@ let tests =
             let query = 
                 select {
                     for a in addressTable do
-                    where (5L < a.addressid && 20L >= a.addressid)
+                    where (5 < a.addressid && 20 >= a.addressid)
                 }
 
             let sql = query.ToKataQuery() |> toSql
-            Expect.isTrue (sql.Contains("WHERE ((\"a\".\"addressid\" > @p0) AND (\"a\".\"addressid\" <= @p1))")) ""
+            Expect.isTrue (sql.Contains("WHERE ((\"a\".\"addressid\" > @p0) AND (\"a\".\"addressid\" <= @p1))")) sql
         }
 
         test "Where Not Binary" {

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -133,6 +133,17 @@ let tests =
                 "Should wrap OR clause in parenthesis and each individual where clause in parenthesis."
         }
 
+        test "Where value and column are swapped" {
+            let query = 
+                select {
+                    for a in addressTable do
+                    where (5L < a.addressid && 20L >= a.addressid)
+                }
+
+            let sql = query.ToKataQuery() |> toSql
+            Expect.isTrue (sql.Contains("WHERE ((\"a\".\"addressid\" > @p0) AND (\"a\".\"addressid\" <= @p1))")) ""
+        }
+
         test "Where Not Binary" {
             let query = 
                 select {

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -131,6 +131,17 @@ let tests =
                 "Should wrap OR clause in parenthesis and each individual where clause in parenthesis."
         }
 
+        test "Where value and column are swapped" {
+            let query = 
+                select {
+                    for c in customerTable do
+                    where (5L < c.CUSTOMER_ID && 20L >= c.CUSTOMER_ID)
+                }
+
+            let sql = query.ToKataQuery() |> toSql
+            Expect.isTrue (sql.Contains("WHERE ((\"c\".\"CUSTOMER_ID\" > @p0) AND (\"c\".\"CUSTOMER_ID\" <= @p1))")) ""
+        }
+
         test "Where Not Binary" {
             let query = 
                 select {

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -139,7 +139,7 @@ let tests =
                 }
 
             let sql = query.ToKataQuery() |> toSql
-            Expect.isTrue (sql.Contains("WHERE ((\"c\".\"CUSTOMER_ID\" > @p0) AND (\"c\".\"CUSTOMER_ID\" <= @p1))")) ""
+            Expect.isTrue (sql.Contains("WHERE ((\"c\".\"CUSTOMER_ID\" > :p0) AND (\"c\".\"CUSTOMER_ID\" <= :p1))")) sql
         }
 
         test "Where Not Binary" {

--- a/src/Tests/SqlServer/QueryUnitTests.fs
+++ b/src/Tests/SqlServer/QueryUnitTests.fs
@@ -133,7 +133,7 @@ let tests =
                 "Should wrap OR clause in parenthesis and each individual where clause in parenthesis."
         }
 
-        ftest "Where value and column are swapped" {
+        test "Where value and column are swapped" {
             let query = 
                 select {
                     for a in addressTable do
@@ -141,7 +141,7 @@ let tests =
                 }
 
             let sql = query.ToKataQuery() |> toSql
-            Expect.isTrue (sql.Contains("WHERE (([a].[AddressID] > @p0) AND ([a].[AddressID] <= @p1))")) ""
+            Expect.isTrue (sql.Contains("WHERE (([a].[AddressID] > @p0) AND ([a].[AddressID] <= @p1))")) sql
         }
 
         test "Where Not Binary" {

--- a/src/Tests/SqlServer/QueryUnitTests.fs
+++ b/src/Tests/SqlServer/QueryUnitTests.fs
@@ -133,6 +133,17 @@ let tests =
                 "Should wrap OR clause in parenthesis and each individual where clause in parenthesis."
         }
 
+        ftest "Where value and column are swapped" {
+            let query = 
+                select {
+                    for a in addressTable do
+                    where (5 < a.AddressID && 20 >= a.AddressID)
+                }
+
+            let sql = query.ToKataQuery() |> toSql
+            Expect.isTrue (sql.Contains("WHERE (([a].[AddressID] > @p0) AND ([a].[AddressID] <= @p1))")) ""
+        }
+
         test "Where Not Binary" {
             let query = 
                 select {

--- a/src/Tests/Sqlite/QueryUnitTests.fs
+++ b/src/Tests/Sqlite/QueryUnitTests.fs
@@ -132,6 +132,17 @@ let tests =
                 "Should wrap OR clause in parenthesis and each individual where clause in parenthesis."
         }
 
+        test "Where value and column are swapped" {
+            let query = 
+                select {
+                    for a in addressTable do
+                    where (5L < a.AddressID && 20L >= a.AddressID)
+                }
+
+            let sql = query.ToKataQuery() |> toSql
+            Expect.isTrue (sql.Contains("WHERE ((\"a\".\"AddressID\" > @p0) AND (\"a\".\"AddressID\" <= @p1))")) ""
+        }
+
         test "Where Not Binary" {
             let query = 
                 select {

--- a/src/Tests/Sqlite/QueryUnitTests.fs
+++ b/src/Tests/Sqlite/QueryUnitTests.fs
@@ -140,7 +140,7 @@ let tests =
                 }
 
             let sql = query.ToKataQuery() |> toSql
-            Expect.isTrue (sql.Contains("WHERE ((\"a\".\"AddressID\" > @p0) AND (\"a\".\"AddressID\" <= @p1))")) ""
+            Expect.isTrue (sql.Contains("WHERE ((\"a\".\"AddressID\" > @p0) AND (\"a\".\"AddressID\" <= @p1))")) sql
         }
 
         test "Where Not Binary" {


### PR DESCRIPTION
I was looking at this code while working on something else, and saw an opportunity to address a slight nuisance that I ran into before, so I decided to create a PR for it.  Feel free to just close this if it's not a direction you want to go, since I didn't create an issue or any discussion around this before making the PR.

Currently, if you write a query `where (5 <= row.x && row.x < 10)`, it will compile but crash with a "not implemented" exception at runtime.  This PR adds the ability to put a value on the left and the column on the right in a WHERE comparison.
