### PR TITLE
Correlated subqueries?

### DIFF
--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -1,4 +1,5 @@
 ﻿namespace SqlHydra.Query
+open System
 
 [<AutoOpen>]
 module Table = 
@@ -9,10 +10,6 @@ module Table =
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
     
-    /// Maps the entity 'T to a correlated parent table of the exact same name.
-    let correlatedTable<'T> = 
-        Unchecked.defaultof<'T>
-
     /// Maps the entity 'T to a schema of the given name.
     [<System.Obsolete("The table schema is now automatically inferred from the declaring type.")>]
     let inSchema<'T> (schemaName: string) (qs: QuerySource<'T>) =

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -1,5 +1,4 @@
 ﻿namespace SqlHydra.Query
-open System
 
 [<AutoOpen>]
 module Table = 
@@ -9,7 +8,7 @@ module Table =
         let ent = typeof<'T>
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
-    
+
     /// Maps the entity 'T to a schema of the given name.
     [<System.Obsolete("The table schema is now automatically inferred from the declaring type.")>]
     let inSchema<'T> (schemaName: string) (qs: QuerySource<'T>) =

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -9,10 +9,6 @@ module Table =
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
 
-    type CorrelatedTable<'T> = CorrelatedTable of QuerySource<'T>
-
-    let correlatedTable<'T> = CorrelatedTable table<'T>
-
     /// Maps the entity 'T to a schema of the given name.
     [<System.Obsolete("The table schema is now automatically inferred from the declaring type.")>]
     let inSchema<'T> (schemaName: string) (qs: QuerySource<'T>) =

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -9,6 +9,10 @@ module Table =
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
 
+    type CorrelatedTable<'T> = CorrelatedTable of QuerySource<'T>
+
+    let correlatedTable<'T> = CorrelatedTable table<'T>
+
     /// Maps the entity 'T to a schema of the given name.
     [<System.Obsolete("The table schema is now automatically inferred from the declaring type.")>]
     let inSchema<'T> (schemaName: string) (qs: QuerySource<'T>) =

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -8,6 +8,10 @@ module Table =
         let ent = typeof<'T>
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
+    
+    /// Maps the entity 'T to a correlated parent table of the exact same name.
+    let correlatedTable<'T> = 
+        Unchecked.defaultof<'T>
 
     /// Maps the entity 'T to a schema of the given name.
     [<System.Obsolete("The table schema is now automatically inferred from the declaring type.")>]

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -201,46 +201,6 @@ type SelectBuilder<'Selected, 'Mapped> () =
             
         QuerySource<'JoinResult, Query>(outerQuery.Join(innerTableNameAsAlias, fun j -> joinOn), mergedTables)
 
-    /// INNER JOIN table on one or more columns
-    [<CustomOperation("correlate", MaintainsVariableSpace = true, IsLikeJoin = true, JoinConditionWord = "on")>]
-    member this.Correlate (outerSource: QuerySource<'Outer>, 
-                      innerSource: QuerySource<'Inner>, 
-                      outerKeySelector: Expression<Func<'Outer,'Key>>, 
-                      innerKeySelector: Expression<Func<'Inner,'Key>>, 
-                      resultSelector: Expression<Func<'Outer,'Inner,'JoinResult>> ) = 
-
-        let outerProperties = LinqExpressionVisitors.visitJoin<'Outer, 'Key> outerKeySelector // left
-        let innerProperties = LinqExpressionVisitors.visitJoin<'Inner, 'Key> innerKeySelector // right
-
-        let mergedTables = 
-            // Update outer table mappings with join aliases (accumulated outer/left mappings)
-            let outerTableMappings = 
-                outerProperties
-                |> List.fold (fun (mappings: Map<TableMappingKey, TableMapping>) joinPI -> 
-                    let _, updatedMappings = TableMappings.tryGetByRootOrAlias joinPI.Alias mappings
-                    updatedMappings
-                ) outerSource.TableMappings
-
-            // Update inner table mapping with join aliases (this will always be 1 mapping being joined)
-            let innerTableMappings = 
-                innerProperties
-                |> List.fold (fun (mappings: Map<TableMappingKey, TableMapping>) joinPI -> 
-                    let _, updatedMappings = TableMappings.tryGetByRootOrAlias joinPI.Alias mappings
-                    updatedMappings
-                ) innerSource.TableMappings
-        
-            mergeTableMappings (outerTableMappings, innerTableMappings)
-
-        let outerQuery = outerSource |> getQueryOrDefault
-            
-        let query = 
-            List.zip outerProperties innerProperties
-            |> List.fold (fun (q: Query) (outerProp, innerProp) -> 
-                q.WhereColumns($"{outerProp.Alias}.{outerProp.Member.Name}", "=", $"{innerProp.Alias}.{innerProp.Member.Name}")
-            ) outerQuery
-
-        QuerySource<'JoinResult, Query>(query, mergedTables)
-
     /// LEFT JOIN table on one or more columns
     [<CustomOperation("leftJoin", MaintainsVariableSpace = true, IsLikeJoin = true, JoinConditionWord = "on")>]
     member this.LeftJoin (outerSource: QuerySource<'Outer>, 
@@ -285,6 +245,16 @@ type SelectBuilder<'Selected, 'Mapped> () =
             ) (Join())
             
         QuerySource<'JoinResult, Query>(outerQuery.LeftJoin(innerTableNameAsAlias, fun j -> joinOn), mergedTables)
+
+    /// References a table variable from a correlated parent query from within a subquery.
+    [<CustomOperation("correlate", MaintainsVariableSpace = true, IsLikeZip = true)>]
+    member this.Correlate (outerSource: QuerySource<'Outer>, 
+                      CorrelatedTable innerSource: CorrelatedTable<'Inner>, 
+                      resultSelector: Expression<Func<'Outer,'Inner,'JoinResult>> ) = 
+
+        let mergedTables = mergeTableMappings (outerSource.TableMappings, innerSource.TableMappings)
+        let query = outerSource |> getQueryOrDefault
+        QuerySource<'JoinResult, Query>(query, mergedTables)
 
     /// Sets the GROUP BY for one or more columns.
     [<CustomOperation("groupBy", MaintainsVariableSpace = true)>]

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -249,7 +249,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
     /// References a table variable from a correlated parent query from within a subquery.
     [<CustomOperation("correlate", MaintainsVariableSpace = true, IsLikeZip = true)>]
     member this.Correlate (outerSource: QuerySource<'Outer>, 
-                      CorrelatedTable innerSource: CorrelatedTable<'Inner>, 
+                      innerSource: QuerySource<'Inner>, 
                       resultSelector: Expression<Func<'Outer,'Inner,'JoinResult>> ) = 
 
         let mergedTables = mergeTableMappings (outerSource.TableMappings, innerSource.TableMappings)

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -253,7 +253,7 @@ let tests =
             let latestOrderByCustomer = 
                 select {
                     for d in table<sales.salesorderheader> do
-                    correlate od in correlatedTable<sales.salesorderheader>
+                    correlate od in table<sales.salesorderheader>
                     where (d.customerid = od.customerid)
                     select (maxBy d.orderdate)
                 }

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -253,7 +253,7 @@ let tests =
             let latestOrderByCustomer = 
                 select {
                     for d in table<OT.ORDERS> do
-                    correlate od in correlatedTable<OT.ORDERS>
+                    correlate od in table<OT.ORDERS>
                     where (d.CUSTOMER_ID = od.CUSTOMER_ID)
                     select (maxBy d.ORDER_DATE)
                 }

--- a/src/Tests/SqlServer/QueryUnitTests.fs
+++ b/src/Tests/SqlServer/QueryUnitTests.fs
@@ -253,10 +253,26 @@ LEFT JOIN [Sales].[SalesOrderDetail] AS [d] ON ([o].[SalesOrderID] = [d].[SalesO
         }
 
         test "Correlated Subquery" {
+
+            let lowestPriceByProductLine = 
+                select {
+                    for inner in productTable do
+                    correlate outer in productTable
+                    where (inner.ProductLine = outer.ProductLine)
+                    select (minBy inner.StandardCost)
+                }
+
+            let cheapestByProductLine = 
+                select {
+                    for outer in productTable do
+                    where (outer.StandardCost = subqueryOne lowestPriceByProductLine)
+                    select outer
+                }
+            
             let maxOrderQty = 
                 select {
                     for d in table<Sales.SalesOrderDetail> do
-                    correlate od in correlatedTable<Sales.SalesOrderDetail>
+                    correlate od in table<Sales.SalesOrderDetail>
                     where (d.ProductID = od.ProductID)
                     select (maxBy d.OrderQty)
                 }

--- a/src/Tests/SqlServer/QueryUnitTests.fs
+++ b/src/Tests/SqlServer/QueryUnitTests.fs
@@ -508,5 +508,31 @@ INNER JOIN [Production].[Product] AS [p2] ON ([p1].[ProductID] = [p2].[ProductID
             | :? System.NotSupportedException -> () // Good
             | ex -> failwith "Should fail with NotSupportedException"
         }
+
+        test "Correlated Subquery" {
+            let maxOrderQty = 
+                let od = correlatedTable<Sales.SalesOrderDetail>
+
+                select {
+                    for d in orderDetailTable do
+                    where (d.ProductID = od.ProductID)
+                    select (maxBy d.OrderQty)
+                }
+
+            let query = 
+                select {
+                    for od in orderDetailTable do
+                    where (od.OrderQty = subqueryOne maxOrderQty)
+                    orderBy od.ProductID
+                    select (od.SalesOrderID, od.ProductID, od.OrderQty)
+                }
+                
+
+            let sql = query.ToKataQuery() |> toSql
+            Expect.equal
+                sql
+                "SELECT..."
+                ""            
+        }
         
     ]

--- a/src/Tests/Sqlite/QueryUnitTests.fs
+++ b/src/Tests/Sqlite/QueryUnitTests.fs
@@ -252,7 +252,7 @@ let tests =
             let latestOrderByCustomer = 
                 select {
                     for d in table<main.SalesOrderHeader> do
-                    correlate od in correlatedTable<main.SalesOrderHeader>
+                    correlate od in table<main.SalesOrderHeader>
                     where (d.CustomerID = od.CustomerID)
                     select (maxBy d.OrderDate)
                 }


### PR DESCRIPTION
This maybe fixes #48. 
It tries to implement option number 2 as referenced in that issue. It lets you write a correlated subquery like
```f#
            let maxOrderQty = 
                select {
                    for d in table<Sales.SalesOrderDetail> do
                    correlate od in correlatedTable<Sales.SalesOrderDetail>
                    where (d.ProductID = od.ProductID)
                    select (maxBy d.OrderQty)
                }

            let query = 
                select {
                    for od in orderDetailTable do
                    where (od.OrderQty = subqueryOne maxOrderQty)
                    orderBy od.ProductID
                    select (od.SalesOrderID, od.ProductID, od.OrderQty)
                }
```
My main gripe here is that I'm pretty sure the alias used in the subquery has to match the alias in the parent query, but I don't know if there's a way around that.  Maybe it could just be documented?

Does this seem like an acceptable solution?  Would you like me to take a stab at updating the README?