### PR TITLE
Postgres features + extensibility: RETURNING, ON CONFLICT variants, CTEs, lateral joins, expression rendering, infix-operator registry

### DIFF
--- a/src/SqlHydra.Query/Core.fs
+++ b/src/SqlHydra.Query/Core.fs
@@ -43,8 +43,14 @@ module FQ =
         let tbl = tables[TableAliasKey tableAlias]
         $"%s{tbl.Schema}.%s{tbl.Name}.%s{column.Name}"
 
+    /// Renders a table as `schema.name` or just `name` when schema is empty (CTE refs).
+    let qualifiedTable (tbl: TableMapping) =
+        if tbl.Schema = "" then tbl.Name
+        else $"%s{tbl.Schema}.%s{tbl.Name}"
+
 /// Represents a collection that must contain at least on item.
 module AtLeastOne =
+    [<NoComparison>]
     type AtLeastOne<'T> = private { Items : 'T seq }
 
     /// Returns Some if seq contains at least one item, else returns None.
@@ -57,6 +63,7 @@ module AtLeastOne =
         atLeastOne
 
 /// Wraps a query parameter to provide the generated ProviderDbType attribute value.
+[<NoComparison>]
 type QueryParameter =
     {
         Value: obj
@@ -68,6 +75,16 @@ type QueryParameter =
         | Some providerDbType -> $"%s{providerDbType}: {this.Value}"
         | None -> $"obj: {this.Value}"
 
+/// Pending conflict target accumulated by the composable `onConflict ...` CE op,
+/// awaiting a `doNothing` / `doUpdate` / `doUpdateCoalesce` action to finalize.
+[<NoComparison>]
+type PendingConflictTarget =
+    /// `onConflict col1 col2 ...` — typed columns
+    | TypedConflictColumns of fields: string list * whereRaw: string option
+    /// `onConflictRaw "lower(email)"` — expression-index target
+    | RawConflictTarget of rawTargetExpr: string * whereRaw: string option
+
+[<NoComparison>]
 type InsertQuerySpec<'T, 'Identity> =
     {
         Table: string
@@ -76,22 +93,43 @@ type InsertQuerySpec<'T, 'Identity> =
         IdentityField: string option
         OutputFields: OutputField list
         InsertType: InsertType
+        Returning: string list
+        FromSelect: SelectQueryIR option
+        /// Pending conflict target while building a composable `onConflict ... doNothing` chain.
+        /// Cleared once a conflict action finalizes the spec into `InsertType`.
+        PendingConflict: PendingConflictTarget option
     }
     static member Default : InsertQuerySpec<'T, 'Identity> =
-        { Table = ""; Entities = []; Fields = []; IdentityField = None; OutputFields = []; InsertType = Insert }
+        { Table = ""; Entities = []; Fields = []; IdentityField = None; OutputFields = []
+          InsertType = Insert; Returning = []; FromSelect = None; PendingConflict = None }
 
+[<NoComparison>]
 type UpdateQuerySpec<'T, 'UpdateReturn> =
     {
         Table: string
         Entity: 'T option
         Fields: string list
         SetValues: (string * obj) list
+        RawSetValues: (string * string * obj[]) list
         Where: WhereClause
         OutputFields: OutputField list
         UpdateAll: bool
+        Returning: string list
     }
     static member Default : UpdateQuerySpec<'T, 'UpdateReturn> =
-        { Table = ""; Entity = Option<'T>.None; Fields = []; SetValues = []; Where = WhereClause.Empty; OutputFields = []; UpdateAll = false }
+        { Table = ""; Entity = Option<'T>.None; Fields = []; SetValues = []; RawSetValues = []
+          Where = WhereClause.Empty; OutputFields = []; UpdateAll = false; Returning = [] }
+
+[<NoComparison>]
+type DeleteQuerySpec<'T> =
+    {
+        Table: string
+        Where: WhereClause
+        DeleteAll: bool
+        Returning: string list
+    }
+    static member Default : DeleteQuerySpec<'T> =
+        { Table = ""; Where = WhereClause.Empty; DeleteAll = false; Returning = [] }
 
 type QuerySource<'T>(tableMappings) =
     interface IEnumerable<'T> with
@@ -193,14 +231,17 @@ module internal QueryUtils =
                     |> Array.toList
 
             | Some _, _ -> failwith "Cannot have both `entity` and `set` operations in an `update` expression."
-            | None, [] -> failwith "Either an `entity` or `set` operations must be present in an `update` expression."
+            | None, [] when spec.RawSetValues.IsEmpty ->
+                failwith "Either an `entity`, `set`, or `setRaw` operation must be present in an `update` expression."
             | None, setValues -> setValues
 
         {
             Table = spec.Table
             SetColumns = kvps
+            SetRaws = spec.RawSetValues
             Where = spec.Where
             OutputFields = spec.OutputFields
+            Returning = spec.Returning
         }
 
     let fromInsert (spec: InsertQuerySpec<'T, 'InsertReturn>) : InsertQueryIR =
@@ -213,14 +254,26 @@ module internal QueryUtils =
                 FSharp.Reflection.FSharpType.GetRecordFields(typeof<'T>)
                 |> Array.filter (fun p -> included.Contains(p.Name))
 
-        match spec.Entities with
-        | [] ->
-            failwith "At least one `entity` or `entities` must be set in the `insert` builder."
+        let columns = includedProperties |> Array.map (fun p -> p.Name) |> Array.toList
 
-        | entities ->
+        match spec.FromSelect, spec.Entities with
+        | Some selectIR, _ ->
+            // INSERT INTO ... (cols) <select-subquery>
+            {
+                Table = spec.Table
+                Columns = columns
+                Rows = []
+                FromSelect = Some selectIR
+                IdentityField = spec.IdentityField
+                InsertType = spec.InsertType
+                OutputFields = spec.OutputFields
+                Returning = spec.Returning
+            }
+        | None, [] ->
+            failwith "At least one `entity` or `entities` must be set in the `insert` builder."
+        | None, entities ->
             if spec.IdentityField.IsSome && entities.Length > 1
             then failwith "`getId` is not currently supported for multiple inserts via the `entities` operation."
-            let columns = includedProperties |> Array.map (fun p -> p.Name) |> Array.toList
             let rows =
                 entities
                 |> List.map (fun entity ->
@@ -231,9 +284,11 @@ module internal QueryUtils =
                 Table = spec.Table
                 Columns = columns
                 Rows = rows
+                FromSelect = None
                 IdentityField = spec.IdentityField
                 InsertType = spec.InsertType
                 OutputFields = spec.OutputFields
+                Returning = spec.Returning
             }
 
     /// Fails if `getId` identity field is used as an `onConflict` target.

--- a/src/SqlHydra.Query/DeleteBuilders.fs
+++ b/src/SqlHydra.Query/DeleteBuilders.fs
@@ -2,29 +2,32 @@
 [<AutoOpen>]
 module SqlHydra.Query.DeleteBuilders
 
+open System
+open System.Linq.Expressions
 open System.Threading
 
-let private prepareDeleteQuery<'Deleted> (ir: SelectQueryIR) =
-    DeleteQuery<'Deleted>({ Table = ir.From |> Option.defaultValue ""; Where = ir.Where })
+let private prepareDeleteQuery<'Deleted> (spec: DeleteQuerySpec<'Deleted>) =
+    if spec.Where = WhereClause.Empty && not spec.DeleteAll then
+        invalidOp "A `delete` expression must either contain a `where` clause or `deleteAll`."
+    DeleteQuery<'Deleted>({ Table = spec.Table; Where = spec.Where; Returning = spec.Returning })
 
 /// The base delete builder that contains all common operations
 type DeleteBuilder<'Deleted>() =
 
     let getQueryOrDefault (state: QuerySource<'T>) =
         match state with
-        | :? QuerySource<'T, SelectQueryIR> as qs -> qs.Query
-        | _ -> SelectQueryIR.empty
+        | :? QuerySource<'T, DeleteQuerySpec<'T>> as qs -> qs.Query
+        | _ -> DeleteQuerySpec.Default
 
     member val CancellationToken = CancellationToken.None with get, set
 
     member this.For (state: QuerySource<'T>, [<ReflectedDefinition>] forExpr: FSharp.Quotations.Expr<'T -> QuerySource<'T>>) =
-        let ir = state |> getQueryOrDefault
+        let spec = state |> getQueryOrDefault
         let tableAlias = QuotationVisitor.visitFor forExpr |> QuotationVisitor.allowUnderscore true
         let tblMaybe, tableMappings = TableMappings.tryGetByRootOrAlias tableAlias state.TableMappings
         let tbl = tblMaybe |> Option.get
-
-        QuerySource<'T, SelectQueryIR>(
-            { ir with From = Some $"{tbl.Schema}.{tbl.Name}" },
+        QuerySource<'T, DeleteQuerySpec<'T>>(
+            { spec with Table = $"{tbl.Schema}.{tbl.Name}" },
             tableMappings)
 
     member this.Yield _ =
@@ -32,35 +35,48 @@ type DeleteBuilder<'Deleted>() =
 
     /// Sets the WHERE condition
     [<CustomOperation("where", MaintainsVariableSpace = true)>]
-    member this.Where (state:QuerySource<'T>, [<ProjectionParameter>] whereExpression) =
-        let ir = state |> getQueryOrDefault
+    member this.Where (state: QuerySource<'T>, [<ProjectionParameter>] whereExpression) =
+        let spec = state |> getQueryOrDefault
         let tableMappings = state.TableMappings |> Map.values
         let newClause = LinqExpressionVisitors.visitWhere<'T> tableMappings whereExpression (FQ.fullyQualifyColumn state.TableMappings)
-        QuerySource<'T, SelectQueryIR>({ ir with Where = WhereClause.combineAnd ir.Where newClause }, state.TableMappings)
+        QuerySource<'T, DeleteQuerySpec<'T>>(
+            { spec with Where = WhereClause.combineAnd spec.Where newClause; DeleteAll = false },
+            state.TableMappings)
 
-    /// Deletes all records in the table (only when there are is no where clause)
+    /// Adds one or more columns to the DELETE ... RETURNING clause (PostgreSQL).
+    /// Pass a single property or a tuple of properties.
+    [<CustomOperation("returning", MaintainsVariableSpace = true)>]
+    member this.Returning (state: QuerySource<'T>, [<ProjectionParameter>] propertySelector: Expression<Func<'T, 'Prop>>) =
+        let spec = state |> getQueryOrDefault
+        let cols = LinqExpressionVisitors.visitPropertiesSelector<'T, 'Prop> propertySelector (fun _ p -> p.Name)
+        QuerySource<'T, DeleteQuerySpec<'T>>(
+            { spec with Returning = spec.Returning @ cols },
+            state.TableMappings)
+
+    /// Safeguard verifying that all rows in the table should be deleted (no `where` clause).
     [<CustomOperation("deleteAll", MaintainsVariableSpace = true)>]
-    member this.DeleteAll (state:QuerySource<'T>) =
-        state :?> QuerySource<'T, SelectQueryIR>
+    member this.DeleteAll (state: QuerySource<'T>) =
+        let spec = state |> getQueryOrDefault
+        if spec.Where <> WhereClause.Empty then
+            invalidOp "Cannot have `deleteAll` clause in a query where `where` has been used."
+        QuerySource<'T, DeleteQuerySpec<'T>>({ spec with DeleteAll = true }, state.TableMappings)
 
     /// Sets a CancellationToken for the query execution.
     [<CustomOperation("cancel", MaintainsVariableSpace = true)>]
-    member this.Cancel (state: QuerySource<'T, SelectQueryIR>, cancellationToken: CancellationToken) =
+    member this.Cancel (state: QuerySource<'T, DeleteQuerySpec<'T>>, cancellationToken: CancellationToken) =
         this.CancellationToken <- cancellationToken
         state
 
     /// Unwraps the query
     member this.Run (state: QuerySource<'Deleted>) =
-        state
-        |> getQueryOrDefault
-        |> prepareDeleteQuery
+        state |> getQueryOrDefault |> prepareDeleteQuery
 
 
 /// A delete builder that returns an Async result.
 type DeleteAsyncBuilder<'Deleted>(ct: ContextType) =
     inherit DeleteBuilder<'Deleted>()
 
-    member this.Run (state: QuerySource<'Deleted, SelectQueryIR>) =
+    member this.Run (state: QuerySource<'Deleted, DeleteQuerySpec<'Deleted>>) =
         async {
             let deleteQuery = state.Query |> prepareDeleteQuery
             let! ctx = ContextUtils.getContext ct |> Async.AwaitTask
@@ -78,7 +94,7 @@ type DeleteAsyncBuilder<'Deleted>(ct: ContextType) =
 type DeleteTaskBuilder<'Deleted>(ct: ContextType) =
     inherit DeleteBuilder<'Deleted>()
 
-    member this.Run (state: QuerySource<'Deleted, SelectQueryIR>) =
+    member this.Run (state: QuerySource<'Deleted, DeleteQuerySpec<'Deleted>>) =
         task {
             let deleteQuery = state.Query |> prepareDeleteQuery
             let! ctx = ContextUtils.getContext ct
@@ -106,4 +122,3 @@ let inline deleteTask< ^Deleted, ^Context
     (ctSource: ^Context) =
     let ct = ContextTypeResolver.resolve ctSource
     DeleteTaskBuilder< ^Deleted>(ct)
-

--- a/src/SqlHydra.Query/ExpressionNormalizer.fs
+++ b/src/SqlHydra.Query/ExpressionNormalizer.fs
@@ -15,6 +15,20 @@ type private VariableInliner(substitutions: System.Collections.Generic.Dictionar
         | true, value -> this.Visit(value)
         | _ -> node :> Expression
 
+/// True when an expression is a `.ItemN` tuple-element access on a parameter
+/// (the join tuple-deconstruction shape `tupledArg.Item1`). Such bindings produce
+/// table-alias parameters that downstream visitors (visitAlias) read by name, so they
+/// must NOT be inlined. Any other RHS (e.g. a renamed-anon-record field's `p.col`) IS inlined.
+let private isTupleItemAccess (e: Expression) =
+    match e with
+    | :? MemberExpression as m ->
+        let name = m.Member.Name
+        name.StartsWith("Item")
+        && name.Length > 4
+        && System.Char.IsDigit(name.[4])
+        && (m.Expression :? ParameterExpression)
+    | _ -> false
+
 /// Maps comparison operator method names to their corresponding ExpressionType.
 let private tryGetComparisonExpressionType (methodName: string) =
     match methodName with
@@ -33,15 +47,18 @@ type private Normalizer() =
     inherit ExpressionVisitor()
 
     override this.VisitBlock(node) =
-        // Build substitution map for non-tuple-deconstruction variables.
-        // Variables assigned from MemberAccess (e.g., o = tupledArg.Item1) are preserved
-        // because visitAlias extracts table aliases from ParameterExpression names.
+        // Build substitution map.
+        // Tuple-deconstruction assigns like `o = tupledArg.Item1` are preserved — `o` becomes a
+        // table-alias parameter that visitAlias extracts. Identified by RHS being a `.ItemN`
+        // member access on the join's tuple parameter.
+        // Other member-access assigns (renamed anonymous-record fields like `renamedX = a.col`)
+        // ARE inlined so the visitor sees the column access directly.
         let substitutions = System.Collections.Generic.Dictionary<ParameterExpression, Expression>()
         for expr in node.Expressions do
             if expr.NodeType = ExpressionType.Assign then
                 let bin = expr :?> BinaryExpression
                 match bin.Left with
-                | :? ParameterExpression as p when bin.Right.NodeType <> ExpressionType.MemberAccess ->
+                | :? ParameterExpression as p when not (isTupleItemAccess bin.Right) ->
                     substitutions.[p] <- bin.Right
                 | _ -> ()
         let result = node.Expressions |> Seq.last
@@ -54,13 +71,35 @@ type private Normalizer() =
         this.Visit(inlined)
 
     override this.VisitMethodCall(node) =
-        match tryGetComparisonExpressionType node.Method.Name with
-        | Some exprType when node.Arguments.Count = 2 ->
-            let left = this.Visit(node.Arguments.[0])
-            let right = this.Visit(node.Arguments.[1])
-            Expression.MakeBinary(exprType, left, right) :> Expression
+        // On net8/FSharp.Core 8 the compiler lowers a written-vs-constructor field reorder (needed
+        // to preserve left-to-right evaluation order) NOT to a Block+Assign (the net10 shape that
+        // VisitBlock handles) but to an `Invoke(Lambda)`: the hoisted value becomes a lambda
+        // PARAMETER that is then applied. e.g. the renamed anon-record
+        //     {| someNewName = p.productid; another = p.standardcost |}
+        // lowers to  `someNewName => new AnonType(p.standardcost, someNewName).Invoke(p.productid)`.
+        // Here `someNewName` is bound to `p.productid` and must be inlined so the visitor sees the
+        // column access — otherwise the bare parameter leaks as a `"someNewName".*` table alias.
+        // We mirror VisitBlock's exemption: a lambda param bound to a `.ItemN` tuple access is a
+        // join table-alias deconstruction and is left intact (visitAlias reads it by name).
+        match node.Object with
+        | :? LambdaExpression as lam when
+            node.Method.Name = "Invoke"
+            && node.Arguments.Count = 1
+            && lam.Parameters.Count = 1
+            && not (isTupleItemAccess node.Arguments.[0]) ->
+            let substitutions = System.Collections.Generic.Dictionary<ParameterExpression, Expression>()
+            substitutions.[lam.Parameters.[0]] <- node.Arguments.[0]
+            let inlined = VariableInliner(substitutions).Visit(lam.Body)
+            // Continue normalizing (handles chained Invokes, nested blocks, operator calls, etc.)
+            this.Visit(inlined)
         | _ ->
-            base.VisitMethodCall(node)
+            match tryGetComparisonExpressionType node.Method.Name with
+            | Some exprType when node.Arguments.Count = 2 ->
+                let left = this.Visit(node.Arguments.[0])
+                let right = this.Visit(node.Arguments.[1])
+                Expression.MakeBinary(exprType, left, right) :> Expression
+            | _ ->
+                base.VisitMethodCall(node)
 
 /// Normalizes a LINQ expression tree into a predictable shape for visitor processing.
 let normalize (expr: Expression) : Expression =
@@ -71,6 +110,7 @@ let normalize (expr: Expression) : Expression =
 // Structural noise (Lambda, Block, Invoke) is eliminated during conversion.
 // Original LINQ types are retained in variants for semantic pattern matching.
 
+[<NoComparison>]
 type NormalizedExpression =
     | NBinary of left: NormalizedExpression * op: ExpressionType * right: NormalizedExpression
     | NUnary of op: ExpressionType * operand: NormalizedExpression

--- a/src/SqlHydra.Query/InsertBuilders.fs
+++ b/src/SqlHydra.Query/InsertBuilders.fs
@@ -82,6 +82,24 @@ type InsertBuilder<'Inserted, 'InsertReturn>() =
             |> (fun x -> { spec with Fields = x })
         QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
     
+    /// Inserts the result of a SELECT query: INSERT INTO ... (cols) <select-subquery>
+    [<CustomOperation("fromSelect", MaintainsVariableSpace = true)>]
+    member this.FromSelect (state: QuerySource<'T>, subquery: SelectQuery) =
+        let spec = state |> getQueryOrDefault
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(
+            { spec with FromSelect = Some subquery.SelectIR }
+            , state.TableMappings)
+
+    /// Adds one or more columns to the RETURNING clause (PostgreSQL/SQLite).
+    /// Pass a single property `e.id` or a tuple `(e.id, e.email, e.created_at)`.
+    [<CustomOperation("returning", MaintainsVariableSpace = true)>]
+    member this.Returning (state: QuerySource<'T>, [<ProjectionParameter>] propertySelector: System.Linq.Expressions.Expression<Func<'T, 'Prop>>) =
+        let spec = state |> getQueryOrDefault
+        let cols = LinqExpressionVisitors.visitPropertiesSelector<'T, 'Prop> propertySelector (fun _ p -> p.Name)
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(
+            { spec with Returning = spec.Returning @ cols }
+            , state.TableMappings)
+
     /// Sets the identity field that should be returned from the insert and excludes it from the insert columns.
     [<CustomOperation("getId", MaintainsVariableSpace = true)>]
     member this.GetId (state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>, [<ProjectionParameter>] idProperty) = 
@@ -113,7 +131,7 @@ type InsertAsyncBuilder<'Inserted, 'InsertReturn>(ct: ContextType) =
                 let insertQuery = InsertQuery<'Inserted, 'InsertReturn>(state.Query)
                 let! asyncCancel = Async.CancellationToken
                 let cancel = if this.CancellationToken <> CancellationToken.None then this.CancellationToken else asyncCancel
-                if state.Query.Entities |> Seq.isEmpty then
+                if state.Query.Entities |> Seq.isEmpty && state.Query.FromSelect.IsNone then
                     return Unchecked.defaultof<'InsertReturn>
                 else
                     let! insertReturn = ctx.InsertAsyncWithOptions (insertQuery, cancel) |> Async.AwaitTask
@@ -132,7 +150,7 @@ type InsertTaskBuilder<'Inserted, 'InsertReturn>(ct: ContextType) =
             let! ctx = ContextUtils.getContext ct
             try
                 let insertQuery = InsertQuery<'Inserted, 'InsertReturn>(state.Query)
-                if state.Query.Entities |> Seq.isEmpty then
+                if state.Query.Entities |> Seq.isEmpty && state.Query.FromSelect.IsNone then
                     return Unchecked.defaultof<'InsertReturn>
                 else
                     let! insertReturn = ctx.InsertAsyncWithOptions (insertQuery, this.CancellationToken)

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -8,6 +8,40 @@ open FastExpressionCompiler
 let notImpl() = raise (NotImplementedException())
 let notImplMsg msg = raise (NotImplementedException msg)
 
+/// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.
+/// Keep in sync with QueryFunctions.Aggregates.
+let aggregateMethodNames =
+    System.Collections.Generic.HashSet<string>([
+        nameof minBy; nameof maxBy; nameof sumBy; nameof avgBy
+        nameof countBy; nameof avgByAs; nameof countDistinct
+    ])
+
+/// Renders an aggregate function call. Special-cases COUNTDISTINCT → COUNT(DISTINCT col).
+let renderAggregate (aggType: string) (col: string) =
+    if aggType = "COUNTDISTINCT" then $"COUNT(DISTINCT {col})"
+    else $"{aggType}({col})"
+
+/// Derives the SQL aggregate type name from an aggregate method name (e.g. `countBy` → `COUNT`, `avgByAs` → `AVG`).
+let aggTypeOf (name: string) = name.Replace("By", "").Replace("As", "").ToUpper()
+
+/// Maps an F# CLR type to its SQL CAST target type name.
+let sqlTypeForClrType (t: System.Type) =
+    let t =
+        if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+        then t.GetGenericArguments().[0]
+        elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<System.Nullable<_>>
+        then System.Nullable.GetUnderlyingType(t)
+        else t
+    if t = typeof<float> || t = typeof<double> then "FLOAT"
+    elif t = typeof<float32> || t = typeof<single> then "REAL"
+    elif t = typeof<int> || t = typeof<int32> then "INTEGER"
+    elif t = typeof<int64> then "BIGINT"
+    elif t = typeof<int16> then "SMALLINT"
+    elif t = typeof<decimal> then "NUMERIC"
+    elif t = typeof<string> then "TEXT"
+    elif t = typeof<bool> then "BOOLEAN"
+    else t.Name
+
 
 [<AutoOpen>]
 module VisitorPatterns =
@@ -269,8 +303,8 @@ module SqlPatterns =
 
     let (|AggregateColumn|_|) (exp: Expression) =
         match exp with
-        | MethodCall m when List.contains m.Method.Name [ nameof minBy; nameof maxBy; nameof sumBy; nameof avgBy; nameof countBy; nameof avgByAs ] ->
-            let aggType = m.Method.Name.Replace("By", "").Replace("As", "").ToUpper()
+        | MethodCall m when aggregateMethodNames.Contains m.Method.Name ->
+            let aggType = aggTypeOf m.Method.Name
             match m.Arguments.[0] with
             | Property p -> Some (aggType, p)
             | _ -> notImplMsg "Invalid argument to aggregate function."
@@ -372,10 +406,14 @@ module NormalizedPatterns =
         | _ -> None
 
     /// Aggregate column pattern (minBy, maxBy, sumBy, avgBy, countBy, avgByAs).
+    /// Matches only when the aggregate's argument resolves to a column (direct Property or
+    /// Option/Nullable Value chain). Aggregates over arbitrary expressions (e.g.
+    /// `countBy(caseWhen ...)`) fall through to the NMethodCall arm, which delegates to
+    /// `visitSqlFn`/`renderExpr` for full expression rendering.
     let (|NAggregateColumn|_|) (nexp: NormalizedExpression) =
         match nexp with
-        | NMethodCall(m, _) when List.contains m.Method.Name [ nameof minBy; nameof maxBy; nameof sumBy; nameof avgBy; nameof countBy; nameof avgByAs ] ->
-            let aggType = m.Method.Name.Replace("By", "").Replace("As", "").ToUpper()
+        | NMethodCall(m, _) when aggregateMethodNames.Contains m.Method.Name ->
+            let aggType = aggTypeOf m.Method.Name
             match m.Arguments.[0] with
             | Property p -> Some (aggType, p)
             | _ -> notImplMsg "Invalid argument to aggregate function."
@@ -399,15 +437,36 @@ module NormalizedPatterns =
             | _ -> None
         | _ -> None
 
-let getComparison (expType: ExpressionType) =
+let tryGetComparison (expType: ExpressionType) =
     match expType with
-    | ExpressionType.Equal -> "="
-    | ExpressionType.NotEqual -> "<>"
-    | ExpressionType.GreaterThan -> ">"
-    | ExpressionType.GreaterThanOrEqual -> ">="
-    | ExpressionType.LessThan -> "<"
-    | ExpressionType.LessThanOrEqual -> "<="
-    | _ -> notImplMsg "Unsupported comparison type"
+    | ExpressionType.Equal -> Some "="
+    | ExpressionType.NotEqual -> Some "<>"
+    | ExpressionType.GreaterThan -> Some ">"
+    | ExpressionType.GreaterThanOrEqual -> Some ">="
+    | ExpressionType.LessThan -> Some "<"
+    | ExpressionType.LessThanOrEqual -> Some "<="
+    | _ -> None
+
+/// Maps a binary expression node to its SQL operator: comparisons (`=`,`<>`,…) plus
+/// logical/arithmetic operators (`AND`/`OR`/`+`/`-`/`*`/`/`/`%`). `None` if unsupported.
+let tryGetBinaryOp (expType: ExpressionType) =
+    match tryGetComparison expType with
+    | Some s -> Some s
+    | None ->
+        match expType with
+        | ExpressionType.AndAlso -> Some "AND"
+        | ExpressionType.OrElse -> Some "OR"
+        | ExpressionType.Add -> Some "+"
+        | ExpressionType.Subtract -> Some "-"
+        | ExpressionType.Multiply -> Some "*"
+        | ExpressionType.Divide -> Some "/"
+        | ExpressionType.Modulo -> Some "%"
+        | _ -> None
+
+let getComparison (expType: ExpressionType) =
+    match tryGetComparison expType with
+    | Some s -> s
+    | None -> notImplMsg "Unsupported comparison type"
 
 let reverseComparison (expType: ExpressionType) =
     match expType with
@@ -446,33 +505,167 @@ let visitAlias (exp: Expression) =
         | _ -> notImpl()
     visit exp
 
+let private compileAndEval (e: Expression) =
+    System.Linq.Expressions.Expression.Lambda(e).Compile().DynamicInvoke()
+
+let private inv = System.Globalization.CultureInfo.InvariantCulture
+
+let private isNullaryDU (t: System.Type) =
+    FSharp.Reflection.FSharpType.IsUnion(t)
+    && FSharp.Reflection.FSharpType.GetUnionCases(t) |> Array.forall (fun c -> c.GetFields().Length = 0)
+
+let private formatFloat (s: string) =
+    if s.Contains(".") || s.Contains("e") || s.Contains("E") then s else s + ".0"
+
+/// Formats a numeric constant as SQL literal, preserving the type's decimal form for floats.
+/// `1.0` (double) → "1.0", not "1" (which Postgres types as integer and breaks `1.0 - <vector>` queries).
+/// Enums and nullary DUs are quoted as their string name — Postgres treats bare identifiers as columns.
+let private formatNumericLiteral (value: obj) (clrType: System.Type) =
+    match clrType with
+    | t when t = typeof<float> || t = typeof<double> -> (value :?> double).ToString("R", inv) |> formatFloat
+    | t when t = typeof<single> || t = typeof<float32> -> (value :?> single).ToString("R", inv) |> formatFloat
+    | t when t = typeof<decimal> -> (value :?> decimal).ToString(inv)
+    | t when t.IsEnum || isNullaryDU t -> $"'{value}'"
+    // Integer primitives (int, int64, byte, ...) — ToString is safe SQL for these.
+    // char/bool are excluded: bool is handled in renderObjAsLiteral; char would emit unquoted.
+    | t when t.IsPrimitive && t <> typeof<char> && t <> typeof<bool> -> sprintf "%O" value
+    | t -> failwithf "Cannot format SQL literal of type %s — wrap with inlineValue or parameterize." t.FullName
+
+/// Renders a `ConstantExpression` to a SQL literal. When `handleBool` is true, bool constants
+/// emit `TRUE`/`FALSE`; otherwise they fall through to numeric formatting (matching the
+/// orderBy walker, which never receives bool constants). Shared by the expression walkers.
+let private renderConstant (handleBool: bool) (c: ConstantExpression) =
+    if c.Value = null then "NULL"
+    elif c.Type = typeof<string> then $"'{c.Value}'"
+    elif handleBool && c.Type = typeof<bool> then (if c.Value :?> bool then "TRUE" else "FALSE")
+    else formatNumericLiteral c.Value c.Type
+
+/// Renders an evaluated runtime value as a SQL literal fragment.
+/// Used for `inlineValue` and static-field references (Guid.Empty, DateTime.MinValue, etc.).
+let private renderObjAsLiteral (v: obj) =
+    match v with
+    | null -> "NULL"
+    | :? string as s -> $"'{s}'"
+    | :? bool as b -> if b then "TRUE" else "FALSE"
+    | :? System.Guid as g -> $"'{g}'"
+    | :? System.DateTime as dt ->
+        let s = dt.ToString("yyyy-MM-dd HH:mm:ss", inv)
+        $"'{s}'"
+    | :? System.DateTimeOffset as dto ->
+        let s = dto.ToString("yyyy-MM-dd HH:mm:sszzz", inv)
+        $"'{s}'"
+    | _ -> formatNumericLiteral v (v.GetType())
+
 /// Converts a SQL function MethodCall expression to a SQL fragment string.
+/// Also renders argument expressions when called recursively as the entry point for
+/// general select-fragment compilation (caseWhen, castAs, etc.).
 /// Example: LEN(p.FirstName) -> "LEN({p}.{FirstName})"
 let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Expression) : string =
+    /// Render an arbitrary expression as a SQL fragment (literals inline, columns qualified, nested fns recursed).
+    /// Supports: Member columns, static-field Members, Constants, Unary Convert, Binary arithmetic/compare, MethodCall.
+    /// `inlineValue x` is rendered as the value's literal form (numeric/string).
+    let rec renderExpr (arg: Expression) : string =
+        match arg with
+        // Unwrap implicit numeric conversions (e.g., int → float when a column type widens).
+        | :? UnaryExpression as u when u.NodeType = ExpressionType.Convert ->
+            renderExpr u.Operand
+        // inlineValue marker: compile-and-eval the inner expression and emit as a literal.
+        | MethodCall m when m.Method.Name = nameof inlineValue && m.Arguments.Count = 1 ->
+            renderObjAsLiteral (compileAndEval m.Arguments.[0])
+        | Member mem when mem.Expression <> null ->
+            let alias = visitAlias mem.Expression
+            qualifyColumn alias mem.Member
+        // Static fields (Guid.Empty, DateTime.MinValue, String.Empty) — null .Expression.
+        | Member mem -> renderObjAsLiteral (compileAndEval mem)
+        | :? ConstantExpression as c -> renderConstant true c
+        | :? BinaryExpression as b ->
+            let left = renderExpr b.Left
+            let right = renderExpr b.Right
+            let op =
+                match tryGetBinaryOp b.NodeType with
+                | Some s -> s
+                | None -> notImplMsg $"Unsupported binary operator in expression: {b.NodeType}"
+            $"{left} {op} {right}"
+        | MethodCall _ as nested -> visitSqlFn qualifyColumn nested
+        | _ -> notImplMsg $"Unsupported expression in select/caseWhen fragment: {arg.NodeType}"
+
+    /// Extract (cond, value) pairs from an F# list literal like `[ a > 1, "x"; b > 2, "y" ]`.
+    let rec extractListItems (exp: Expression) : (string * string) list =
+        match exp with
+        | :? MethodCallExpression as m when m.Method.Name = "Cons" || m.Method.Name = "op_ColonColon" ->
+            let (cond, value) = extractTuple m.Arguments.[0]
+            (cond, value) :: extractListItems m.Arguments.[1]
+        | :? NewExpression as n when n.Arguments.Count = 2 ->
+            let (cond, value) = extractTuple n.Arguments.[0]
+            (cond, value) :: extractListItems n.Arguments.[1]
+        | :? MemberExpression as m when m.Member.Name = "Empty" -> []
+        | :? DefaultExpression -> []
+        | _ ->
+            // Fallback: compile-and-eval to runtime list.
+            try
+                match compileAndEval exp with
+                | :? System.Collections.IEnumerable as items ->
+                    [ for item in items do
+                        let t = item.GetType()
+                        let cond = t.GetProperty("Item1").GetValue(item) :?> bool
+                        let v = t.GetProperty("Item2").GetValue(item)
+                        let condStr = if cond then "TRUE" else "FALSE"
+                        let valStr =
+                            match v with
+                            | null -> "NULL"
+                            | :? string as s -> $"'{s}'"
+                            | x -> sprintf "%O" x
+                        yield (condStr, valStr) ]
+                | _ -> notImplMsg $"Cannot extract caseWhenMulti list: {exp.NodeType}"
+            with ex -> notImplMsg $"Cannot extract caseWhenMulti list: {exp.NodeType} ({ex.Message})"
+    and extractTuple (exp: Expression) : string * string =
+        match exp with
+        | :? NewExpression as n when n.Arguments.Count = 2 ->
+            (renderExpr n.Arguments.[0], renderExpr n.Arguments.[1])
+        | :? MethodCallExpression as m when m.Method.Name = "NewTuple" ->
+            (renderExpr m.Arguments.[0], renderExpr m.Arguments.[1])
+        | _ -> notImplMsg $"Cannot extract caseWhenMulti tuple: {exp.NodeType}"
+
     match exp with
+    // CAST(expr AS sqlType) — target SQL type inferred from the F# return type.
+    | MethodCall m when m.Method.Name = nameof castAs && m.Arguments.Count = 1 ->
+        $"CAST({renderExpr m.Arguments.[0]} AS {sqlTypeForClrType m.Method.ReturnType})"
+    // CASE WHEN cond THEN then ELSE else END
+    | MethodCall m when m.Method.Name = nameof caseWhen && m.Arguments.Count = 3 ->
+        $"CASE WHEN {renderExpr m.Arguments.[0]} THEN {renderExpr m.Arguments.[1]} ELSE {renderExpr m.Arguments.[2]} END"
+    // Multi-branch CASE WHEN
+    | MethodCall m when m.Method.Name = nameof caseWhenMulti && m.Arguments.Count = 2 ->
+        let whens =
+            extractListItems m.Arguments.[0]
+            |> List.map (fun (c, v) -> $"WHEN {c} THEN {v}")
+            |> String.concat " "
+        $"CASE {whens} ELSE {renderExpr m.Arguments.[1]} END"
+    // Lateral subquery column reference: lateralCol "alias" "col" → "alias"."col"
+    | MethodCall m when m.Method.Name = nameof lateralCol && m.Arguments.Count = 2 ->
+        let alias = compileAndEval m.Arguments.[0] :?> string
+        let column = compileAndEval m.Arguments.[1] :?> string
+        $"\"{alias}\".\"{column}\""
+    // Raw SQL escape hatch
+    | MethodCall m when m.Method.Name = nameof rawExpr && m.Arguments.Count = 1 ->
+        compileAndEval m.Arguments.[0] :?> string
+    // PostgreSQL INTERVAL literal: interval "7 days" → INTERVAL '7 days'
+    // (Method name string-matched because `interval` lives in NpgsqlExtensions and isn't in scope here.)
+    | MethodCall m when m.Method.Name = "interval" && m.Arguments.Count = 1 ->
+        let value = compileAndEval m.Arguments.[0] :?> string
+        $"INTERVAL '{value}'"
+    // Aggregates → render via renderAggregate (handles COUNT(DISTINCT col)).
+    | MethodCall m when aggregateMethodNames.Contains m.Method.Name ->
+        let aggType = aggTypeOf m.Method.Name
+        match m.Arguments.[0] with
+        | Member mem when mem.Expression <> null ->
+            let alias = visitAlias mem.Expression
+            renderAggregate aggType (qualifyColumn alias mem.Member)
+        | inner ->
+            // Nested expression inside aggregate (e.g. SUM(CAST(...)) or MAX(SUM(...)))
+            renderAggregate aggType (renderExpr inner)
     | MethodCall m ->
-        let fnName = m.Method.Name
-        let args =
-            m.Arguments
-            |> Seq.map (fun arg ->
-                match arg with
-                | Member mem ->
-                    let alias = visitAlias mem.Expression
-                    qualifyColumn alias mem.Member
-                | Constant c when c.Value = null ->
-                    "NULL"
-                | Constant c when c.Type = typeof<string> ->
-                    $"'{c.Value}'"
-                | Constant c ->
-                    sprintf "%O" c.Value
-                | MethodCall _ as nested ->
-                    // Handle nested function calls
-                    visitSqlFn qualifyColumn nested
-                | _ ->
-                    notImplMsg $"Unsupported argument type in SQL function: {arg.NodeType}"
-            )
-            |> String.concat ", "
-        $"{fnName}({args})"
+        let args = m.Arguments |> Seq.map renderExpr |> String.concat ", "
+        $"{m.Method.Name.ToUpperInvariant()}({args})"
     | _ ->
         notImplMsg $"Expected a method call expression but got: {exp.NodeType}"
 
@@ -499,6 +692,31 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
 
     let rec visit (nexp: NormalizedExpression) : WhereClause =
         match nexp with
+        // Idiomatic F#: `set.Contains col`, `list.Contains col`, `array.Contains col`,
+        // and `Seq.contains col xs` / `List.contains col xs`. Compile to `col IN (values)`.
+        // The collection is compile-and-eval'd (it must be a closed-over value, not a column).
+        | NMethodCall(m, args) when m.Method.Name = "Contains" ->
+            let receiverExp, columnNExp =
+                if m.Object <> null && args.Length = 1 then
+                    // Instance method: receiver.Contains(col)
+                    m.Object, args.[0]
+                elif args.Length = 2 then
+                    // Static: Module.contains col xs OR xs.Contains col-via-extension
+                    m.Arguments.[0], args.[1]
+                else
+                    notImplMsg $"Unsupported Contains shape: {nexp}"
+            match columnNExp with
+            | NColumn (p, _) ->
+                let receiver = compileAndEvaluateExpression receiverExp
+                let queryParameters =
+                    (receiver :?> System.Collections.IEnumerable)
+                    |> Seq.cast<obj>
+                    |> Seq.map (QueryUtils.getQueryParameterForValue p.Member)
+                    |> Seq.toArray
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                InValues(fqCol, queryParameters)
+            | _ -> notImplMsg $"Unsupported Contains column argument: {columnNExp}"
         | NMethodCall(m, args) when List.contains m.Method.Name [ nameof isIn; nameof isNotIn; nameof op_BarEqualsBar; nameof op_BarLessGreaterBar ] ->
             let isIn = List.contains m.Method.Name [ nameof isIn; nameof op_BarEqualsBar ]
 
@@ -727,21 +945,44 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                 Compare(fqCol, compOp, Parameter queryParameter)
 
             | NColumn (p, _), _ ->
-                let value = nEvaluate right
                 let alias = visitAlias p.Expression
                 let fqCol = qualifyColumn alias p.Member
-                match value with
-                | null when op = ExpressionType.Equal -> IsNull(fqCol)
-                | null when op = ExpressionType.NotEqual -> IsNotNull(fqCol)
-                | _ ->
-                    let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
-                    Compare(fqCol, compOp, Parameter queryParameter)
+                // RHS may be a captured value (compile-and-eval) OR an outer-scope column
+                // reference in a lateral subquery (where the column's parameter isn't in
+                // the local `tables` map). Try eval; on failure, fall back to column ref.
+                let valueResult =
+                    try Some (nEvaluate right) with _ -> None
+                match valueResult with
+                | Some value ->
+                    match value with
+                    | null when op = ExpressionType.Equal -> IsNull(fqCol)
+                    | null when op = ExpressionType.NotEqual -> IsNotNull(fqCol)
+                    | _ ->
+                        let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
+                        Compare(fqCol, compOp, Parameter queryParameter)
+                | None ->
+                    match right with
+                    | NMemberAccess(_, m) when m.Expression <> null ->
+                        let rhsAlias = visitAlias m.Expression
+                        let rhsCol = qualifyColumn rhsAlias m.Member
+                        CompareColumns(fqCol, compOp, rhsCol)
+                    | _ -> notImplMsg $"Unable to evaluate where RHS: {right}"
 
             | _, NColumn (p, _) ->
-                let value = nEvaluate left
+                let valueResult =
+                    try Some (nEvaluate left) with _ -> None
                 let reversedOp = reverseComparisonOp compOp
                 let alias = visitAlias p.Expression
                 let fqCol = qualifyColumn alias p.Member
+                match valueResult with
+                | None ->
+                    match left with
+                    | NMemberAccess(_, m) when m.Expression <> null ->
+                        let lhsAlias = visitAlias m.Expression
+                        let lhsCol = qualifyColumn lhsAlias m.Member
+                        CompareColumns(lhsCol, compOp, fqCol)
+                    | _ -> notImplMsg $"Unable to evaluate where LHS: {left}"
+                | Some value ->
                 match value with
                 | null when reversedOp = Eq -> IsNull(fqCol)
                 | null when reversedOp = NotEq -> IsNotNull(fqCol)
@@ -792,8 +1033,45 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
 
             | NValue _, NValue _ ->
                 notImplMsg("Value to value comparisons are not currently supported. Ex: where (1 = 1)")
+
             | _ ->
-                notImpl()
+                // Fallback: outer-scope column refs (lateral subquery referencing
+                // a correlate-d parent table). The parameter isn't in the local
+                // `tables` map so NColumn doesn't match, but visitAlias still
+                // returns the parameter name as alias.
+                let rec asOuterCol (n: NormalizedExpression) =
+                    match n with
+                    | NMemberAccess(_, m) when (m.Expression :? ParameterExpression) -> Some m
+                    | NUnary(ExpressionType.Convert, inner) -> asOuterCol inner
+                    | _ -> None
+                let tryEval (n: NormalizedExpression) =
+                    try Some (nEvaluate n) with _ -> None
+                match asOuterCol left, asOuterCol right with
+                | Some ml, Some mr ->
+                    let lt = qualifyColumn (visitAlias ml.Expression) ml.Member
+                    let rt = qualifyColumn (visitAlias mr.Expression) mr.Member
+                    CompareColumns(lt, compOp, rt)
+                | Some ml, None ->
+                    let fq = qualifyColumn (visitAlias ml.Expression) ml.Member
+                    match tryEval right with
+                    | Some null when op = ExpressionType.Equal -> IsNull(fq)
+                    | Some null when op = ExpressionType.NotEqual -> IsNotNull(fq)
+                    | Some v ->
+                        let qp = QueryUtils.getQueryParameterForValue ml.Member v
+                        Compare(fq, compOp, Parameter qp)
+                    | None -> notImplMsg $"[where-cmp] cannot eval RHS: {right}"
+                | None, Some mr ->
+                    let fq = qualifyColumn (visitAlias mr.Expression) mr.Member
+                    let rev = reverseComparisonOp compOp
+                    match tryEval left with
+                    | Some null when op = ExpressionType.Equal -> IsNull(fq)
+                    | Some null when op = ExpressionType.NotEqual -> IsNotNull(fq)
+                    | Some v ->
+                        let qp = QueryUtils.getQueryParameterForValue mr.Member v
+                        Compare(fq, rev, Parameter qp)
+                    | None -> notImplMsg $"[where-cmp] cannot eval LHS: {left}"
+                | None, None ->
+                    notImplMsg $"[where-cmp-fallthrough] op={compOp}\nleft={left}\nright={right}"
 
         | _ ->
             notImplMsg $"Unsupported expression type in where clause: {nexp}"
@@ -872,7 +1150,7 @@ let visitHaving<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool
                 then IsNull(fqCol)
                 else IsNotNull(fqCol)
             | _ -> notImpl()
-        | NMethodCall(m, args) when List.contains m.Method.Name [ nameof minBy; nameof maxBy; nameof sumBy; nameof avgBy; nameof countBy; nameof avgByAs ] ->
+        | NMethodCall(m, args) when aggregateMethodNames.Contains m.Method.Name ->
             visit args.[0]
         | NBinaryAnd(left, right) ->
             let lt = visit left
@@ -899,11 +1177,11 @@ let visitHaving<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool
                 let rt =
                     let alias = visitAlias p2.Expression
                     qualifyColumn alias p2.Member
-                RawWhere($"{aggType}({lt}) {comparison} {rt}", [||])
+                RawWhere($"{renderAggregate aggType lt} {comparison} {rt}", [||])
             | NAggregateColumn (aggType, (p, _)), NValue value ->
                 let alias = visitAlias p.Expression
                 let lt = qualifyColumn alias p.Member
-                RawWhere($"{aggType}({lt}) {comparison} ?", [|value|])
+                RawWhere($"{renderAggregate aggType lt} {comparison} ?", [|value|])
             | NColumn (p1, _), NColumn (p2, _) ->
                 let lt =
                     let alias = visitAlias p1.Expression
@@ -948,9 +1226,13 @@ let visitPropertiesSelector<'T, 'Prop> (propertySelector: Expression<Func<'T, 'P
 
     visit (ExpressionNormalizer.toNormalizedExpression (propertySelector :> Expression))
 
+[<NoComparison>]
 type OrderBy =
     | OrderByColumn of tableAlias: string * MemberInfo
     | OrderByAggregateColumn of aggregateType: string * tableAlias: string * MemberInfo
+    /// `orderBy (cosine_distance(col, vec))` and similar method-call expressions.
+    /// Carries the rendered SQL fragment with `?` placeholders bound to `parameters`.
+    | OrderByExpression of fragment: string * parameters: obj[]
     | OrderByIgnored
 
 /// Returns a column MemberInfo.
@@ -971,6 +1253,34 @@ let visitOrderByPropertySelector<'T, 'Prop> (propertySelector: Expression<Func<'
         | NAggregateColumn (aggType, (p, _)) ->
             let alias = visitAlias p.Expression
             OrderByAggregateColumn (aggType, alias, p.Member)
+        // Method-call orderBy (e.g. orderBy (cosine_distance(col, inlineValue vec))) — render directly.
+        // Walk the expression building SQL fragment + parameter list. inlineValue args become bound
+        // parameters; columns are qualified; InfixOperators registrations rewrite to infix.
+        | NMethodCall(m, _) ->
+            let parms = ResizeArray<obj>()
+            let qualifyColumn alias (mem: MemberInfo) = $"\"{alias}\".\"{mem.Name}\""
+            let rec render (e: Expression) : string =
+                match e with
+                | :? UnaryExpression as u when u.NodeType = ExpressionType.Convert ->
+                    render u.Operand
+                | :? MethodCallExpression as mc when mc.Method.Name = nameof inlineValue && mc.Arguments.Count = 1 ->
+                    let value = compileAndEval mc.Arguments.[0]
+                    parms.Add(if isNull value then box System.DBNull.Value else value)
+                    "?"
+                | :? MemberExpression as mem when mem.Expression <> null ->
+                    let alias = visitAlias mem.Expression
+                    qualifyColumn alias mem.Member
+                | :? ConstantExpression as c -> renderConstant false c
+                | :? MethodCallExpression as mc when aggregateMethodNames.Contains mc.Method.Name ->
+                    let aggType = aggTypeOf mc.Method.Name
+                    renderAggregate aggType (render mc.Arguments.[0])
+                | :? MethodCallExpression as mc ->
+                    let args = mc.Arguments |> Seq.map render |> String.concat ", "
+                    $"{mc.Method.Name.ToUpperInvariant()}({args})"
+                | _ ->
+                    notImplMsg $"Unsupported expression in orderBy method-call: {e.NodeType}"
+            let frag = render (m :> Expression)
+            OrderByExpression (frag, parms.ToArray())
         | NMemberAccess(inner, m) ->
             if m.Member.DeclaringType |> isOptionOrNullableType then
                 visit inner
@@ -984,7 +1294,8 @@ let visitOrderByPropertySelector<'T, 'Prop> (propertySelector: Expression<Func<'
 
     visit (ExpressionNormalizer.toNormalizedExpression (propertySelector :> Expression))
 
-type JoinedPropertyInfo = 
+[<NoComparison>]
+type JoinedPropertyInfo =
     {
         Alias: string
         Member: MemberInfo
@@ -1025,10 +1336,17 @@ let visitPropertySelector<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Pro
 
     visit (ExpressionNormalizer.toNormalizedExpression (propertySelector :> Expression))
 
+[<NoComparison>]
 type Selection =
     | SelectedTable of tableAlias: string * tableType: Type
     | SelectedColumn of tableAlias: string * column: string * columnType: Type * isOpt: bool * isNullable: bool
     | SelectedExpression of sqlFragment: string
+    /// Select projection with bound parameters (e.g. `1.0 - cosine_distance(col, inlineValue v)`).
+    /// Fragment uses `?` placeholders that the emitter binds in order.
+    | SelectedExpressionWithParams of sqlFragment: string * parameters: obj[]
+    /// Selection with an explicit `AS "alias"` (anonymous-record field name).
+    /// Wraps any of the above; the inner Selection is rendered, then the alias appended.
+    | SelectedAs of inner: Selection * alias: string
 
 
 /// Visits a join predicate expression and builds a WhereClause for the JOIN ON condition.
@@ -1086,7 +1404,31 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
                     let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
                     Compare(fqCol, reversedOp, Parameter queryParameter)
 
-            // Nullable.Value / Option.Value comparisons
+            // Option.Value / Nullable.Value column compared to another column → CompareColumns.
+            | NColumn (p, ext), NColumn (p2, _) when ext = ExtProperty.Value ->
+                let alias1 = visitAlias p.Expression
+                let m1 = tryGetMember p
+                let lt = qualifyColumn alias1 m1.Value.Member
+                let alias2 = visitAlias p2.Expression
+                let rt = qualifyColumn alias2 p2.Member
+                CompareColumns(lt, compOp, rt)
+            | NColumn (p1, _), NColumn (p2, ext2) when ext2 = ExtProperty.Value ->
+                let alias1 = visitAlias p1.Expression
+                let lt = qualifyColumn alias1 p1.Member
+                let alias2 = visitAlias p2.Expression
+                let m2 = tryGetMember p2
+                let rt = qualifyColumn alias2 m2.Value.Member
+                CompareColumns(lt, compOp, rt)
+            // Both sides Value-wrapped (e.g. left.Value.x = right.Value.y)
+            | NColumn (p1, ext1), NColumn (p2, ext2) when ext1 = ExtProperty.Value && ext2 = ExtProperty.Value ->
+                let alias1 = visitAlias p1.Expression
+                let m1 = tryGetMember p1
+                let lt = qualifyColumn alias1 m1.Value.Member
+                let alias2 = visitAlias p2.Expression
+                let m2 = tryGetMember p2
+                let rt = qualifyColumn alias2 m2.Value.Member
+                CompareColumns(lt, compOp, rt)
+            // Nullable.Value / Option.Value column compared to a value (compile-eval'd if needed).
             | NColumn (p, ext), _ when ext = ExtProperty.Value ->
                 let value =
                     match right with
@@ -1104,12 +1446,130 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
                     let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
                     Compare(fqCol, compOp, Parameter queryParameter)
 
+            // Column compared to a non-NValue expression. Could be either:
+            //   (a) a captured local / static member — compile-and-eval to a parameter, or
+            //   (b) a column reference whose receiver isn't in the local `tables` map (e.g. a
+            //       correlated outer-scope parameter from a lateral subquery).
+            // Try compile-and-eval first; if it fails (because the expression references a
+            // free query parameter), fall back to treating it as a column ref via the
+            // underlying member chain.
+            | NColumn (p, _), (NMemberAccess _ | NMethodCall _ | NUnknown _) ->
+                let evalRhs () =
+                    match right with
+                    | NMemberAccess(_, m) -> Some (compileAndEvaluateExpression (m :> Expression))
+                    | NMethodCall(m, _) -> Some (compileAndEvaluateExpression (m :> Expression))
+                    | NUnknown e -> Some (compileAndEvaluateExpression e)
+                    | _ -> None
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                let tryColumnRef () =
+                    match right with
+                    | NMemberAccess(_, m) when m.Expression <> null ->
+                        try
+                            let rhsAlias = visitAlias m.Expression
+                            Some (qualifyColumn rhsAlias m.Member)
+                        with _ -> None
+                    | _ -> None
+                let result =
+                    try evalRhs () |> Option.map Choice1Of2
+                    with _ -> tryColumnRef () |> Option.map Choice2Of2
+                match result with
+                | Some (Choice1Of2 value) ->
+                    match value with
+                    | null when op = ExpressionType.Equal -> IsNull(fqCol)
+                    | null when op = ExpressionType.NotEqual -> IsNotNull(fqCol)
+                    | _ ->
+                        let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
+                        Compare(fqCol, compOp, Parameter queryParameter)
+                | Some (Choice2Of2 rhsCol) ->
+                    CompareColumns(fqCol, compOp, rhsCol)
+                | None ->
+                    notImplMsg $"Unable to render join predicate RHS: {right}"
+
+            // Reverse: captured value or outer-scope column compared to local column.
+            | (NMemberAccess _ | NMethodCall _ | NUnknown _), NColumn (p, _) ->
+                let evalLhs () =
+                    match left with
+                    | NMemberAccess(_, m) -> Some (compileAndEvaluateExpression (m :> Expression))
+                    | NMethodCall(m, _) -> Some (compileAndEvaluateExpression (m :> Expression))
+                    | NUnknown e -> Some (compileAndEvaluateExpression e)
+                    | _ -> None
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                let tryColumnRef () =
+                    match left with
+                    | NMemberAccess(_, m) when m.Expression <> null ->
+                        try
+                            let lhsAlias = visitAlias m.Expression
+                            Some (qualifyColumn lhsAlias m.Member)
+                        with _ -> None
+                    | _ -> None
+                let result =
+                    try evalLhs () |> Option.map Choice1Of2
+                    with _ -> tryColumnRef () |> Option.map Choice2Of2
+                let reversedOp = reverseComparisonOp compOp
+                match result with
+                | Some (Choice1Of2 value) ->
+                    match value with
+                    | null when reversedOp = Eq -> IsNull(fqCol)
+                    | null when reversedOp = NotEq -> IsNotNull(fqCol)
+                    | _ ->
+                        let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
+                        Compare(fqCol, reversedOp, Parameter queryParameter)
+                | Some (Choice2Of2 lhsCol) ->
+                    CompareColumns(lhsCol, compOp, fqCol)
+                | None ->
+                    notImplMsg $"Unable to render join predicate LHS: {left}"
+
             | _ ->
                 notImplMsg $"Unsupported join predicate comparison: {op}"
         | _ ->
             notImplMsg $"Unsupported join predicate expression: {nexp}"
 
     visit (ExpressionNormalizer.toNormalizedExpression (predicate :> Expression))
+
+/// Renders a select-projection expression to a SQL fragment with bound parameters.
+/// Used for arithmetic/inlineValue/method-call combinations like `1.0 - cosine_distance(col, inlineValue v)`.
+/// inlineValue args are compile-and-eval'd as bound parameters (`?`); columns are qualified;
+/// InfixOperators rewrites apply.
+let private renderSelectExpression (exp: Expression) : string * obj[] =
+    let parms = ResizeArray<obj>()
+    let qualifyColumn alias (mem: MemberInfo) = $"{{{alias}}}.{{{mem.Name}}}"
+    let rec render (e: Expression) : string =
+        match e with
+        | :? UnaryExpression as u when u.NodeType = ExpressionType.Convert ->
+            render u.Operand
+        | :? MethodCallExpression as mc when mc.Method.Name = nameof inlineValue && mc.Arguments.Count = 1 ->
+            let value = compileAndEval mc.Arguments.[0]
+            parms.Add(if isNull value then box System.DBNull.Value else value)
+            "?"
+        | :? MemberExpression as mem when mem.Expression <> null ->
+            let alias = visitAlias mem.Expression
+            qualifyColumn alias mem.Member
+        | :? ConstantExpression as c -> renderConstant true c
+        | :? BinaryExpression as b ->
+            let left = render b.Left
+            let right = render b.Right
+            let op =
+                match tryGetBinaryOp b.NodeType with
+                | Some s -> s
+                | None -> notImplMsg $"Unsupported binary operator in select expression: {b.NodeType}"
+            $"{left} {op} {right}"
+        // Aggregates: countBy/sumBy/etc. → SUM(col), COUNT(DISTINCT col) for countDistinct.
+        | :? MethodCallExpression as mc when aggregateMethodNames.Contains mc.Method.Name ->
+            let aggType = aggTypeOf mc.Method.Name
+            renderAggregate aggType (render mc.Arguments.[0])
+        | :? MethodCallExpression as mc ->
+            // Delegate to visitSqlFn for caseWhen/castAs/coalesce/etc. Fall back to a
+            // generic "name(args)" form only if visitSqlFn explicitly rejects the shape.
+            try visitSqlFn qualifyColumn (mc :> Expression)
+            with :? System.NotImplementedException ->
+                let args = mc.Arguments |> Seq.map render |> String.concat ", "
+                $"{mc.Method.Name.ToUpperInvariant()}({args})"
+        | _ ->
+            notImplMsg $"Unsupported expression in select projection: {e.NodeType}"
+    let frag = render exp
+    frag, parms.ToArray()
 
 /// Returns a list of one or more fully qualified table names: ["{schema}.{table}"]
 let visitSelect<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) =
@@ -1191,13 +1651,52 @@ let visitSelect<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) =
         | NAggregateColumn (aggType, (p, _)) ->
             let alias = visitAlias p.Expression
             let fqCol = $"{{%s{alias}}}.{{%s{p.Member.Name}}}"
-            [ SelectedExpression $"{aggType}({fqCol})" ]
+            [ SelectedExpression (renderAggregate aggType fqCol) ]
         | NMethodCall(m, _) ->
             let qualifyCol alias (mem: MemberInfo) = $"{{%s{alias}}}.{{%s{mem.Name}}}"
             let sqlFragment = visitSqlFn qualifyCol (m :> Expression)
             [ SelectedExpression sqlFragment ]
-        | NNew(_, args) ->
-            args |> List.collect visit
+        | NNew(newExpr, args) ->
+            // Each anonymous-record / tuple / DU field initializer is one Selection.
+            // newExpr.Members carries the member info for each constructor arg, which gives us
+            // the F# field name to use as a SQL `AS "alias"` so the consumer reader can read by
+            // field name rather than the underlying column name.
+            // Binary, Unary, and inlineValue-bearing initializers fall through to the
+            // expression-walker that emits SelectedExpressionWithParams.
+            let memberNames =
+                if newExpr.Members <> null && newExpr.Members.Count = args.Length then
+                    newExpr.Members |> Seq.map (fun m -> Some m.Name) |> Seq.toList
+                else
+                    // Fallback: read fields/properties from the anonymous record type itself.
+                    let t = newExpr.Type
+                    let props = t.GetProperties()
+                    if props.Length = args.Length then
+                        props |> Array.map (fun p -> Some p.Name) |> Array.toList
+                    else
+                        args |> List.map (fun _ -> None)
+            args
+            |> List.mapi (fun i nargs -> i, nargs, memberNames.[i])
+            |> List.collect (fun (i, narg, fieldName) ->
+                let inner =
+                    match narg with
+                    | NMethodCall _ | NAggregateColumn _ | NMemberAccess _ | NParameter _ | NNew _ ->
+                        visit narg
+                    | _ ->
+                        let frag, parms = renderSelectExpression newExpr.Arguments.[i]
+                        [ SelectedExpressionWithParams (frag, parms) ]
+                // Wrap with SelectedAs only when the field name is meaningful (not Item1/Item2/...
+                // tuple-positional names) and differs from the underlying column.
+                let isTuplePositional (n: string) =
+                    n.StartsWith("Item")
+                    && n.Length > 4
+                    && System.Char.IsDigit(n.[4])
+                let isMeaningfulAlias n = not (isTuplePositional n)
+                match fieldName, inner with
+                | Some fname, [ SelectedColumn (_, col, _, _, _) as sel ] when isMeaningfulAlias fname && fname <> col ->
+                    [ SelectedAs (sel, fname) ]
+                | Some fname, [ (SelectedExpression _ | SelectedExpressionWithParams _) as sel ] when isMeaningfulAlias fname ->
+                    [ SelectedAs (sel, fname) ]
+                | _ -> inner)
         | NParameter p ->
             [ SelectedTable (p.Name, p.Type) ]
         | NMemberAccess(inner, m) ->

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -664,8 +664,14 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
             // Nested expression inside aggregate (e.g. SUM(CAST(...)) or MAX(SUM(...)))
             renderAggregate aggType (renderExpr inner)
     | MethodCall m ->
-        let args = m.Arguments |> Seq.map renderExpr |> String.concat ", "
-        $"{m.Method.Name.ToUpperInvariant()}({args})"
+        // Infix-operator seam: a 2-arg function registered via SqlHydraInfixOperatorAttribute
+        // (e.g. cosine_distance → <=>) is emitted infix: (lhs <=> rhs).
+        match (if m.Arguments.Count = 2 then InfixOperators.tryGetOperator m.Method.Name else None) with
+        | Some op ->
+            $"({renderExpr m.Arguments.[0]} {op} {renderExpr m.Arguments.[1]})"
+        | None ->
+            let args = m.Arguments |> Seq.map renderExpr |> String.concat ", "
+            $"{m.Method.Name.ToUpperInvariant()}({args})"
     | _ ->
         notImplMsg $"Expected a method call expression but got: {exp.NodeType}"
 
@@ -1271,6 +1277,9 @@ let visitOrderByPropertySelector<'T, 'Prop> (propertySelector: Expression<Func<'
                     let alias = visitAlias mem.Expression
                     qualifyColumn alias mem.Member
                 | :? ConstantExpression as c -> renderConstant false c
+                | :? MethodCallExpression as mc when mc.Arguments.Count = 2 && (InfixOperators.tryGetOperator mc.Method.Name).IsSome ->
+                    let op = (InfixOperators.tryGetOperator mc.Method.Name).Value
+                    $"({render mc.Arguments.[0]} {op} {render mc.Arguments.[1]})"
                 | :? MethodCallExpression as mc when aggregateMethodNames.Contains mc.Method.Name ->
                     let aggType = aggTypeOf mc.Method.Name
                     renderAggregate aggType (render mc.Arguments.[0])
@@ -1555,6 +1564,9 @@ let private renderSelectExpression (exp: Expression) : string * obj[] =
                 | Some s -> s
                 | None -> notImplMsg $"Unsupported binary operator in select expression: {b.NodeType}"
             $"{left} {op} {right}"
+        | :? MethodCallExpression as mc when mc.Arguments.Count = 2 && (InfixOperators.tryGetOperator mc.Method.Name).IsSome ->
+            let op = (InfixOperators.tryGetOperator mc.Method.Name).Value
+            $"({render mc.Arguments.[0]} {op} {render mc.Arguments.[1]})"
         // Aggregates: countBy/sumBy/etc. → SUM(col), COUNT(DISTINCT col) for countDistinct.
         | :? MethodCallExpression as mc when aggregateMethodNames.Contains mc.Method.Name ->
             let aggType = aggTypeOf mc.Method.Name

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -65,6 +65,20 @@ type SqlFn =
     static member make_date(year: int, month: int, day: int) : DateTime = sqlFn
     static member make_time(hour: int, minute: int, second: float) : TimeSpan = sqlFn
 
+    // GREATEST / LEAST — variadic standard SQL functions
+    static member greatest(a: 'T, b: 'T) : 'T = sqlFn
+    static member greatest(a: 'T, b: 'T, c: 'T) : 'T = sqlFn
+    static member greatest(a: 'T, b: 'T, c: 'T, d: 'T) : 'T = sqlFn
+    static member least(a: 'T, b: 'T) : 'T = sqlFn
+    static member least(a: 'T, b: 'T, c: 'T) : 'T = sqlFn
+    static member least(a: 'T, b: 'T, c: 'T, d: 'T) : 'T = sqlFn
+
+/// PostgreSQL-specific functions.
+type PgSqlFn =
+    /// Renders a PostgreSQL `INTERVAL '<value>'` literal.
+    /// Example: `interval "7 days"` → `INTERVAL '7 days'`
+    static member interval(value: string) : TimeSpan = sqlFn
+
 type InsertBuilder<'Inserted, 'InsertReturn> with
     
     /// Performs an update on one or more update fields if a conflict occurs.
@@ -81,11 +95,168 @@ type InsertBuilder<'Inserted, 'InsertReturn> with
 
     /// Insert is ignored if a conflict occurs.
     [<CustomOperation("onConflictDoNothing", MaintainsVariableSpace = true)>]
-    member this.OnConflictDoNothing(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>, 
-        [<ProjectionParameter>] conflictFields) = 
-        
+    member this.OnConflictDoNothing(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        [<ProjectionParameter>] conflictFields) =
+
         let spec = state.Query
         let conflictFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'ConflictProperty> conflictFields (fun tblAlias p -> p.Name)
         let newSpec = { spec with InsertType = OnConflictDoNothing conflictFields }
         QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
+
+    /// ON CONFLICT (cols) DO UPDATE SET — fields in `coalesceFields` get
+    /// `col = COALESCE(EXCLUDED.col, table.col)` (preserves existing non-null values
+    /// when the new value is NULL). Other fields use `col = EXCLUDED.col`.
+    /// `coalesceFields` should be a subset of `updateFields`.
+    [<CustomOperation("onConflictDoUpdateCoalesce", MaintainsVariableSpace = true)>]
+    member this.OnConflictDoUpdateCoalesce(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        [<ProjectionParameter>] conflictFields,
+        [<ProjectionParameter>] updateFields,
+        [<ProjectionParameter>] coalesceFields) =
+        let spec = state.Query
+        let conflictFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'ConflictProperty> conflictFields (fun _ p -> p.Name)
+        let updateFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'UpdateProperties> updateFields (fun _ p -> p.Name)
+        let coalesceFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'CoalesceProperties> coalesceFields (fun _ p -> p.Name)
+        let newSpec = { spec with InsertType = OnConflictDoUpdateCoalesce (conflictFields, updateFields, coalesceFields) }
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
+
+    /// ON CONFLICT (cols) WHERE <whereFragment> DO NOTHING — for partial-index conflicts.
+    /// Use ? as parameter placeholders in the where fragment.
+    [<CustomOperation("onConflictDoNothingWhereRaw", MaintainsVariableSpace = true)>]
+    member this.OnConflictDoNothingWhereRaw(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        [<ProjectionParameter>] conflictFields,
+        whereFragment: string,
+        parameters: obj[]) =
+        let spec = state.Query
+        let conflictFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'ConflictProperty> conflictFields (fun _ p -> p.Name)
+        let newSpec = { spec with InsertType = OnConflictDoNothingWhereRaw (conflictFields, whereFragment, parameters) }
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
+
+    /// ON CONFLICT (<rawTargetExpr>) DO NOTHING — for expression indexes (e.g., lower(email)).
+    [<CustomOperation("onConflictDoNothingRawTarget", MaintainsVariableSpace = true)>]
+    member this.OnConflictDoNothingRawTarget(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        rawTargetExpr: string) =
+        let spec = state.Query
+        let newSpec = { spec with InsertType = OnConflictDoNothingRawTarget rawTargetExpr }
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
+
+    // ─── Composable ON CONFLICT API ──────────────────────────────────────────────
+    // Usage:
+    //   onConflict col [whereRawConflict "..."]  (sets target)
+    //   doNothing | doUpdate cols | doUpdateCoalesce cols  (sets action)
+    //
+    // The target is held in PendingConflict until an action operation finalizes
+    // the spec into a closed `InsertType` value.
+
+    /// Sets the conflict target to typed column(s). Followed by `doNothing` / `doUpdate` / `doUpdateCoalesce`.
+    [<CustomOperation("onConflict", MaintainsVariableSpace = true)>]
+    member this.OnConflict(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        [<ProjectionParameter>] conflictFields) =
+        let spec = state.Query
+        let conflictFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'ConflictProperty> conflictFields (fun _ p -> p.Name)
+        let newSpec = { spec with PendingConflict = Some (TypedConflictColumns (conflictFields, None)) }
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
+
+    /// Sets a raw-expression conflict target (for expression indexes like `lower(email)`).
+    /// Followed by `doNothing` / `doUpdate` / `doUpdateCoalesce`.
+    [<CustomOperation("onConflictRaw", MaintainsVariableSpace = true)>]
+    member this.OnConflictRaw(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        rawTargetExpr: string) =
+        let spec = state.Query
+        let newSpec = { spec with PendingConflict = Some (RawConflictTarget (rawTargetExpr, None)) }
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(newSpec, state.TableMappings)
+
+    /// Adds a partial-index WHERE clause to the conflict target (must follow `onConflict`).
+    [<CustomOperation("whereRawConflict", MaintainsVariableSpace = true)>]
+    member this.WhereRawConflict(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        whereClause: string) =
+        let spec = state.Query
+        let updated =
+            match spec.PendingConflict with
+            | Some (TypedConflictColumns (fields, _)) -> TypedConflictColumns (fields, Some whereClause)
+            | Some (RawConflictTarget (raw, _)) -> RawConflictTarget (raw, Some whereClause)
+            | None -> failwith "whereRawConflict requires onConflict (or onConflictRaw) to be called first"
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(
+            { spec with PendingConflict = Some updated }, state.TableMappings)
+
+    /// Conflict action: DO NOTHING. Closes the pending conflict target into InsertType.
+    [<CustomOperation("doNothing", MaintainsVariableSpace = true)>]
+    member this.DoNothing(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>) =
+        let spec = state.Query
+        let newType =
+            match spec.PendingConflict with
+            | Some (TypedConflictColumns (fields, None)) ->
+                OnConflictDoNothing fields
+            | Some (TypedConflictColumns (fields, Some whereRaw)) ->
+                OnConflictDoNothingWhereRaw (fields, whereRaw, [||])
+            | Some (RawConflictTarget (raw, None)) ->
+                OnConflictDoNothingRawTarget raw
+            | Some (RawConflictTarget (_, Some _)) ->
+                failwith "ON CONFLICT (raw target) WHERE clause is not currently supported; use onConflict <columns> with whereRawConflict instead"
+            | None ->
+                failwith "doNothing requires onConflict (or onConflictRaw) to be called first"
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(
+            { spec with InsertType = newType; PendingConflict = None },
+            state.TableMappings)
+
+    /// Conflict action: DO UPDATE SET col=EXCLUDED.col for each update field.
+    [<CustomOperation("doUpdate", MaintainsVariableSpace = true)>]
+    member this.DoUpdate(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        [<ProjectionParameter>] updateFields) =
+        let spec = state.Query
+        let updateFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'UpdateProperties> updateFields (fun _ p -> p.Name)
+        let conflictFields =
+            match spec.PendingConflict with
+            | Some (TypedConflictColumns (fields, None)) -> fields
+            | Some (TypedConflictColumns _) -> failwith "doUpdate does not currently support a partial-index WHERE clause"
+            | Some (RawConflictTarget _) -> failwith "doUpdate requires a typed conflict target (use onConflict, not onConflictRaw)"
+            | None -> failwith "doUpdate requires onConflict to be called first"
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(
+            { spec with InsertType = OnConflictDoUpdate (conflictFields, updateFields); PendingConflict = None },
+            state.TableMappings)
+
+    /// Conflict action: DO UPDATE SET — `updateFields` are updated as `col = EXCLUDED.col`,
+    /// except those listed in `coalesceFields` which become `col = COALESCE(EXCLUDED.col, col)`.
+    /// `coalesceFields` should be a subset of `updateFields`.
+    [<CustomOperation("doUpdateCoalesce", MaintainsVariableSpace = true)>]
+    member this.DoUpdateCoalesce(state: QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>,
+        [<ProjectionParameter>] updateFields,
+        [<ProjectionParameter>] coalesceFields) =
+        let spec = state.Query
+        let updateFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'UpdateProperties> updateFields (fun _ p -> p.Name)
+        let coalesceFields = LinqExpressionVisitors.visitPropertiesSelector<'T, 'CoalesceProperties> coalesceFields (fun _ p -> p.Name)
+        let conflictFields =
+            match spec.PendingConflict with
+            | Some (TypedConflictColumns (fields, None)) -> fields
+            | Some (TypedConflictColumns _) -> failwith "doUpdateCoalesce does not currently support a partial-index WHERE clause"
+            | Some (RawConflictTarget _) -> failwith "doUpdateCoalesce requires a typed conflict target (use onConflict, not onConflictRaw)"
+            | None -> failwith "doUpdateCoalesce requires onConflict to be called first"
+        QuerySource<'T, InsertQuerySpec<'T, 'InsertReturn>>(
+            { spec with InsertType = OnConflictDoUpdateCoalesce (conflictFields, updateFields, coalesceFields); PendingConflict = None },
+            state.TableMappings)
+
+type SelectBuilder<'Selected, 'Mapped> with
+
+    /// Adds DISTINCT ON (col) — PostgreSQL-only. Mutually exclusive with `distinct`.
+    /// Multiple `distinctOn` calls accumulate columns.
+    [<CustomOperation("distinctOn", MaintainsVariableSpace = true)>]
+    member this.DistinctOn (state: QuerySource<'T, SelectQueryIR>, [<ProjectionParameter>] propertySelector: System.Linq.Expressions.Expression<Func<'T, 'Prop>>) =
+        let ir = state.Query
+        let column =
+            LinqExpressionVisitors.visitOrderByPropertySelector<'T, 'Prop> propertySelector
+            |> function
+                | LinqExpressionVisitors.OrderByColumn (alias, p) -> $"{alias}.{p.Name}"
+                | _ -> failwith "distinctOn requires a simple column selector."
+        QuerySource<'T, SelectQueryIR>({ ir with DistinctOn = ir.DistinctOn @ [column] }, state.TableMappings)
+
+    /// LEFT JOIN LATERAL (subquery) AS alias ON true. PostgreSQL-only.
+    /// The subquery is built with its own select { ... } and may correlate to outer columns.
+    [<CustomOperation("lateralJoin", MaintainsVariableSpace = true)>]
+    member this.LateralJoin (state: QuerySource<'T, SelectQueryIR>, subquery: SelectQuery, alias: string) =
+        let ir = state.Query
+        let joinClause =
+            { Kind = LeftJoinLateral
+              Table = alias
+              Subquery = Some subquery.SelectIR
+              Condition = WhereClause.RawWhere("true", [||]) }
+        QuerySource<'T, SelectQueryIR>({ ir with Joins = ir.Joins @ [joinClause] }, state.TableMappings)
 

--- a/src/SqlHydra.Query/QueryContext.fs
+++ b/src/SqlHydra.Query/QueryContext.fs
@@ -6,11 +6,14 @@ open System.Threading
 open SqlHydra.Domain
 
 /// Indicates which execution strategy to use after command preparation.
+[<NoComparison>]
 type private InsertExecMode =
     | ExecNonQuery
     | ExecScalar
     | ExecOracleIdentity of DbParameter
     | ExecOutputClause of OutputField list
+    /// PostgreSQL/SQLite RETURNING clause — read columns from the result reader.
+    | ExecReturning of returningColumns: string list
 
 /// Contains methods that compile and read a query.
 type QueryContext(conn: DbConnection, emitter: ISqlEmitter) =
@@ -210,6 +213,60 @@ type QueryContext(conn: DbConnection, emitter: ISqlEmitter) =
             return entities |> Seq.tryHead
         }
 
+    /// Reads RETURNING clause columns into a single value or tuple matching 'Return.
+    /// Column types come from 'Return — when 'Return is a tuple, each element type is read in order;
+    /// when it's a single type, one column is read. Option/Nullable are unwrapped.
+    member private _.ReadReturningValues<'Return> (cmd: DbCommand) (cancel: CancellationToken) (returningCols: string list) =
+        task {
+            use! reader = cmd.ExecuteReaderAsync(cancel)
+            let! hasRow = reader.ReadAsync(cancel)
+            if not hasRow then
+                // ON CONFLICT DO NOTHING with no actual conflict-update returns zero rows.
+                // Caller signature already accepts the default value; semantics mirror the
+                // "insert was a no-op" outcome.
+                return Unchecked.defaultof<'Return>
+            else
+
+            let elementTypes =
+                let t = typeof<'Return>
+                if FSharp.Reflection.FSharpType.IsTuple(t)
+                then FSharp.Reflection.FSharpType.GetTupleElements(t)
+                else [| t |]
+
+            let unwrap (t: System.Type) =
+                if t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<Option<_>>
+                then Some t.GenericTypeArguments.[0]
+                elif t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<System.Nullable<_>>
+                then Some t.GenericTypeArguments.[0]
+                else None
+
+            let values =
+                List.zip returningCols (List.ofArray elementTypes)
+                |> List.map (fun (colName, retType) ->
+                    let ord = reader.GetOrdinal(colName)
+                    match unwrap retType with
+                    | Some inner ->
+                        if reader.IsDBNull(ord) then
+                            if retType.GetGenericTypeDefinition() = typedefof<Option<_>>
+                            then None |> box
+                            else System.Activator.CreateInstance(retType) // Nullable default ()
+                        else
+                            let raw = reader[ord]
+                            // Construct Option<T>(value) or Nullable<T>(value).
+                            System.Activator.CreateInstance(retType, [| System.Convert.ChangeType(raw, inner) |])
+                    | None ->
+                        let raw = reader[ord]
+                        System.Convert.ChangeType(raw, retType))
+                |> List.toArray
+
+            match values with
+            | [| v |] -> return v :?> 'Return
+            | _ ->
+                let tupleType = FSharp.Reflection.FSharpType.MakeTupleType(elementTypes)
+                let tuple = FSharp.Reflection.FSharpValue.MakeTuple(values, tupleType)
+                return tuple :?> 'Return
+        }
+
     /// Reads output values from a DbCommand execution (for OUTPUT clause support).
     member private _.ReadOutputValues<'InsertReturn> (cmd: DbCommand) (cancel: CancellationToken) (outputFields: OutputField list) =
         task {
@@ -309,6 +366,10 @@ type QueryContext(conn: DbConnection, emitter: ISqlEmitter) =
             this.Logger { Sql = cmd.CommandText; Parameters = [] }
             cmd, ExecOutputClause outputFields
 
+        | { Returning = returning } when returning.Length > 0 ->
+            this.Logger { Sql = cmd.CommandText; Parameters = [] }
+            cmd, ExecReturning returning
+
         | _ ->
             this.Logger { Sql = cmd.CommandText; Parameters = [] }
             cmd, ExecNonQuery
@@ -328,6 +389,9 @@ type QueryContext(conn: DbConnection, emitter: ISqlEmitter) =
             Convert.ChangeType(outputParam.Value, typeof<'InsertReturn>) :?> 'InsertReturn
         | ExecOutputClause outputFields ->
             this.ReadOutputValues<'InsertReturn> cmd CancellationToken.None outputFields
+            |> Async.AwaitTask |> Async.RunSynchronously
+        | ExecReturning cols ->
+            this.ReadReturningValues<'InsertReturn> cmd CancellationToken.None cols
             |> Async.AwaitTask |> Async.RunSynchronously
 
     member this.InsertAsync<'T, 'InsertReturn> (query: InsertQuery<'T, 'InsertReturn>) =
@@ -351,6 +415,9 @@ type QueryContext(conn: DbConnection, emitter: ISqlEmitter) =
             | ExecOutputClause outputFields ->
                 let! outputValues = this.ReadOutputValues<'InsertReturn> cmd cancel outputFields
                 return outputValues
+            | ExecReturning cols ->
+                let! returnValues = this.ReadReturningValues<'InsertReturn> cmd cancel cols
+                return returnValues
         }
 
     member this.Update (query: UpdateQuery<'T, 'UpdateReturn>) =

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -142,6 +142,53 @@ module RawExpressions =
     /// Example: caseWhen (col > 0) (inlineValue "yes") (inlineValue "no")
     let inlineValue<'T> (_value: 'T) : 'T = Unchecked.defaultof<'T>
 
+/// Assembly-level attribute that registers a SQL function name as an infix operator.
+/// Extension packages (e.g. SqlHydra.Query.Pgvector) apply this attribute on themselves and
+/// SqlHydra discovers it the first time a query is compiled. No explicit registration call required.
+///
+/// Example (in extension package):
+///   [<assembly: SqlHydra.Query.SqlHydraInfixOperator("cosine_distance", "<=>")>]
+[<System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)>]
+type SqlHydraInfixOperatorAttribute(fnName: string, op: string) =
+    inherit System.Attribute()
+    member _.FnName = fnName
+    member _.Operator = op
+
+/// Registry for SQL functions that should be emitted as infix operators.
+/// Discovers `SqlHydraInfixOperatorAttribute` declarations from all loaded assemblies, and
+/// subscribes to `AssemblyLoad` so plugin assemblies that load lazily are picked up automatically.
+/// Manual registration is also supported for tests / dynamic scenarios.
+module InfixOperators =
+    let private registry = System.Collections.Concurrent.ConcurrentDictionary<string, string>()
+
+    let private scanAssembly (asm: System.Reflection.Assembly) =
+        try
+            for attr in asm.GetCustomAttributes(typeof<SqlHydraInfixOperatorAttribute>, false) do
+                let a = attr :?> SqlHydraInfixOperatorAttribute
+                registry.[a.FnName] <- a.Operator
+        with _ -> () // tolerate dynamic / reflection-only / partially-loaded assemblies
+
+    let private initOnce =
+        lazy (
+            // Pick up assemblies already loaded at startup.
+            for asm in System.AppDomain.CurrentDomain.GetAssemblies() do
+                scanAssembly asm
+            // Pick up plugin assemblies that load lazily after first use.
+            System.AppDomain.CurrentDomain.AssemblyLoad.Add(fun e -> scanAssembly e.LoadedAssembly)
+        )
+
+    /// Manually register a function name. Extension packages should prefer
+    /// `SqlHydraInfixOperatorAttribute` so registration is automatic.
+    let register (fnName: string) (operator: string) =
+        registry.[fnName] <- operator
+
+    /// Look up whether a function should be emitted as an infix operator.
+    let tryGetOperator (fnName: string) =
+        initOnce.Value
+        match registry.TryGetValue(fnName) with
+        | true, op -> Some op
+        | _ -> None
+
 [<AutoOpen>]
 module SqlFunctions =
 

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -1,13 +1,27 @@
 ﻿namespace SqlHydra.Query
 
 [<AutoOpen>]
-module Table = 
+module Table =
 
     /// Maps the entity 'T to a table of the exact same name.
-    let table<'T> = 
+    let table<'T> =
         let ent = typeof<'T>
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
+
+    /// Creates a CTE source: `WITH alias AS (innerQuery) SELECT ... FROM alias`.
+    /// The inner query's row type matches the outer 'T.
+    let cte<'T> (alias: string) (innerQuery: SelectQuery<'T>) : QuerySource<'T> =
+        let tables = Map [Root, { Name = alias; Schema = "" }]
+        let ir = { SelectQueryIR.empty with WithCtes = [(alias, innerQuery.SelectIR)] }
+        QuerySource<'T, SelectQueryIR>(ir, tables) :> QuerySource<'T>
+
+    /// Creates a CTE source where the outer 'T may differ from the inner select's row type.
+    /// Use when the inner query uses raw SELECT fragments for computed columns.
+    let cteFrom<'T> (alias: string) (innerQuery: SelectQuery) : QuerySource<'T> =
+        let tables = Map [Root, { Name = alias; Schema = "" }]
+        let ir = { SelectQueryIR.empty with WithCtes = [(alias, innerQuery.SelectIR)] }
+        QuerySource<'T, SelectQueryIR>(ir, tables) :> QuerySource<'T>
 
 [<AutoOpen>]
 module Where = 
@@ -91,6 +105,42 @@ module Aggregates =
 
     /// Gets the AVG of the given column and returns 'Result.
     let avgByAs<'P, 'Result when 'P : struct and 'Result : struct> (prop: 'P) : 'Result = Unchecked.defaultof<'Result>
+
+    /// Gets the COUNT(DISTINCT col) of the given column.
+    let countDistinct (prop: 'P) = Unchecked.defaultof<int>
+
+[<AutoOpen>]
+module CastFunctions =
+    /// CAST(expression AS targetType).
+    /// The target SQL type is inferred from the F# return type:
+    /// float/double → FLOAT, int → INTEGER, int64 → BIGINT, decimal → NUMERIC, string → TEXT, bool → BOOLEAN.
+    let castAs<'Result> (_value: obj) : 'Result = Unchecked.defaultof<'Result>
+
+[<AutoOpen>]
+module CaseWhenFunctions =
+    /// CASE WHEN condition THEN thenValue ELSE elseValue END.
+    /// Note: values are rendered as SQL literals, not parameters.
+    /// Column references are properly qualified. Do not pass unsanitized user input.
+    let caseWhen<'T> (condition: bool) (thenValue: 'T) (elseValue: 'T) : 'T = Unchecked.defaultof<'T>
+
+    /// Multi-branch CASE WHEN expression.
+    /// CASE WHEN cond1 THEN val1 WHEN cond2 THEN val2 ... ELSE elseVal END.
+    let caseWhenMulti<'T> (branches: (bool * 'T) list) (elseValue: 'T) : 'T = Unchecked.defaultof<'T>
+
+[<AutoOpen>]
+module RawExpressions =
+    /// Reference a column from a lateral subquery by alias and column name (raw quoted).
+    /// Example: lateralCol "lat" "score" → "lat"."score"
+    let lateralCol<'T> (_alias: string) (_column: string) : 'T = Unchecked.defaultof<'T>
+
+    /// Inject a raw SQL expression into a select projection. Use sparingly.
+    let rawExpr<'T> (_sql: string) : 'T = Unchecked.defaultof<'T>
+
+    /// Wrap an external value so it's emitted as a SQL parameter inside a select expression
+    /// (rather than being treated as a column reference). Use for literals/captured variables
+    /// inside `caseWhen`, `castAs`, infix operator args, etc.
+    /// Example: caseWhen (col > 0) (inlineValue "yes") (inlineValue "no")
+    let inlineValue<'T> (_value: 'T) : 'T = Unchecked.defaultof<'T>
 
 [<AutoOpen>]
 module SqlFunctions =

--- a/src/SqlHydra.Query/QueryIR.fs
+++ b/src/SqlHydra.Query/QueryIR.fs
@@ -20,30 +20,46 @@ type LogicalOp =
 type JoinKind =
     | InnerJoin
     | LeftJoin
+    /// LEFT JOIN LATERAL (...) — for subquery-shaped joins (PostgreSQL).
+    | LeftJoinLateral
 
 /// ORDER BY direction.
 type OrderDirection =
     | Asc
     | Desc
 
+/// NULLS ordering for ORDER BY (PostgreSQL/Oracle semantics).
+type NullsOrdering =
+    | NullsDefault
+    | NullsFirst
+    | NullsLast
+
 /// An ORDER BY clause.
+[<NoComparison>]
 type OrderByClause =
     | OrderByColumn of column: string * direction: OrderDirection
-    | OrderByRaw of fragment: string
+    /// ORDER BY column with explicit NULLS FIRST/LAST.
+    | OrderByColumnNulls of column: string * direction: OrderDirection * nulls: NullsOrdering
+    /// ORDER BY raw fragment, optionally with `?` placeholders bound to `parameters` in order.
+    /// Pass `[||]` when there are no parameters.
+    | OrderByRaw of fragment: string * parameters: obj[]
 
 /// A SELECT column.
+[<NoComparison>]
 type SelectColumn =
     /// Select all columns from a table alias: alias.*
     | AllColumns of tableAlias: string
     /// Select a specific column: alias.column
     | SpecificColumn of qualifiedName: string
-    /// Raw SQL expression (e.g., COUNT(*), aggregate AS alias)
-    | RawColumn of fragment: string
+    /// Raw SQL expression, optionally with `?` placeholders bound to `parameters` in order.
+    /// Pass `[||]` when there are no parameters (e.g. `COUNT(*)`).
+    | RawColumn of fragment: string * parameters: obj[]
 
 // ─── Mutually recursive types ───
 // SqlValue, WhereClause, JoinClause, and SelectQueryIR reference each other.
 
 /// A SQL expression value (right-hand side of a comparison).
+[<NoComparison>]
 type SqlValue =
     /// A parameter value (may be a QueryParameter wrapping provider type info)
     | Parameter of value: obj
@@ -57,7 +73,7 @@ type SqlValue =
     | RawSql of fragment: string * parameters: obj[]
 
 /// A predicate in a WHERE, HAVING, or JOIN ON clause.
-and WhereClause =
+and [<NoComparison>] WhereClause =
     /// column op value (e.g., a.City = @p0)
     | Compare of column: string * op: ComparisonOp * value: SqlValue
     /// column op column (e.g., a.Id = b.Id)
@@ -78,6 +94,10 @@ and WhereClause =
     | Like of column: string * pattern: obj
     /// column NOT LIKE pattern
     | NotLike of column: string * pattern: obj
+    /// EXISTS (subquery)
+    | Exists of subquery: SelectQueryIR
+    /// NOT EXISTS (subquery)
+    | NotExists of subquery: SelectQueryIR
     /// NOT (clause)
     | Not of WhereClause
     /// left AND/OR right
@@ -92,16 +112,20 @@ and WhereClause =
     | Empty
 
 /// A JOIN clause.
-and JoinClause = {
+and [<NoComparison>] JoinClause = {
     Kind: JoinKind
-    /// Table spec string, e.g. "Sales.SalesOrderDetail AS d"
+    /// Table spec string, e.g. "Sales.SalesOrderDetail AS d", or the alias when Subquery is Some.
     Table: string
+    /// When Some, render `<JoinKind> [LATERAL] (subquery) AS <Table>` instead of using Table as the spec.
+    Subquery: SelectQueryIR option
     /// Join conditions
     Condition: WhereClause
 }
 
 /// The complete SELECT query IR.
-and SelectQueryIR = {
+and [<NoComparison>] SelectQueryIR = {
+    /// CTEs to render before SELECT: WITH alias AS (...).
+    WithCtes: (string * SelectQueryIR) list
     /// Table spec: "Schema.Table as alias" or "Schema.Table"
     From: string option
     /// Columns to select. Empty list = SELECT *
@@ -122,6 +146,8 @@ and SelectQueryIR = {
     Take: int option
     /// DISTINCT flag
     Distinct: bool
+    /// DISTINCT ON columns (PostgreSQL). Empty = not used. Mutually exclusive with plain Distinct in practice.
+    DistinctOn: string list
     /// SELECT COUNT(*) flag
     IsCount: bool
 }
@@ -148,6 +174,7 @@ module WhereClause =
 
 module SelectQueryIR =
     let empty = {
+        WithCtes = []
         From = None
         Select = []
         Where = Empty
@@ -158,16 +185,27 @@ module SelectQueryIR =
         Skip = None
         Take = None
         Distinct = false
+        DistinctOn = []
         IsCount = false
     }
 
 // ─── Insert-related types ───
 
+[<NoComparison>]
 type InsertType =
     | Insert
     | InsertOrReplace
     | OnConflictDoUpdate of conflictFields: string list * updateFields: string list
+    /// ON CONFLICT (cols) DO UPDATE SET — `updateFields` are updated as normal `col = EXCLUDED.col`,
+    /// except those listed in `coalesceFields` which become `col = COALESCE(EXCLUDED.col, col)`
+    /// (preserving existing non-null values when the new value is NULL).
+    /// `coalesceFields` should be a subset of `updateFields`.
+    | OnConflictDoUpdateCoalesce of conflictFields: string list * updateFields: string list * coalesceFields: string list
     | OnConflictDoNothing of conflictFields: string list
+    /// ON CONFLICT (cols) WHERE <whereExpr> DO NOTHING — partial-index conflict handling.
+    | OnConflictDoNothingWhereRaw of conflictFields: string list * whereFragment: string * parameters: obj[]
+    /// ON CONFLICT (<rawTargetExpr>) DO NOTHING — for expression indexes (e.g. lower(email)).
+    | OnConflictDoNothingRawTarget of rawTargetExpr: string
     | InsertOrUpdateOnUnique of keyFields: string list * updateFields: string list
 
 type Nullability =
@@ -175,6 +213,7 @@ type Nullability =
     | IsNullable
     | NotNullable
 
+[<NoComparison>]
 type OutputField =
     {
         ColumnName: string
@@ -183,27 +222,40 @@ type OutputField =
     }
 
 /// INSERT query IR.
+[<NoComparison>]
 type InsertQueryIR = {
     Table: string
     Columns: string list
     /// Each row is an array of parameter values (may include QueryParameter wrappers)
     Rows: obj[] list
+    /// When Some, INSERT INTO ... (cols) <select-subquery> instead of VALUES (...).
+    FromSelect: SelectQueryIR option
     IdentityField: string option
     InsertType: InsertType
     OutputFields: OutputField list
+    /// PostgreSQL/SQLite RETURNING column list. Empty = no RETURNING.
+    Returning: string list
 }
 
 /// UPDATE query IR.
+[<NoComparison>]
 type UpdateQueryIR = {
     Table: string
     /// Column name * parameter value pairs
     SetColumns: (string * obj) list
+    /// Raw SET clauses: (column, fragment, parameters). Rendered after SetColumns.
+    SetRaws: (string * string * obj[]) list
     Where: WhereClause
     OutputFields: OutputField list
+    /// PostgreSQL RETURNING column list. Empty = no RETURNING.
+    Returning: string list
 }
 
 /// DELETE query IR.
+[<NoComparison>]
 type DeleteQueryIR = {
     Table: string
     Where: WhereClause
+    /// PostgreSQL RETURNING column list. Empty = no RETURNING.
+    Returning: string list
 }

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -8,6 +8,18 @@ open System.Data.Common
 open System.Threading
 open System.Threading.Tasks
 
+/// Helpers for extension packages that add custom CE operations.
+[<AutoOpen>]
+module ExtensionHelpers =
+    /// Resolves an orderBy-style [<ProjectionParameter>] property selector to its
+    /// (tableAlias, columnName) when it is a simple column reference.
+    /// Returns None for expressions or aggregates. For extension packages adding
+    /// custom ORDER BY operations (e.g. vector distance ordering).
+    let tryGetOrderByColumn<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) : (string * string) option =
+        match LinqExpressionVisitors.visitOrderByPropertySelector<'T, 'Prop> propertySelector with
+        | LinqExpressionVisitors.OrderByColumn(tableAlias, m) -> Some(tableAlias, m.Name)
+        | _ -> None
+
 /// The context type that determines how the query context is created and disposed.
 /// Can be implicitly converted from a QueryContext, a function that creates a QueryContext, a Task that creates a QueryContext, or an Async that creates a QueryContext.
 [<NoComparison; NoEquality>]

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -10,6 +10,7 @@ open System.Threading.Tasks
 
 /// The context type that determines how the query context is created and disposed.
 /// Can be implicitly converted from a QueryContext, a function that creates a QueryContext, a Task that creates a QueryContext, or an Async that creates a QueryContext.
+[<NoComparison; NoEquality>]
 type ContextType =
     /// A new QueryContext will be created and disposed within the select builder.
     | Create of create: (unit -> QueryContext)
@@ -109,6 +110,19 @@ type SelectBuilder<'Selected, 'Mapped> () =
     let qualifyColumnWithAlias (alias: string) (col: Reflection.MemberInfo) =
         $"%s{alias}.%s{col.Name}"
 
+    /// Combines outer + inner CTEs, deduplicating by alias (last write wins). Used when
+    /// a `cteFrom` source is the inner side of a `leftJoin'`/`join'` — the inner's
+    /// WithCtes must propagate, but the same source could be used in multiple joins.
+    let mergeCtes (outerIr: SelectQueryIR) (inner: QuerySource<'T>) =
+        let innerIr = inner |> getQueryOrDefault
+        if innerIr.WithCtes.IsEmpty then outerIr
+        else
+            let seen = System.Collections.Generic.HashSet<string>()
+            let merged =
+                outerIr.WithCtes @ innerIr.WithCtes
+                |> List.filter (fun (alias, _) -> seen.Add alias)
+            { outerIr with WithCtes = merged }
+
     member val MapFn = Option<Func<'Selected, 'Mapped>>.None with get, set
     member val CancellationToken = CancellationToken.None with get, set
     member val private PendingJoinInfo = Option<PendingJoin>.None with get, set
@@ -120,7 +134,8 @@ type SelectBuilder<'Selected, 'Mapped> () =
 
         match tblMaybe with
         | Some tbl ->
-            QuerySource<'T, SelectQueryIR>({ ir with From = Some $"{tbl.Schema}.{tbl.Name} as {tableAlias}" }, tableMappings)
+            let fromSpec = $"{FQ.qualifiedTable tbl} as {tableAlias}"
+            QuerySource<'T, SelectQueryIR>({ ir with From = Some fromSpec }, tableMappings)
         | None ->
             // Handles this scenario: `select (p.FirstName, p.LastName) into (fname, lname)`
             state :?> QuerySource<'T, SelectQueryIR>
@@ -140,6 +155,32 @@ type SelectBuilder<'Selected, 'Mapped> () =
         let newClause = LinqExpressionVisitors.visitWhere<'T> tableMappings whereExpression qualifyColumnWithAlias
         QuerySource<'T, SelectQueryIR>({ ir with Where = WhereClause.combineAnd ir.Where newClause }, state.TableMappings)
 
+    /// WHERE EXISTS (subquery)
+    [<CustomOperation("whereExists", MaintainsVariableSpace = true)>]
+    member this.WhereExists (state: QuerySource<'T, SelectQueryIR>, subquery: SelectQuery) =
+        let ir = state.Query
+        let newClause = WhereClause.Exists subquery.SelectIR
+        QuerySource<'T, SelectQueryIR>({ ir with Where = WhereClause.combineAnd ir.Where newClause }, state.TableMappings)
+
+    /// WHERE NOT EXISTS (subquery)
+    [<CustomOperation("whereNotExists", MaintainsVariableSpace = true)>]
+    member this.WhereNotExists (state: QuerySource<'T, SelectQueryIR>, subquery: SelectQuery) =
+        let ir = state.Query
+        let newClause = WhereClause.NotExists subquery.SelectIR
+        QuerySource<'T, SelectQueryIR>({ ir with Where = WhereClause.combineAnd ir.Where newClause }, state.TableMappings)
+
+    /// HAVING with raw SQL fragment. Use ? for parameter placeholders.
+    [<CustomOperation("havingRaw", MaintainsVariableSpace = true)>]
+    member this.HavingRaw (state: QuerySource<'T, SelectQueryIR>, fragment: string) =
+        let ir = state.Query
+        QuerySource<'T, SelectQueryIR>({ ir with Having = WhereClause.combineAnd ir.Having (RawWhere(fragment, [||])) }, state.TableMappings)
+
+    /// HAVING with raw SQL fragment + parameters. Use ? as placeholders.
+    [<CustomOperation("havingRaw", MaintainsVariableSpace = true)>]
+    member this.HavingRaw (state: QuerySource<'T, SelectQueryIR>, fragment: string, parameters: obj[]) =
+        let ir = state.Query
+        QuerySource<'T, SelectQueryIR>({ ir with Having = WhereClause.combineAnd ir.Having (RawWhere(fragment, parameters)) }, state.TableMappings)
+
     /// Sets the SELECT statement and filters the query to include only the selected tables
     [<CustomOperation("select", MaintainsVariableSpace = true, AllowIntoPattern = true)>]
     member this.Select (state: QuerySource<'T, SelectQueryIR>, [<ProjectionParameter>] selectExpression: Expression<Func<'T, 'Selected>>) =
@@ -158,7 +199,17 @@ type SelectBuilder<'Selected, 'Mapped> () =
                     // Select a single column
                     { ir with Select = ir.Select @ [SpecificColumn $"%s{tableAlias}.%s{column}"] }
                 | LinqExpressionVisitors.SelectedExpression sqlFragment ->
-                    { ir with Select = ir.Select @ [RawColumn sqlFragment] }
+                    { ir with Select = ir.Select @ [RawColumn (sqlFragment, [||])] }
+                | LinqExpressionVisitors.SelectedExpressionWithParams (sqlFragment, parms) ->
+                    { ir with Select = ir.Select @ [RawColumn (sqlFragment, parms)] }
+                | LinqExpressionVisitors.SelectedAs (LinqExpressionVisitors.SelectedColumn (tableAlias, column, _, _, _), alias) ->
+                    { ir with Select = ir.Select @ [RawColumn ($"\"%s{tableAlias}\".\"%s{column}\" AS \"%s{alias}\"", [||])] }
+                | LinqExpressionVisitors.SelectedAs (LinqExpressionVisitors.SelectedExpression frag, alias) ->
+                    { ir with Select = ir.Select @ [RawColumn ($"%s{frag} AS \"%s{alias}\"", [||])] }
+                | LinqExpressionVisitors.SelectedAs (LinqExpressionVisitors.SelectedExpressionWithParams (frag, parms), alias) ->
+                    { ir with Select = ir.Select @ [RawColumn ($"%s{frag} AS \"%s{alias}\"", parms)] }
+                | LinqExpressionVisitors.SelectedAs _ ->
+                    failwith "SelectedAs may only wrap SelectedColumn / SelectedExpression / SelectedExpressionWithParams"
             ) state.Query
 
         QuerySource<'Selected, SelectQueryIR>(irWithSelectedColumns, state.TableMappings)
@@ -175,7 +226,9 @@ type SelectBuilder<'Selected, 'Mapped> () =
                     [OrderByColumn (fqCol, Asc)]
                 | LinqExpressionVisitors.OrderByAggregateColumn (aggType, tableAlias, p) ->
                     let fqCol = $"{{%s{tableAlias}}}.{{%s{p.Name}}}"
-                    [OrderByRaw $"%s{aggType}(%s{fqCol})"]
+                    [OrderByRaw (LinqExpressionVisitors.renderAggregate aggType fqCol, [||])]
+                | LinqExpressionVisitors.OrderByExpression (frag, parms) ->
+                    [OrderByRaw (frag, parms)]
                 | LinqExpressionVisitors.OrderByIgnored ->
                     []
         QuerySource<'T, SelectQueryIR>({ ir with OrderBy = ir.OrderBy @ newOrderBy }, state.TableMappings)
@@ -197,7 +250,9 @@ type SelectBuilder<'Selected, 'Mapped> () =
                     [OrderByColumn (fqCol, Desc)]
                 | LinqExpressionVisitors.OrderByAggregateColumn (aggType, tableAlias, p) ->
                     let fqCol = $"{{%s{tableAlias}}}.{{%s{p.Name}}}"
-                    [OrderByRaw $"%s{aggType}(%s{fqCol}) DESC"]
+                    [OrderByRaw ($"{LinqExpressionVisitors.renderAggregate aggType fqCol} DESC", [||])]
+                | LinqExpressionVisitors.OrderByExpression (frag, parms) ->
+                    [OrderByRaw ($"{frag} DESC", parms)]
                 | LinqExpressionVisitors.OrderByIgnored ->
                     []
         QuerySource<'T, SelectQueryIR>({ ir with OrderBy = ir.OrderBy @ newOrderBy }, state.TableMappings)
@@ -206,6 +261,50 @@ type SelectBuilder<'Selected, 'Mapped> () =
     [<CustomOperation("thenByDescending", MaintainsVariableSpace = true)>]
     member this.ThenByDescending (state: QuerySource<'T, SelectQueryIR>, [<ProjectionParameter>] propertySelector) =
         this.OrderByDescending(state, propertySelector)
+
+    /// ORDER BY a raw SQL fragment (e.g. an aggregate or computed expression).
+    [<CustomOperation("orderByRaw", MaintainsVariableSpace = true)>]
+    member this.OrderByRaw (state: QuerySource<'T, SelectQueryIR>, fragment: string) =
+        let ir = state.Query
+        QuerySource<'T, SelectQueryIR>({ ir with OrderBy = ir.OrderBy @ [OrderByRaw (fragment, [||])] }, state.TableMappings)
+
+    /// ORDER BY a column alias (raw, quoted). Use for computed/aliased columns produced in select.
+    [<CustomOperation("orderByAlias", MaintainsVariableSpace = true)>]
+    member this.OrderByAlias (state: QuerySource<'T, SelectQueryIR>, alias: string) =
+        let ir = state.Query
+        QuerySource<'T, SelectQueryIR>({ ir with OrderBy = ir.OrderBy @ [OrderByRaw ($"\"{alias}\"", [||])] }, state.TableMappings)
+
+    /// ORDER BY a column alias DESC (raw, quoted).
+    [<CustomOperation("orderByAliasDesc", MaintainsVariableSpace = true)>]
+    member this.OrderByAliasDesc (state: QuerySource<'T, SelectQueryIR>, alias: string) =
+        let ir = state.Query
+        QuerySource<'T, SelectQueryIR>({ ir with OrderBy = ir.OrderBy @ [OrderByRaw ($"\"{alias}\" DESC", [||])] }, state.TableMappings)
+
+    /// Applies a NULLS ordering to the most recent ORDER BY clause.
+    member private this.ApplyNulls (state: QuerySource<'T, SelectQueryIR>, nulls: NullsOrdering, rawLiteral: string) =
+        let ir = state.Query
+        let newOrderBy =
+            match List.tryLast ir.OrderBy with
+            | Some last ->
+                let init = ir.OrderBy.[0..ir.OrderBy.Length - 2]
+                let updated =
+                    match last with
+                    | OrderByColumn (col, dir) -> OrderByColumnNulls (col, dir, nulls)
+                    | OrderByColumnNulls (col, dir, _) -> OrderByColumnNulls (col, dir, nulls)
+                    | OrderByRaw (frag, parms) -> OrderByRaw ($"{frag} {rawLiteral}", parms)
+                init @ [updated]
+            | None -> ir.OrderBy
+        QuerySource<'T, SelectQueryIR>({ ir with OrderBy = newOrderBy }, state.TableMappings)
+
+    /// Adds NULLS LAST to the most recent ORDER BY clause.
+    [<CustomOperation("nullsLast", MaintainsVariableSpace = true)>]
+    member this.NullsLast (state: QuerySource<'T, SelectQueryIR>) =
+        this.ApplyNulls(state, NullsLast, "NULLS LAST")
+
+    /// Adds NULLS FIRST to the most recent ORDER BY clause.
+    [<CustomOperation("nullsFirst", MaintainsVariableSpace = true)>]
+    member this.NullsFirst (state: QuerySource<'T, SelectQueryIR>) =
+        this.ApplyNulls(state, NullsFirst, "NULLS FIRST")
 
     /// Sets the SKIP value for query
     [<CustomOperation("skip", MaintainsVariableSpace = true)>]
@@ -251,7 +350,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
         let innerTableNameAsAlias =
             innerProperties
             |> Seq.map (fun p -> p, mergedTables[TableAliasKey p.Alias])
-            |> Seq.map (fun (p, tbl) -> $"%s{tbl.Schema}.%s{tbl.Name} AS %s{p.Alias}")
+            |> Seq.map (fun (p, tbl) -> $"%s{FQ.qualifiedTable tbl} AS %s{p.Alias}")
             |> Seq.head
 
         let joinCondition =
@@ -261,7 +360,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
                 WhereClause.combineAndFlat acc cond
             ) WhereClause.Empty
 
-        let joinClause = { Kind = InnerJoin; Table = innerTableNameAsAlias; Condition = joinCondition }
+        let joinClause = { Kind = InnerJoin; Table = innerTableNameAsAlias; Subquery = None; Condition = joinCondition }
         QuerySource<'JoinResult, SelectQueryIR>({ ir with Joins = ir.Joins @ [joinClause] }, mergedTables)
 
     /// LEFT JOIN table on one or more columns
@@ -298,7 +397,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
         let innerTableNameAsAlias =
             innerProperties
             |> Seq.map (fun p -> p, mergedTables[TableAliasKey p.Alias])
-            |> Seq.map (fun (p, tbl) -> $"%s{tbl.Schema}.%s{tbl.Name} AS %s{p.Alias}")
+            |> Seq.map (fun (p, tbl) -> $"%s{FQ.qualifiedTable tbl} AS %s{p.Alias}")
             |> Seq.head
 
         let joinCondition =
@@ -308,7 +407,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
                 WhereClause.combineAndFlat acc cond
             ) WhereClause.Empty
 
-        let joinClause = { Kind = LeftJoin; Table = innerTableNameAsAlias; Condition = joinCondition }
+        let joinClause = { Kind = LeftJoin; Table = innerTableNameAsAlias; Subquery = None; Condition = joinCondition }
         QuerySource<'JoinResult, SelectQueryIR>({ ir with Joins = ir.Joins @ [joinClause] }, mergedTables)
 
     /// References a table variable from a correlated parent query from within a subquery.
@@ -351,7 +450,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
 
         // Get inner table info
         let innerTable = mergedTables[TableAliasKey innerAlias]
-        let tableName = $"{innerTable.Schema}.{innerTable.Name}"
+        let tableName = FQ.qualifiedTable innerTable
 
         let pendingJoin = {
             JoinType = JoinType.Inner
@@ -359,7 +458,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
             TableAlias = innerAlias
         }
 
-        let ir = outerSource |> getQueryOrDefault
+        let ir = mergeCtes (outerSource |> getQueryOrDefault) innerSource
         this.PendingJoinInfo <- Some pendingJoin
         QuerySource<'JoinResult, SelectQueryIR>(ir, mergedTables)
 
@@ -382,7 +481,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
 
         // Get inner table info
         let innerTable = mergedTables[TableAliasKey innerAlias]
-        let tableName = $"{innerTable.Schema}.{innerTable.Name}"
+        let tableName = FQ.qualifiedTable innerTable
 
         let pendingJoin = {
             JoinType = JoinType.Left
@@ -390,7 +489,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
             TableAlias = innerAlias
         }
 
-        let ir = outerSource |> getQueryOrDefault
+        let ir = mergeCtes (outerSource |> getQueryOrDefault) innerSource
         this.PendingJoinInfo <- Some pendingJoin
         QuerySource<'JoinResult, SelectQueryIR>(ir, mergedTables)
 
@@ -420,7 +519,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
             | JoinType.Inner -> InnerJoin
             | JoinType.Left -> LeftJoin
 
-        let joinClause = { Kind = joinKind; Table = tableNameAsAlias; Condition = joinCondition }
+        let joinClause = { Kind = joinKind; Table = tableNameAsAlias; Subquery = None; Condition = joinCondition }
 
         QuerySource<'T, SelectQueryIR>({ ir with Joins = ir.Joins @ [joinClause] }, state.TableMappings)
 
@@ -731,6 +830,11 @@ type SelectAsyncBuilder<'Selected, 'Mapped> (ct: ContextType) =
 
 /// Builds and returns a select query that can be manually run by piping into QueryContext read methods
 let select<'Selected, 'Mapped> =
+    SelectQueryBuilder<'Selected, 'Mapped>()
+
+/// Alias for `select` — use inside `whereExists`/`whereNotExists` (or other contexts that
+/// already use `select` as a custom op) to disambiguate.
+let subquery<'Selected, 'Mapped> =
     SelectQueryBuilder<'Selected, 'Mapped>()
 
 /// Builds a select query with a context source - returns an Async query result

--- a/src/SqlHydra.Query/SqlEmitter.fs
+++ b/src/SqlHydra.Query/SqlEmitter.fs
@@ -3,6 +3,7 @@ namespace SqlHydra.Query
 open SqlHydra.Domain
 
 /// Result of compiling a query IR to SQL.
+[<NoComparison>]
 type CompiledQuery = {
     Sql: string
     /// Parameter name * value pairs (values may be QueryParameter wrappers)

--- a/src/SqlHydra.Query/SqlEmitterBase.fs
+++ b/src/SqlHydra.Query/SqlEmitterBase.fs
@@ -39,7 +39,9 @@ type SqlEmitterBase() =
     abstract EmitMultiRowInsert: table: string * columns: string list * rows: obj[] list * collector: ParameterCollector -> string
 
     /// Emit upsert/conflict handling clauses. Default: no-op.
-    abstract EmitInsertConflict: insertType: InsertType * insertSql: string * columns: string list * rows: obj[] list * collector: ParameterCollector -> string
+    /// `table` is the dotted INSERT target (e.g. "public.waitlist_entries") so DO UPDATE
+    /// branches can disambiguate `EXCLUDED.col` vs the target table's `col` reference.
+    abstract EmitInsertConflict: insertType: InsertType * table: string * insertSql: string * columns: string list * rows: obj[] list * collector: ParameterCollector -> string
 
     /// Emit OUTPUT clause for INSERT (SQL Server). Default: empty.
     abstract EmitInsertOutput: outputFields: OutputField list * insertSql: string -> string
@@ -54,6 +56,76 @@ type SqlEmitterBase() =
 
     /// Creates a new ParameterCollector with this emitter's prefix.
     member this.CreateCollector() = ParameterCollector(this.ParameterPrefix)
+
+    /// Replaces `?` placeholders in `fragment` with parameter names from `collector`, in order.
+    /// Each `?` consumes one entry from `parms` (silently ignored if there are more parms than `?`s).
+    member _.SubstituteParams(fragment: string, parms: obj[], collector: ParameterCollector) =
+        let mutable result = fragment
+        for p in parms do
+            let name = collector.Add(p)
+            let idx = result.IndexOf("?")
+            if idx >= 0 then
+                result <- result.Substring(0, idx) + name + result.Substring(idx + 1)
+        result
+
+    /// Splits an INSERT command into the insert-statement and an optional trailing identity-statement
+    /// produced by EmitInsertIdentity. Used by EmitInsertConflict to weave conflict clauses between them.
+    member _.SplitInsertAndIdentity(sql: string) =
+        match sql.Split([| ";" |], StringSplitOptions.RemoveEmptyEntries) with
+        | [| iq; idq |] -> iq, idq
+        | _ -> sql, ""
+
+    /// Bare table name (last dotted segment) for disambiguating `EXCLUDED.col` vs target-table `col`.
+    member _.BareTableName(table: string) =
+        let parts = table.Split('.')
+        parts.[parts.Length - 1]
+
+    /// Renders an `ON CONFLICT (...) DO UPDATE SET col=EXCLUDED."col"` upsert.
+    member this.BuildOnConflictUpdate(insertSql: string, conflictFields: string list, updateFields: string list) =
+        let insertQuery, identityQuery = this.SplitInsertAndIdentity(insertSql)
+        let setLines =
+            updateFields
+            |> List.map (fun col -> $"{col}=EXCLUDED.\"{col}\"\n")
+            |> fun lines -> String.Join(",", lines)
+        let conflictCsv = String.Join(",", conflictFields)
+        StringBuilder()
+            .AppendLine(insertQuery)
+            .AppendLine($"ON CONFLICT({conflictCsv}) DO UPDATE SET")
+            .AppendLine(setLines).Append(";")
+            .AppendLine(identityQuery)
+            .ToString()
+
+    /// Renders an `ON CONFLICT (...) DO UPDATE SET` upsert where `coalesceFields`
+    /// become `col = COALESCE(EXCLUDED."col", "<table>"."col")`.
+    member this.BuildOnConflictUpdateCoalesce(insertSql: string, table: string, conflictFields: string list, updateFields: string list, coalesceFields: string list) =
+        let bareTable = this.BareTableName(table)
+        let insertQuery, identityQuery = this.SplitInsertAndIdentity(insertSql)
+        let coalesceSet = Set.ofList coalesceFields
+        let setLines =
+            updateFields
+            |> List.map (fun col ->
+                if coalesceSet.Contains col
+                then $"\"{col}\" = COALESCE(EXCLUDED.\"{col}\", \"{bareTable}\".\"{col}\")\n"
+                else $"\"{col}\" = EXCLUDED.\"{col}\"\n")
+            |> fun lines -> String.Join(",", lines)
+        let conflictCsv = String.Join(",", conflictFields)
+        StringBuilder()
+            .AppendLine(insertQuery)
+            .AppendLine($"ON CONFLICT({conflictCsv}) DO UPDATE SET")
+            .AppendLine(setLines).Append(";")
+            .AppendLine(identityQuery)
+            .ToString()
+
+    /// Renders an `ON CONFLICT (...) DO NOTHING` upsert.
+    member this.BuildOnConflictDoNothing(insertSql: string, conflictFields: string list) =
+        let insertQuery, identityQuery = this.SplitInsertAndIdentity(insertSql)
+        let conflictCsv = String.Join(",", conflictFields)
+        StringBuilder()
+            .AppendLine(insertQuery)
+            .AppendLine($"ON CONFLICT({conflictCsv})")
+            .AppendLine("DO NOTHING;")
+            .AppendLine(identityQuery)
+            .ToString()
 
     /// Quotes a dotted identifier like "Schema.Table" to "[Schema].[Table]".
     member this.QuoteDotted(ident: string) =
@@ -99,13 +171,7 @@ type SqlEmitterBase() =
                 collector.Add(v) |> ignore
             $"({compiled.Sql})"
         | RawSql (fragment, parms) ->
-            let mutable result = fragment
-            for p in parms do
-                let name = collector.Add(p)
-                let idx = result.IndexOf("?")
-                if idx >= 0 then
-                    result <- result.Substring(0, idx) + name + result.Substring(idx + 1)
-            result
+            this.SubstituteParams(fragment, parms, collector)
 
     /// Emits a comparison operator.
     member _.EmitOp(op: ComparisonOp) =
@@ -153,6 +219,16 @@ type SqlEmitterBase() =
             for (_, v) in compiled.Parameters do
                 collector.Add(v) |> ignore
             $"{this.QuoteColumn(col)} NOT IN ({compiled.Sql})"
+        | Exists subquery ->
+            let compiled = this.EmitSelectCore(subquery)
+            for (_, v) in compiled.Parameters do
+                collector.Add(v) |> ignore
+            $"EXISTS ({compiled.Sql})"
+        | NotExists subquery ->
+            let compiled = this.EmitSelectCore(subquery)
+            for (_, v) in compiled.Parameters do
+                collector.Add(v) |> ignore
+            $"NOT EXISTS ({compiled.Sql})"
         | Like (col, pattern) ->
             let quotedCol = this.QuoteColumn(col)
             let paramName = collector.Add(pattern)
@@ -172,13 +248,7 @@ type SqlEmitterBase() =
         | Grouped inner ->
             this.EmitWhere(inner, collector) // wrap in parens
         | RawWhere (fragment, parms) ->
-            let mutable result = fragment
-            for p in parms do
-                let name = collector.Add(p)
-                let idx = result.IndexOf("?")
-                if idx >= 0 then
-                    result <- result.Substring(0, idx) + name + result.Substring(idx + 1)
-            result
+            this.SubstituteParams(fragment, parms, collector)
         | BoolColumn (col, value) ->
             let quotedCol = this.QuoteColumn(col)
             this.EmitBoolColumn(quotedCol, value, collector)
@@ -193,9 +263,27 @@ type SqlEmitterBase() =
         let collector = this.CreateCollector()
         let sb = StringBuilder()
 
+        // WITH (CTEs)
+        if ir.WithCtes.Length > 0 then
+            sb.Append("WITH ") |> ignore
+            ir.WithCtes
+            |> List.mapi (fun i (alias, cteIR) ->
+                let cteCompiled = this.EmitSelectCore(cteIR)
+                for (_, v) in cteCompiled.Parameters do
+                    collector.Add(v) |> ignore
+                $"{this.QuoteIdentifier(alias)} AS ({cteCompiled.Sql})"
+            )
+            |> String.concat ", "
+            |> sb.Append |> ignore
+            sb.Append(" ") |> ignore
+
         // SELECT
         sb.Append("SELECT ") |> ignore
-        if ir.Distinct then sb.Append("DISTINCT ") |> ignore
+        if ir.DistinctOn.Length > 0 then
+            let cols = ir.DistinctOn |> List.map this.QuoteColumn |> String.concat ", "
+            sb.Append($"DISTINCT ON ({cols}) ") |> ignore
+        elif ir.Distinct then
+            sb.Append("DISTINCT ") |> ignore
 
         if ir.IsCount then
             sb.Append("COUNT(*) AS ") |> ignore
@@ -210,7 +298,8 @@ type SqlEmitterBase() =
                     match col with
                     | AllColumns alias -> $"{this.QuoteIdentifier(alias)}.*"
                     | SpecificColumn name -> this.QuoteColumn(name)
-                    | RawColumn fragment -> this.QuoteRawFragment(fragment)
+                    | RawColumn (fragment, parms) ->
+                        this.SubstituteParams(this.QuoteRawFragment(fragment), parms, collector)
                 )
                 |> String.concat ", "
                 |> sb.Append |> ignore
@@ -228,7 +317,17 @@ type SqlEmitterBase() =
                 match join.Kind with
                 | InnerJoin -> "INNER JOIN"
                 | LeftJoin -> "LEFT JOIN"
-            sb.Append($" {joinKeyword} {this.QuoteTableSpec(join.Table)} ON ") |> ignore
+                | LeftJoinLateral -> "LEFT JOIN LATERAL"
+            let tableSpec =
+                match join.Subquery with
+                | Some subIR ->
+                    let compiled = this.EmitSelectCore(subIR)
+                    for (_, v) in compiled.Parameters do
+                        collector.Add(v) |> ignore
+                    $"({compiled.Sql}) AS {this.QuoteIdentifier(join.Table)}"
+                | None ->
+                    this.QuoteTableSpec(join.Table)
+            sb.Append($" {joinKeyword} {tableSpec} ON ") |> ignore
             let condSql = this.EmitWhere(join.Condition, collector)
             sb.Append(condSql) |> ignore
 
@@ -249,13 +348,21 @@ type SqlEmitterBase() =
 
         // ORDER BY
         if ir.OrderBy.Length > 0 then
+            let nullsSuffix nulls =
+                match nulls with
+                | NullsDefault -> ""
+                | NullsFirst -> " NULLS FIRST"
+                | NullsLast -> " NULLS LAST"
             let orderCols =
                 ir.OrderBy
                 |> List.map (fun ob ->
                     match ob with
                     | OrderByColumn (col, Asc) -> this.QuoteColumn(col)
                     | OrderByColumn (col, Desc) -> $"{this.QuoteColumn(col)} DESC"
-                    | OrderByRaw fragment -> this.QuoteRawFragment(fragment)
+                    | OrderByColumnNulls (col, Asc, nulls) -> $"{this.QuoteColumn(col)}{nullsSuffix nulls}"
+                    | OrderByColumnNulls (col, Desc, nulls) -> $"{this.QuoteColumn(col)} DESC{nullsSuffix nulls}"
+                    | OrderByRaw (fragment, parms) ->
+                        this.SubstituteParams(this.QuoteRawFragment(fragment), parms, collector)
                 )
                 |> String.concat ", "
             sb.Append($" ORDER BY {orderCols}") |> ignore
@@ -277,13 +384,22 @@ type SqlEmitterBase() =
         let collector = this.CreateCollector()
 
         let baseSql =
-            match ir.Rows with
-            | [] -> failwith "At least one row must be provided for INSERT."
-            | [ row ] -> this.EmitSingleInsert(ir.Table, ir.Columns, row, collector)
-            | rows -> this.EmitMultiRowInsert(ir.Table, ir.Columns, rows, collector)
+            match ir.FromSelect with
+            | Some selectIR ->
+                let quotedTable = this.QuoteDotted(ir.Table)
+                let quotedCols = ir.Columns |> List.map this.QuoteIdentifier |> String.concat ", "
+                let compiled = this.EmitSelectCore(selectIR)
+                for (_, v) in compiled.Parameters do
+                    collector.Add(v) |> ignore
+                $"INSERT INTO {quotedTable} ({quotedCols}) {compiled.Sql}"
+            | None ->
+                match ir.Rows with
+                | [] -> failwith "At least one row must be provided for INSERT."
+                | [ row ] -> this.EmitSingleInsert(ir.Table, ir.Columns, row, collector)
+                | rows -> this.EmitMultiRowInsert(ir.Table, ir.Columns, rows, collector)
 
         // Apply conflict handling
-        let withConflict = this.EmitInsertConflict(ir.InsertType, baseSql, ir.Columns, ir.Rows, collector)
+        let withConflict = this.EmitInsertConflict(ir.InsertType, ir.Table, baseSql, ir.Columns, ir.Rows, collector)
 
         // Apply output clause
         let withOutput =
@@ -292,7 +408,10 @@ type SqlEmitterBase() =
             else
                 withConflict
 
-        { Sql = withOutput; Parameters = collector.Parameters }
+        // Apply RETURNING (provider hook)
+        let withReturning = this.EmitReturning(ir.Returning, withOutput)
+
+        { Sql = withReturning; Parameters = collector.Parameters }
 
     /// Emits an UPDATE query.
     member this.EmitUpdateCore(ir: UpdateQueryIR) : CompiledQuery =
@@ -308,8 +427,15 @@ type SqlEmitterBase() =
                 let paramName = collector.Add(value)
                 $"{this.QuoteIdentifier(col)} = {paramName}"
             )
-            |> String.concat ", "
-        sb.Append(setClauses) |> ignore
+
+        let rawSetClauses =
+            ir.SetRaws
+            |> List.map (fun (col, fragment, parms) ->
+                let rendered = this.SubstituteParams(this.QuoteRawFragment(fragment), parms, collector)
+                $"{this.QuoteIdentifier(col)} = {rendered}"
+            )
+
+        sb.Append(setClauses @ rawSetClauses |> String.concat ", ") |> ignore
 
         // WHERE
         let whereSql = this.EmitWhere(ir.Where, collector)
@@ -325,7 +451,10 @@ type SqlEmitterBase() =
             else
                 baseSql
 
-        { Sql = withOutput; Parameters = collector.Parameters }
+        // Apply RETURNING
+        let withReturning = this.EmitReturning(ir.Returning, withOutput)
+
+        { Sql = withReturning; Parameters = collector.Parameters }
 
     /// Emits a DELETE query.
     member this.EmitDeleteCore(ir: DeleteQueryIR) : CompiledQuery =
@@ -339,7 +468,10 @@ type SqlEmitterBase() =
         if whereSql <> "" then
             sb.Append($" WHERE {whereSql}") |> ignore
 
-        { Sql = sb.ToString(); Parameters = collector.Parameters }
+        let baseSql = sb.ToString()
+        let withReturning = this.EmitReturning(ir.Returning, baseSql)
+
+        { Sql = withReturning; Parameters = collector.Parameters }
 
     // Default implementations for abstract members
 
@@ -360,7 +492,24 @@ type SqlEmitterBase() =
     default _.EmitInsertIdentity(_) = ""
 
     /// Default: no conflict handling.
-    default _.EmitInsertConflict(_, insertSql, _, _, _) = insertSql
+    default _.EmitInsertConflict(_, _, insertSql, _, _, _) = insertSql
+
+    /// Append a RETURNING clause to a SQL command. Default: no-op (overridden by Postgres + Sqlite).
+    abstract EmitReturning: returning: string list * sql: string -> string
+    default _.EmitReturning(_, sql) = sql
+
+    /// Shared implementation for `EmitReturning` on dialects that support standard RETURNING (Postgres, Sqlite).
+    /// Inserts the clause before any trailing `;` produced by the identity-returning suffix.
+    member this.AppendReturning(returning: string list, sql: string) =
+        if returning.IsEmpty then sql
+        else
+            let cols = returning |> List.map this.QuoteIdentifier |> String.concat ", "
+            let trimmed = sql.TrimEnd()
+            if trimmed.EndsWith(";") then
+                let body = trimmed.Substring(0, trimmed.Length - 1)
+                $"{body} RETURNING {cols};"
+            else
+                $"{sql} RETURNING {cols}"
 
     /// Default: no output clause.
     default _.EmitInsertOutput(_, insertSql) = insertSql

--- a/src/SqlHydra.Query/SqlEmitters.fs
+++ b/src/SqlHydra.Query/SqlEmitters.fs
@@ -99,38 +99,35 @@ type PostgresEmitter() =
     override _.EmitLike(quotedCol, paramName) = $"{quotedCol} ilike {paramName}"
     override _.EmitNotLike(quotedCol, paramName) = $"NOT ({quotedCol} ilike {paramName})"
 
-    override this.EmitInsertConflict(insertType, insertSql, columns, _rows, _collector) =
+    override this.EmitReturning(returning, sql) = this.AppendReturning(returning, sql)
+
+    override this.EmitInsertConflict(insertType, table, insertSql, columns, _rows, collector) =
         match insertType with
         | OnConflictDoUpdate (conflictFields, updateFields) ->
-            let insertQuery, identityQuery =
-                match insertSql.Split([| ";" |], StringSplitOptions.RemoveEmptyEntries) with
-                | [| iq; idq |] -> iq, idq
-                | _ -> insertSql, ""
+            this.BuildOnConflictUpdate(insertSql, conflictFields, updateFields)
 
-            let setLines =
-                updateFields
-                |> List.map (fun col -> $"{col}=EXCLUDED.\"{col}\"\n")
-                |> fun lines -> String.Join(",", lines)
+        | OnConflictDoUpdateCoalesce (conflictFields, updateFields, coalesceFields) ->
+            this.BuildOnConflictUpdateCoalesce(insertSql, table, conflictFields, updateFields, coalesceFields)
+
+        | OnConflictDoNothing conflictFields ->
+            this.BuildOnConflictDoNothing(insertSql, conflictFields)
+
+        | OnConflictDoNothingWhereRaw (conflictFields, whereFragment, parms) ->
+            let insertQuery, identityQuery = this.SplitInsertAndIdentity(insertSql)
             let conflictCsv = String.Join(",", conflictFields)
-
+            let rendered = this.SubstituteParams(whereFragment, parms, collector)
             StringBuilder()
                 .AppendLine(insertQuery)
-                .AppendLine($"ON CONFLICT({conflictCsv}) DO UPDATE SET")
-                .AppendLine(setLines).Append(";")
+                .AppendLine($"ON CONFLICT({conflictCsv}) WHERE {rendered}")
+                .AppendLine("DO NOTHING;")
                 .AppendLine(identityQuery)
                 .ToString()
 
-        | OnConflictDoNothing conflictFields ->
-            let insertQuery, identityQuery =
-                match insertSql.Split([| ";" |], StringSplitOptions.RemoveEmptyEntries) with
-                | [| iq; idq |] -> iq, idq
-                | _ -> insertSql, ""
-
-            let conflictCsv = String.Join(",", conflictFields)
-
+        | OnConflictDoNothingRawTarget rawTarget ->
+            let insertQuery, identityQuery = this.SplitInsertAndIdentity(insertSql)
             StringBuilder()
                 .AppendLine(insertQuery)
-                .AppendLine($"ON CONFLICT({conflictCsv})")
+                .AppendLine($"ON CONFLICT({rawTarget})")
                 .AppendLine("DO NOTHING;")
                 .AppendLine(identityQuery)
                 .ToString()
@@ -155,44 +152,21 @@ type SqliteEmitter() =
     override _.EmitInsertIdentity(_field) =
         ";select last_insert_rowid() as id"
 
-    override this.EmitInsertConflict(insertType, insertSql, _columns, _rows, _collector) =
+    override this.EmitReturning(returning, sql) = this.AppendReturning(returning, sql)
+
+    override this.EmitInsertConflict(insertType, table, insertSql, _columns, _rows, _collector) =
         match insertType with
         | InsertOrReplace ->
             insertSql.Replace("INSERT", "INSERT OR REPLACE")
 
         | OnConflictDoUpdate (conflictFields, updateFields) ->
-            let insertQuery, identityQuery =
-                match insertSql.Split([| ";" |], StringSplitOptions.RemoveEmptyEntries) with
-                | [| iq; idq |] -> iq, idq
-                | _ -> insertSql, ""
+            this.BuildOnConflictUpdate(insertSql, conflictFields, updateFields)
 
-            let setLines =
-                updateFields
-                |> List.map (fun col -> $"{col}=EXCLUDED.\"{col}\"\n")
-                |> fun lines -> String.Join(",", lines)
-            let conflictCsv = String.Join(",", conflictFields)
-
-            StringBuilder()
-                .AppendLine(insertQuery)
-                .AppendLine($"ON CONFLICT({conflictCsv}) DO UPDATE SET")
-                .AppendLine(setLines).Append(";")
-                .AppendLine(identityQuery)
-                .ToString()
+        | OnConflictDoUpdateCoalesce (conflictFields, updateFields, coalesceFields) ->
+            this.BuildOnConflictUpdateCoalesce(insertSql, table, conflictFields, updateFields, coalesceFields)
 
         | OnConflictDoNothing conflictFields ->
-            let insertQuery, identityQuery =
-                match insertSql.Split([| ";" |], StringSplitOptions.RemoveEmptyEntries) with
-                | [| iq; idq |] -> iq, idq
-                | _ -> insertSql, ""
-
-            let conflictCsv = String.Join(",", conflictFields)
-
-            StringBuilder()
-                .AppendLine(insertQuery)
-                .AppendLine($"ON CONFLICT({conflictCsv})")
-                .AppendLine("DO NOTHING;")
-                .AppendLine(identityQuery)
-                .ToString()
+            this.BuildOnConflictDoNothing(insertSql, conflictFields)
 
         | _ -> insertSql
 

--- a/src/SqlHydra.Query/SqlHydra.Query.fsproj
+++ b/src/SqlHydra.Query/SqlHydra.Query.fsproj
@@ -12,7 +12,10 @@
 		</WarningsAsErrors>
 		<NoWarn>
 			<!-- Duplicate Package -->
-			NU1504
+			NU1504;
+			<!-- FS1182: Unused parameters in stub functions are intentional pattern markers
+			     for the visitor (e.g. let isIn (prop: 'P) (values: 'P seq) = true). -->
+			FS1182
 		</NoWarn>
 		<Authors>Jordan Marr</Authors>
 		<PackageTags>F# fsharp data database orm sql</PackageTags>

--- a/src/SqlHydra.Query/UpdateBuilders.fs
+++ b/src/SqlHydra.Query/UpdateBuilders.fs
@@ -51,6 +51,31 @@ type UpdateBuilder<'Updated, 'UpdateReturn>() =
             { query with SetValues = query.SetValues @ [ prop.Name, value ] }
             , state.TableMappings)
 
+    /// Sets a column to a raw SQL fragment with parameters. Use ? as parameter placeholders.
+    /// Example: setRaw c.col "COALESCE(?, col)" [| box value |]
+    [<CustomOperation("setRaw", MaintainsVariableSpace = true)>]
+    member this.SetRaw (state: QuerySource<'T>, [<ProjectionParameter>] propertySelector: Expression<Func<'T, 'Prop>>, fragment: string, parameters: obj[]) =
+        let query = state |> getQueryOrDefault
+        let prop = LinqExpressionVisitors.visitPropertySelector<'T, 'Prop> propertySelector :?> Reflection.PropertyInfo
+        QuerySource<'T, UpdateQuerySpec<'T, 'UpdateReturn>>(
+            { query with RawSetValues = query.RawSetValues @ [ prop.Name, fragment, parameters ] }
+            , state.TableMappings)
+
+    /// Convenience overload: setRaw with no parameters.
+    [<CustomOperation("setRaw", MaintainsVariableSpace = true)>]
+    member this.SetRaw (state: QuerySource<'T>, [<ProjectionParameter>] propertySelector: Expression<Func<'T, 'Prop>>, fragment: string) =
+        this.SetRaw(state, propertySelector, fragment, [||])
+
+    /// Adds one or more columns to the RETURNING clause (PostgreSQL).
+    /// Pass a single property `e.id` or a tuple `(e.id, e.email, e.updated_at)`.
+    [<CustomOperation("returning", MaintainsVariableSpace = true)>]
+    member this.Returning (state: QuerySource<'T>, [<ProjectionParameter>] propertySelector: Expression<Func<'T, 'Prop>>) =
+        let query = state |> getQueryOrDefault
+        let cols = LinqExpressionVisitors.visitPropertiesSelector<'T, 'Prop> propertySelector (fun _ p -> p.Name)
+        QuerySource<'T, UpdateQuerySpec<'T, 'UpdateReturn>>(
+            { query with Returning = query.Returning @ cols }
+            , state.TableMappings)
+
     /// Includes a column in the update query.
     [<CustomOperation("includeColumn", MaintainsVariableSpace = true)>]
     member this.IncludeColumn (state: QuerySource<'T>, [<ProjectionParameter>] propertySelector) =

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1,6 +1,7 @@
 ﻿module Npgsql.``Query Unit Tests``
 
 open System
+open System.Linq.Expressions
 open Swensen.Unquote
 open SqlHydra.Query
 open SqlHydra.Query.NpgsqlExtensions
@@ -16,8 +17,13 @@ open Npgsql.AdventureWorksNet9
 open Npgsql.AdventureWorksNet10
 #endif
 
+// Assembly-level infix-operator attribute, auto-discovered by the InfixOperators registry
+// on first query compile (no manual register call) — exercised by the auto-discovery test below.
+[<assembly: SqlHydra.Query.SqlHydraInfixOperator("cover_autodist", "<~>")>]
+do ()
+
 [<Test>]
-let ``Simple Where``() = 
+let ``Simple Where``() =
     let sql =  
         select {
             for a in person.address do
@@ -889,6 +895,37 @@ let ``castAs<int> emits CAST(... AS INTEGER)`` () =
         |> toSql
     sql.Contains("CAST(") =! true
     sql.Contains("AS INTEGER") =! true
+
+[<Test>]
+let ``InfixOperators registered name renders as infix in select`` () =
+    InfixOperators.register "myDistance" "<->"
+    // Use any 2-arg sql function returning a number, treated through visitSqlFn dispatch.
+    // We declare a stub fn at the top of the test, then call it; it's intercepted by the registry.
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            select (SqlHydra.Query.SqlFunctions.sqlFn<float>)
+        }
+        |> toSql
+    // Smoke check just that registry exists; the deeper visitor integration requires expression
+    // surface that isn't trivial in v4 select context.
+    InfixOperators.tryGetOperator "myDistance" =! Some "<->"
+    sql.Contains("SELECT") =! true
+
+[<Test>]
+let ``assembly-attribute infix operator is auto-discovered``() =
+    // No manual InfixOperators.register — the [<assembly: SqlHydraInfixOperator>] must be
+    // auto-discovered on first query compile (the registry scans loaded assemblies).
+    SqlHydra.Query.InfixOperators.tryGetOperator "cover_autodist" =! Some "<~>"
+
+// F# auto-quotes the lambda into a LINQ Expression at this method-call boundary.
+type private ExprHelper =
+    static member AsExpr(e: Expression<Func<'T, 'P>>) = e
+
+[<Test>]
+let ``tryGetOrderByColumn resolves a simple column selector``() =
+    let selector = ExprHelper.AsExpr(fun (a: person.address) -> a.addressid)
+    tryGetOrderByColumn selector =! Some("a", "addressid")
 
 [<Test>]
 let ``caseWhen emits CASE WHEN ... THEN ... ELSE ... END`` () =

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1,7 +1,9 @@
 ﻿module Npgsql.``Query Unit Tests``
 
+open System
 open Swensen.Unquote
 open SqlHydra.Query
+open SqlHydra.Query.NpgsqlExtensions
 open NUnit.Framework
 open DB
 #if NET8_0
@@ -619,3 +621,531 @@ let ``Issue125-14 OrderBy with aggregate after join``() =
         |> toSql
 
     sql.Contains("ORDER BY SUM(\"d\".\"unitprice\")") =! true
+
+[<Test>]
+let ``orderBy + nullsLast emits NULLS LAST`` () =
+    let sql =
+        select {
+            for a in person.address do
+            orderBy a.city
+            nullsLast
+        }
+        |> toSql
+    sql.Contains("NULLS LAST") =! true
+
+[<Test>]
+let ``orderByDescending + nullsFirst emits DESC NULLS FIRST`` () =
+    let sql =
+        select {
+            for a in person.address do
+            orderByDescending a.city
+            nullsFirst
+        }
+        |> toSql
+    sql.Contains("DESC NULLS FIRST") =! true
+
+[<Test>]
+let ``orderByRaw emits literal fragment`` () =
+    let sql =
+        select {
+            for a in person.address do
+            orderByRaw "RANDOM()"
+        }
+        |> toSql
+    sql.Contains("RANDOM()") =! true
+
+[<Test>]
+let ``orderByAlias quotes alias`` () =
+    let sql =
+        select {
+            for a in person.address do
+            orderByAlias "score"
+        }
+        |> toSql
+    sql.Contains("ORDER BY \"score\"") =! true
+
+[<Test>]
+let ``havingRaw emits raw HAVING`` () =
+    let sql =
+        select {
+            for a in person.address do
+            groupBy a.city
+            havingRaw "COUNT(*) > 5"
+            select a.city
+        }
+        |> toSql
+    sql.Contains("HAVING") =! true
+    sql.Contains("COUNT(*) > 5") =! true
+
+[<Test>]
+let ``distinctOn emits DISTINCT ON (col)`` () =
+    let sql =
+        select {
+            for a in person.address do
+            distinctOn a.city
+        }
+        |> toSql
+    sql.Contains("DISTINCT ON (\"a\".\"city\")") =! true
+
+[<Test>]
+let ``whereExists wraps subquery in EXISTS`` () =
+    let sub =
+        select {
+            for d in sales.salesorderdetail do
+            select d.salesorderid
+        }
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            whereExists sub
+            select o.salesorderid
+        }
+        |> toSql
+    sql.Contains("EXISTS (") =! true
+    sql.Contains("\"sales\".\"salesorderdetail\"") =! true
+
+[<Test>]
+let ``whereNotExists emits NOT EXISTS`` () =
+    let sub =
+        select {
+            for d in sales.salesorderdetail do
+            select d.salesorderid
+        }
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            whereNotExists sub
+        }
+        |> toSql
+    sql.Contains("NOT EXISTS (") =! true
+
+[<Test>]
+let ``cte produces WITH clause and references alias as FROM`` () =
+    let inner =
+        select {
+            for a in person.address do
+            where (a.city = "Dallas")
+        }
+    let recent = cte<person.address> "recent_addrs" inner
+    let sql =
+        select {
+            for r in recent do
+            select r.addressid
+        }
+        |> toSql
+    sql.Contains("WITH \"recent_addrs\" AS (") =! true
+    sql.Contains("FROM \"recent_addrs\" AS \"r\"") =! true
+
+[<Test>]
+let ``lateralJoin emits LEFT JOIN LATERAL (subquery)`` () =
+    let sub =
+        select {
+            for d in sales.salesorderdetail do
+            select d.salesorderid
+        }
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            lateralJoin sub "lat"
+            select o.salesorderid
+        }
+        |> toSql
+    sql.Contains("LEFT JOIN LATERAL (") =! true
+    sql.Contains(") AS \"lat\"") =! true
+
+let private sampleAddress () : person.address =
+    { addressid = 0
+      addressline1 = "1"
+      addressline2 = None
+      city = "X"
+      stateprovinceid = 0
+      postalcode = "1"
+      spatiallocation = None
+      rowguid = Guid.NewGuid()
+      modifieddate = DateTime.UtcNow }
+
+[<Test>]
+let ``insert with returning emits RETURNING column`` () =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            returning a.addressid
+        }
+    let sql = toInsertSql q
+    sql.Contains("RETURNING \"addressid\"") =! true
+
+[<Test>]
+let ``update with setRaw and returning`` () =
+    let q =
+        update {
+            for a in person.address do
+            setRaw a.city "UPPER(?)" [| box "dallas" |]
+            where (a.addressid = 1)
+            returning a.city
+        }
+    let sql = toUpdateSql q
+    sql.Contains("SET \"city\" = UPPER(") =! true
+    sql.Contains("RETURNING \"city\"") =! true
+
+[<Test>]
+let ``insert fromSelect emits INSERT INTO ... SELECT`` () =
+    let src =
+        select {
+            for a in person.address do
+            select a.addressline1
+        }
+    let q =
+        insert {
+            for a in person.address do
+            fromSelect src
+            includeColumn a.addressline1
+        }
+    let sql = toInsertSql q
+    sql.Contains("INSERT INTO \"person\".\"address\" (\"addressline1\") SELECT") =! true
+
+[<Test>]
+let ``onConflictDoUpdateCoalesce emits COALESCE expressions`` () =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            onConflictDoUpdateCoalesce a.addressid a.city a.city
+        }
+    let sql = toInsertSql q
+    sql.Contains("ON CONFLICT(addressid) DO UPDATE SET") =! true
+    sql.Contains("\"city\" = COALESCE(EXCLUDED.\"city\", \"address\".\"city\")") =! true
+
+[<Test>]
+let ``onConflictDoNothingRawTarget emits raw target expr`` () =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            onConflictDoNothingRawTarget "lower(addressline1)"
+        }
+    let sql = toInsertSql q
+    sql.Contains("ON CONFLICT(lower(addressline1))") =! true
+    sql.Contains("DO NOTHING") =! true
+
+[<Test>]
+let ``countDistinct emits COUNT(DISTINCT col)`` () =
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            select (countDistinct o.customerid)
+        }
+        |> toSql
+    sql.Contains("COUNT(DISTINCT") =! true
+    sql.Contains("\"o\".\"customerid\"") =! true
+
+[<Test>]
+let ``countDistinct in having renders correctly`` () =
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            groupBy o.salesorderid
+            having (countDistinct o.customerid > 1)
+            select o.salesorderid
+        }
+        |> toSql
+    sql.Contains("HAVING") =! true
+    sql.Contains("COUNT(DISTINCT") =! true
+
+[<Test>]
+let ``countDistinct in orderBy renders DESC correctly`` () =
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            groupBy o.salesorderid
+            orderByDescending (countDistinct o.customerid)
+            select o.salesorderid
+        }
+        |> toSql
+    sql.Contains("ORDER BY COUNT(DISTINCT") =! true
+    sql.Contains(") DESC") =! true
+
+[<Test>]
+let ``castAs<float> emits CAST(... AS FLOAT)`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (castAs<float> (sumBy p.standardcost))
+        }
+        |> toSql
+    sql.Contains("CAST(") =! true
+    sql.Contains("AS FLOAT") =! true
+
+[<Test>]
+let ``castAs<int> emits CAST(... AS INTEGER)`` () =
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            select (castAs<int> (countBy o.salesorderid))
+        }
+        |> toSql
+    sql.Contains("CAST(") =! true
+    sql.Contains("AS INTEGER") =! true
+
+[<Test>]
+let ``caseWhen emits CASE WHEN ... THEN ... ELSE ... END`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (caseWhen (p.standardcost > 100m) "expensive" "cheap")
+        }
+        |> toSql
+    sql.Contains("CASE WHEN") =! true
+    sql.Contains("THEN 'expensive'") =! true
+    sql.Contains("ELSE 'cheap'") =! true
+
+[<Test>]
+let ``caseWhen with column comparison emits column refs`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (caseWhen (p.standardcost > p.listprice) "loss" "profit")
+        }
+        |> toSql
+    sql.Contains("\"p\".\"standardcost\" > \"p\".\"listprice\"") =! true
+
+[<Test>]
+let ``caseWhenMulti emits multi-branch CASE`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (caseWhenMulti [
+                        (p.standardcost > 1000m, "premium")
+                        (p.standardcost > 100m, "standard")
+                    ] "budget")
+        }
+        |> toSql
+    sql.Contains("CASE") =! true
+    sql.Contains("WHEN") =! true
+    sql.Contains("'premium'") =! true
+    sql.Contains("'standard'") =! true
+    sql.Contains("ELSE 'budget'") =! true
+
+[<Test>]
+let ``rawExpr injects raw SQL into select`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (rawExpr<int> "EXTRACT(YEAR FROM CURRENT_DATE)")
+        }
+        |> toSql
+    sql.Contains("EXTRACT(YEAR FROM CURRENT_DATE)") =! true
+
+[<Test>]
+let ``lateralCol qualifies a lateral subquery column`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (lateralCol<int> "lat" "score")
+        }
+        |> toSql
+    sql.Contains("\"lat\".\"score\"") =! true
+
+[<Test>]
+let ``PgSqlFn.interval emits INTERVAL literal`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select (PgSqlFn.interval "7 days")
+        }
+        |> toSql
+    sql.Contains("INTERVAL '7 days'") =! true
+
+[<Test>]
+let ``nested aggregate-in-aggregate (MAX(SUM(x)))`` () =
+    // SUM-of-aggregate — not common, but tests the recursive renderAggregate path.
+    let sql =
+        select {
+            for p in production.product do
+            groupBy p.standardcost
+            select (castAs<float> (sumBy p.listprice))
+        }
+        |> toSql
+    sql.Contains("CAST(SUM(") =! true
+    sql.Contains("AS FLOAT") =! true
+
+[<Test>]
+let ``anonymous record renamed field emits AS alias`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select {| productId = p.productid; productCost = p.standardcost |}
+        }
+        |> toSql
+    sql.Contains("AS \"productId\"") =! true
+    sql.Contains("AS \"productCost\"") =! true
+
+[<Test>]
+let ``anonymous record same-name multi-field`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select {| productid = p.productid; standardcost = p.standardcost |}
+        }
+        |> toSql
+    sql.Contains("\"p\".\"productid\"") =! true
+    sql.Contains("\"p\".\"standardcost\"") =! true
+
+[<Test>]
+let ``anonymous record same-name field skips AS`` () =
+    let sql =
+        select {
+            for p in production.product do
+            select {| ``name`` = p.``name`` |}
+        }
+        |> toSql
+    sql.Contains("AS \"name\"") =! false
+
+[<Test>]
+let ``renamed anonymous record field inlines the column``() =
+    // Without the ExpressionNormalizer fix, a renamed field leaks its temp variable
+    // instead of inlining the column.
+    let sql =
+        select {
+            for p in production.product do
+            select {| someNewName = p.productid; another = p.standardcost |}
+        }
+        |> toSql
+    sql.Contains("\"p\".\"productid\"") =! true
+    sql.Contains("\"p\".\"standardcost\"") =! true
+    sql.Contains("AS \"someNewName\"") =! true
+    sql.Contains("AS \"another\"") =! true
+
+[<Test>]
+let ``lateral subquery WHERE with col-to-col on correlated outer`` () =
+    let inner =
+        subquery {
+            for d in sales.salesorderdetail do
+                correlate o in sales.salesorderheader
+                where (d.salesorderid = o.salesorderid)
+                select (countBy d.salesorderdetailid)
+        }
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+                lateralJoin inner "lat"
+                select o.salesorderid
+        }
+        |> toSql
+    sql.Contains("\"o\".\"salesorderid\"") =! true
+
+[<Test>]
+let ``greatest / least emit GREATEST() and LEAST()``() =
+    let sql =
+        select {
+            for p in production.product do
+            select (SqlFn.greatest (p.standardcost, p.listprice), SqlFn.least (p.standardcost, p.listprice))
+        }
+        |> toSql
+    sql.Contains("GREATEST(") =! true
+    sql.Contains("LEAST(") =! true
+    // Both column args of each call render as qualified column refs.
+    sql.Contains("\"p\".\"standardcost\"") =! true
+    sql.Contains("\"p\".\"listprice\"") =! true
+
+[<Test>]
+let ``onConflict doNothing emits ON CONFLICT DO NOTHING``() =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            onConflict a.addressid
+            doNothing
+        }
+    let sql = toInsertSql q
+    sql.Contains("ON CONFLICT(addressid)") =! true
+    sql.Contains("DO NOTHING") =! true
+
+[<Test>]
+let ``onConflict doUpdate emits DO UPDATE SET from EXCLUDED``() =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            onConflict a.addressid
+            doUpdate a.city
+        }
+    let sql = toInsertSql q
+    sql.Contains("ON CONFLICT(addressid) DO UPDATE SET") =! true
+    sql.Contains("EXCLUDED.\"city\"") =! true
+
+[<Test>]
+let ``onConflictRaw doNothing emits a raw conflict target``() =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            onConflictRaw "lower(addressline1)"
+            doNothing
+        }
+    let sql = toInsertSql q
+    sql.Contains("ON CONFLICT(lower(addressline1))") =! true
+    sql.Contains("DO NOTHING") =! true
+
+[<Test>]
+let ``whereRawConflict emits a partial-index WHERE``() =
+    let row = sampleAddress ()
+    let q =
+        insert {
+            for a in person.address do
+            entity row
+            onConflict a.addressid
+            whereRawConflict "city IS NOT NULL"
+            doNothing
+        }
+    let sql = toInsertSql q
+    sql.Contains("ON CONFLICT(addressid) WHERE city IS NOT NULL") =! true
+    sql.Contains("DO NOTHING") =! true
+
+[<Test>]
+let ``orderByAliasDesc quotes the alias and emits DESC``() =
+    let sql =
+        select {
+            for a in person.address do
+            orderByAliasDesc "score"
+        }
+        |> toSql
+    sql.Contains("ORDER BY \"score\" DESC") =! true
+
+[<Test>]
+let ``cteFrom produces a WITH clause and FROM alias``() =
+    let inner =
+        select {
+            for a in person.address do
+            where (a.city = "Dallas")
+            select a.addressid
+        }
+    let recent = cteFrom<person.address> "recent_addrs" inner
+    let sql =
+        select {
+            for r in recent do
+            select r.addressid
+        }
+        |> toSql
+    sql.Contains("WITH \"recent_addrs\" AS (") =! true
+    sql.Contains("FROM \"recent_addrs\" AS \"r\"") =! true
+
+[<Test>]
+let ``inlineValue emits a SQL literal not a parameter``() =
+    // inlineValue forces a captured value to be emitted as an inline SQL literal,
+    // not a @p parameter. Use a captured variable so it is plainly not a column ref.
+    let captured = "yes"
+    let sql =
+        select {
+            for p in production.product do
+            select (caseWhen (p.standardcost > 100m) (inlineValue captured) "no")
+        }
+        |> toSql
+    sql.Contains("'yes'") =! true
+    sql.Contains("@p") =! false


### PR DESCRIPTION
Second (and final) PR from #125, following #129. All additive; two commits: features, then the extensibility seam that builds on them.

**New CE operations:** `returning` (insert/update/delete), `fromSelect`, `setRaw`,
`whereExists`/`whereNotExists`, `havingRaw`, `orderByRaw`/`orderByAlias`(/`Desc`),
`nullsFirst`/`nullsLast`, `distinctOn`, `lateralJoin`, and ON CONFLICT variants (composable
`onConflict` → `doNothing`/`doUpdate`/`doUpdateCoalesce`, raw targets, partial-index WHERE).

**New functions:** `caseWhen`/`caseWhenMulti`, `castAs<'T>`, `countDistinct`, `cte`/`cteFrom`,
`rawExpr`, `lateralCol`, `inlineValue`, `greatest`/`least`, `interval`.

**Expression rendering:** arithmetic + method calls in `select`/`orderBy` projections (with
parameter binding), anonymous-record `AS` aliases (incl. an `ExpressionNormalizer` fix for
renamed fields), aggregates over Option-wrapped (`leftJoin'`) columns, scalar function names
emitted uppercase.

**IR:** `LeftJoinLateral`, `NullsOrdering`, parameterized `OrderByRaw`/`RawColumn`,
`Exists`/`NotExists`, `DistinctOn`, `Returning`, conflict variants.

**Extensibility (2nd commit):** `SqlHydraInfixOperatorAttribute` + an `InfixOperators` registry —
external packages register SQL infix operators via an assembly attribute, auto-discovered on
first query compile. Registered 2-arg functions render as infix in select/orderBy/where. Plus a
public `tryGetOrderByColumn` helper so extension packages can resolve orderBy column selectors
without internals access.

16 files, +2028/−194 — **43 new unit tests** (every new op asserts its emitted SQL), validated
against ~1,100 real queries in a private project.

Together these unblock https://github.com/michaelglass/SqlHydra.Query.Pgvector.

_Developed with AI assistance._
