### PR TITLE
Render aggregates over expressions (e.g. `sumBy(caseWhen …)`) instead of throwing

### DIFF
--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -307,7 +307,9 @@ module SqlPatterns =
             let aggType = aggTypeOf m.Method.Name
             match m.Arguments.[0] with
             | Property p -> Some (aggType, p)
-            | _ -> notImplMsg "Invalid argument to aggregate function."
+            // Aggregate over an arbitrary expression (e.g. sumBy(caseWhen ...)): not a column,
+            // so don't match — the expression falls through to full expression rendering.
+            | _ -> None
         | _ -> None
 
 // ─── NormalizedExpression Patterns ───────────────────────────────────────────
@@ -416,7 +418,7 @@ module NormalizedPatterns =
             let aggType = aggTypeOf m.Method.Name
             match m.Arguments.[0] with
             | Property p -> Some (aggType, p)
-            | _ -> notImplMsg "Invalid argument to aggregate function."
+            | _ -> None
         | _ -> None
 
     /// List initializer — delegates to original ListInit pattern.

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1010,6 +1010,32 @@ let ``nested aggregate-in-aggregate (MAX(SUM(x)))`` () =
     sql.Contains("AS FLOAT") =! true
 
 [<Test>]
+let ``aggregate over a caseWhen expression emits SUM(CASE WHEN ...)`` () =
+    // A conditional count: SUM(CASE WHEN cond THEN 1 ELSE 0 END). The aggregate's argument
+    // is an expression (caseWhen), not a bare column — must render, not throw.
+    let sql =
+        select {
+            for p in production.product do
+            groupBy p.color
+            select (sumBy (caseWhen (p.standardcost > 100m) 1 0))
+        }
+        |> toSql
+    sql.Contains("SUM(CASE WHEN") =! true
+    sql.Contains("THEN 1") =! true
+    sql.Contains("ELSE 0") =! true
+
+[<Test>]
+let ``avgBy over a caseWhen expression emits AVG(CASE WHEN ...)`` () =
+    let sql =
+        select {
+            for p in production.product do
+            groupBy p.color
+            select (avgBy (caseWhen (p.standardcost > 100m) 1.0 0.0))
+        }
+        |> toSql
+    sql.Contains("AVG(CASE WHEN") =! true
+
+[<Test>]
 let ``anonymous record renamed field emits AS alias`` () =
     let sql =
         select {


### PR DESCRIPTION
whoops, one more bug from me...

`sumBy`/`avgBy`/etc. over anything other than a bare column threw `Invalid argument to aggregate function` — even though `NAggregateColumn`'s own doc comment says such expressions should fall through to full expression rendering. So a conditional count like `SUM(CASE WHEN … THEN 1 ELSE 0 END)` was impossible.

`AggregateColumn`/`NAggregateColumn` now return `None` for a non-column argument, letting it render as an expression. The Option/Nullable `.Value` chain is unaffected — it's still matched by the `Property` arm.

Tests: `sumBy`/`avgBy` over `caseWhen` now render `SUM(CASE WHEN …)` / `AVG(CASE WHEN …)`.
