### PR TITLE
Modified logger to also use NamedBindings as in the other part of the…

### DIFF
--- a/src/SqlHydra.Query/Kata.fs
+++ b/src/SqlHydra.Query/Kata.fs
@@ -71,9 +71,8 @@ type LoggedSqlResult(r: SqlResult) =
     override this.ToString() = 
         let sb = Text.StringBuilder()
         sb.AppendLine(r.Sql) |> ignore
-        let parameters = SqlKata.Helper.Flatten(r.Bindings)
-        for p in parameters do
-            sb.AppendLine($"- {p}") |> ignore
+        for kvp in r.NamedBindings do
+            sb.AppendLine($"- {kvp.Key}: {kvp.Value}") |> ignore
         sb.ToString()
 
 type InsertType = 


### PR DESCRIPTION
Hi, for context; I will be making a PR for sqlkata soon to truly permit database parameters, locally working and tests passing. The change here does not depend on that.

Noticed that the logging was using Bindings, while the generation of sql was using NamedBindings (as it should). Adjusted the logging to use NamedBindings, all tests still passing. Output will now look like:

```bash
SQL: SELECT * FROM [dbo].[BookingCompany] AS [u] WHERE (([Name] > @Name) OR ([Name] = @Name AND [EmailDomain] > @EmailDomain) OR ([Name] = @Name AND [EmailDomain] = @EmailDomain AND [ProfileSummary] > @ProfileSummary)) ORDER BY [Name], [EmailDomain], [ProfileSummary] OFFSET @p6 ROWS FETCH NEXT @p7 ROWS ONLY
- @Name: Acme
- @EmailDomain: beta.com
- @ProfileSummary: Beta email domain.
- @p6: 0
- @p7: 2
```

Small change, but let me know if you want me to change something.