### PR TITLE
Fix toArray and toList causing compilation errors

### DIFF
--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -334,12 +334,12 @@ type SelectBuilder<'Selected, 'Mapped> () =
     
     /// Returns the query results as an array.
     [<CustomOperation("toArray", MaintainsVariableSpace = true)>]
-    member this.ToArray (state: QuerySource<'Selected, Query>) =
+    member this.ToArray (state: QuerySource<'Selected seq, Query>) =
         QuerySource<'Selected array, Query>(state.Query, state.TableMappings)
 
     /// Returns the query results as a list.
     [<CustomOperation("toList", MaintainsVariableSpace = true)>]
-    member this.ToList (state: QuerySource<'Selected, Query>) =
+    member this.ToList (state: QuerySource<'Selected seq, Query>) =
         QuerySource<'Selected list, Query>(state.Query, state.TableMappings)
 
     /// COUNT aggregate function


### PR DESCRIPTION
Not sure if I'm doing something wrong, but `toArray` and `toList` in select expressions cause type mismatch errors for me whenever I try to use them.

I've tried this tiny little fix in my own codebase and it typechecks. It looks like more functions need fixing though. And I am also not sure how but `mapSeq` works in my code even though it appears to have the same issue...?