### PR TITLE
Tell users when a registered extension loads nothing (instead of silently skipping it)

### DIFF
--- a/src/SqlHydra.Cli/Extensions.fs
+++ b/src/SqlHydra.Cli/Extensions.fs
@@ -130,5 +130,19 @@ let loadNamed (project: FileInfo) (extensionNames: string list) : ISqlHydraExten
         | None ->
             failwith $"Could not find '{dllName}' in the build output of '{project.Name}'. Ensure the project has been built."
         | Some path ->
-            loadFromAssembly path
+            // A registered extension that yields no ISqlHydraExtension is always a mistake worth
+            // stopping for: otherwise generation silently proceeds without the mapping and exits 0,
+            // leaving the affected columns missing from the output with no error. Fail loudly and
+            // point at the likely fixes.
+            match loadFromAssembly path with
+            | [] ->
+                failwith (
+                    $"Extension '{extName}' (loaded from '{path}') contains no ISqlHydraExtension implementations "
+                    + "(e.g. an IExtendTypeMapping). "
+                    + $"Check that '{extName}' in the TOML [extensions] section matches the package or assembly that "
+                    + "implements the extension, and that it is referenced by the project. If the name is correct, the "
+                    + "extension's types may have failed to load — ensure its dependencies are present and that it "
+                    + "targets a compatible SqlHydra version."
+                )
+            | extensions -> extensions
     )

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -64,6 +64,7 @@
     <Compile Include="UnitTests\TomlConfigParser.fs" />
     <Compile Include="UnitTests\ColumnFilters.fs" />
     <Compile Include="UnitTests\TableFilters.fs" />
+    <Compile Include="UnitTests\Extensions.fs" />
     <Compile Include="UnitTests\SchemaTemplateTests.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tests/UnitTests/Extensions.fs
+++ b/src/Tests/UnitTests/Extensions.fs
@@ -1,0 +1,38 @@
+module UnitTests.Extensions
+
+open System
+open System.IO
+open NUnit.Framework
+open Swensen.Unquote
+open SqlHydra
+
+// Lay out a throwaway project the way loadNamed resolves one in production: a `.fsproj` named
+// after the extension (so it's treated as the target project and skips the reference check),
+// optionally with `{name}.dll` in bin/. For `placeDll`, SqlHydra.Domain is a real, loadable
+// assembly that defines the extension interfaces but has no concrete ISqlHydraExtension — i.e.
+// the "named but empty" case (the test assembly itself can't be used: it defines TextTypeMapping).
+let private withTempProject (name: string) (placeDll: bool) (run: FileInfo -> unit) =
+    let root = Path.Combine(Path.GetTempPath(), $"sqlhydra-ext-{Guid.NewGuid():N}")
+    let proj = FileInfo(Path.Combine(root, $"{name}.fsproj"))
+    Directory.CreateDirectory(root) |> ignore
+    File.WriteAllText(proj.FullName, "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>")
+    if placeDll then
+        let bin = Directory.CreateDirectory(Path.Combine(root, "bin"))
+        let asm = typeof<SqlHydra.Domain.ISqlHydraExtension>.Assembly
+        File.Copy(asm.Location, Path.Combine(bin.FullName, $"{name}.dll"))
+    try run proj
+    finally (try Directory.Delete(root, true) with _ -> ())
+
+[<Test>]
+let ``loadNamed raises when a registered extension yields no implementations`` () =
+    let name = typeof<SqlHydra.Domain.ISqlHydraExtension>.Assembly.GetName().Name
+    withTempProject name true (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ name ] |> ignore)
+        test <@ ex.Message.Contains(name) @> // names the offending extension
+        test <@ ex.Message.Contains("no ISqlHydraExtension") @>)
+
+[<Test>]
+let ``loadNamed raises when the named dll is missing from build output`` () =
+    withTempProject "Missing" false (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Missing" ] |> ignore)
+        test <@ ex.Message.Contains("Missing") @>)


### PR DESCRIPTION
small usability fix to the cli when using extensions ...

Register an extension in your TOML (`[extensions] type_mappings`) that loads no `IExtendTypeMapping` — a wrong/typo'd name, the wrong assembly, or types that failed to load — and SqlHydra silently ignores it: generation runs without the mapping and exits `0`, so the only symptom is the affected columns quietly coming out unmapped, w ith no error.

`loadNamed` now errors instead, naming the extension and pointing at the likely fixes (does the `[extensions]` name match the package that implements it, is it referenced, did its types fail to load?).
