### PR TITLE
Add warning about variable usage order in `join` condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,11 @@ let getProductsWithCategory () =
     }
 ```
 
+> [!WARNING]
+> You need to write the join condition using the known variable before the new one
+> 
+> Otherwise, F# will complains about `p` and `c` not being defined
+
 Select `Customer` with left joined `Address` where `CustomerID` is in a list of values:
 (Note that left joined tables will be of type `'T option`, so you will need to use the `.Value` property to access join columns.)
 


### PR DESCRIPTION
I always forget that the order of usage for the variable matters here. This is not a bug in SqlHydra but related to how F# works if I remember correctly.

Today again, after not having work on my SqlHydra project for a few weeks/month it took me several minutes to remember this limitations.

Hopefully, this can save some time to others and myself in the future when checking the documentation.