### PR TITLE
Fix: correlated subquery emits wrong table in FROM when `for`/`correlate` sources differ

### DIFF
--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -317,7 +317,18 @@ type SelectBuilder<'Selected, 'Mapped> () =
                       innerSource: QuerySource<'Inner>,
                       resultSelector: Expression<Func<'Outer,'Inner,'JoinResult>> ) =
 
-        let mergedTables = mergeTableMappings (outerSource.TableMappings, innerSource.TableMappings)
+        // F#'s `IsLikeZip = true` semantics call Correlate BEFORE the enclosing `For`,
+        // so both outerSource.TableMappings and innerSource.TableMappings still have their
+        // tables under the `Root` key. A naive merge collapses both Roots and the later
+        // `For` lookup picks the wrong table. Convert each side's Root → TableAliasKey
+        // first using the parameter names from the resultSelector.
+        let outerAlias, innerAlias =
+            match resultSelector.Parameters |> Seq.toList with
+            | [outer; inner] -> outer.Name, inner.Name
+            | _ -> failwith "Expected two parameters in correlate result selector"
+        let _, outerMappings = TableMappings.tryGetByRootOrAlias outerAlias outerSource.TableMappings
+        let _, innerMappings = TableMappings.tryGetByRootOrAlias innerAlias innerSource.TableMappings
+        let mergedTables = mergeTableMappings (outerMappings, innerMappings)
         let ir = outerSource |> getQueryOrDefault
         QuerySource<'JoinResult, SelectQueryIR>(ir, mergedTables)
 

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -266,6 +266,29 @@ let ``Correlated Subquery``() =
         WHERE (\"d\".\"customerid\" = \"od\".\"customerid\")))".RemoveHydraExpr()
 
 [<Test>]
+let ``Correlated subquery with differing for and correlate tables uses the for source``() =
+    // When the `for` source and `correlate` target are different tables, the merged Root
+    // keys previously collapsed and the inner subquery FROM wrongly referenced the correlate
+    // target instead of the `for` source (SelectBuilder.Correlate).
+    let inner =
+        select {
+            for d in sales.salesorderdetail do
+            correlate h in sales.salesorderheader
+            where (d.salesorderid = h.salesorderid)
+            select (maxBy d.orderqty)
+        }
+
+    let sql =
+        select {
+            for h in sales.salesorderheader do
+            where (h.revisionnumber = subqueryOne inner)
+            select h.salesorderid
+        }
+        |> toSql
+
+    sql.Contains("FROM \"sales\".\"salesorderdetail\"") =! true
+
+[<Test>]
 let ``Delete Query with Where``() = 
     let sql =  
         delete {


### PR DESCRIPTION
Part of #125, split out as a standalone fix.

When a `correlate` subquery's `for` source and `correlate` target are different tables, the
inner `FROM` resolves to the wrong table.

**Cause:** `IsLikeZip` runs `Correlate` before the enclosing `For`, so both table mappings
still key under `Root`; `mergeTableMappings` collapses them.

**Fix:** in `SelectBuilder.Correlate`, re-key each side (`Root` → alias, from the
`resultSelector` param names) before merging. Same-table correlations are unaffected.

Adds `Regression_CorrelateUsesForSourceNotTarget` — fails on `main`, passes with the fix.

```fsharp
select {
    for d in sales.salesorderdetail do
    correlate h in sales.salesorderheader
    where (d.salesorderid = h.salesorderid)
    select (maxBy d.orderqty)
}  // inner FROM must be salesorderdetail, not salesorderheader
```

---

First of three small PRs from #125; the next two stack on this branch and I'll open them once this lands:
- features (new query ops, IR, expression rendering) — [`feature/postgres-features-v4`](https://github.com/michaelglass/SqlHydra/tree/feature/postgres-features-v4)
- extensibility (infix-operator registry; unblocks a pgvector package) — [`feature/postgres-extension-v4`](https://github.com/michaelglass/SqlHydra/tree/feature/postgres-extension-v4)

_Developed with AI assistance; validated against a large private query suite + the test above._
