### PR TITLE
Fix wrong SQL from function calls in `where`/`on'`, and let user-defined functions in

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,13 +31,14 @@ jobs:
           dotnet-version: |
             8.x
             9.x
+            10.x
       - name: Restore
         working-directory: src/
         run: dotnet restore
 
       - name: Start containers
         working-directory: src/.devcontainer
-        run: docker compose up -d mssql postgresql orcl
+        run: docker compose up -d --wait mssql postgresql orcl
       - name: Build
         working-directory: src/
         run: dotnet build --no-restore
@@ -47,10 +48,20 @@ jobs:
 
       - name: Stop and Start containers
         working-directory: src/.devcontainer
-        run: docker compose down && docker compose up -d mssql postgresql orcl
+        run: docker compose down && docker compose up -d --wait mssql postgresql orcl
       - name: Build
         working-directory: src/
         run: dotnet build --no-restore
       - name: Test net9.0
         working-directory: src/
         run: dotnet test --framework net9.0
+
+      - name: Stop and Start containers
+        working-directory: src/.devcontainer
+        run: docker compose down && docker compose up -d --wait mssql postgresql orcl
+      - name: Build
+        working-directory: src/
+        run: dotnet build --no-restore
+      - name: Test net10.0
+        working-directory: src/
+        run: dotnet test --framework net10.0

--- a/README.md
+++ b/README.md
@@ -352,21 +352,39 @@ See the full list for each provider:
 
 **Define custom functions:**
 
-You can easily define your own SQL function wrappers using the `sqlFn` helper:
+You can easily define your own SQL function wrappers using the `sqlFn` helper. Mark them with `[<SqlHydraFunction>]` - one marker on the module covers every wrapper in it:
 ```fsharp
-// Define a wrapper - the function name becomes the SQL function name
-let SOUNDEX (s: string) : string = sqlFn
-let DIFFERENCE (s1: string, s2: string) : int = sqlFn
+// The function name becomes the SQL function name
+[<SqlHydraFunction>]
+module CustomFn =
+    let SOUNDEX (s: string) : string = sqlFn
+    let DIFFERENCE (s1: string, s2: string) : int = sqlFn
 
 // Use in queries
 selectTask db {
     for p in Person.Person do
-    where (SOUNDEX(p.LastName) = SOUNDEX("Smith"))
+    where (CustomFn.SOUNDEX(p.LastName) = CustomFn.SOUNDEX("Smith"))
     select p.LastName
 }
 ```
 
-> **Note:** The `sqlFn` helper returns `Unchecked.defaultof<'Return>` - the function is never executed at runtime. The expression visitor translates the function name and arguments to SQL. If you use an invalid function name, you'll get a database error at runtime.
+Add `[<AutoOpen>]` to the module to call them unqualified, as `open type SqlFn` does for the built-ins.
+
+The marker also goes on a single function, or on a type of static members:
+```fsharp
+[<SqlHydraFunction>]
+let LEVENSHTEIN (s1: string, s2: string) : int = sqlFn
+
+[<SqlHydraFunction>]
+type TextFn =
+    static member METAPHONE(s: string) : string = sqlFn
+```
+
+> **Note:** `[<SqlHydraFunction>]` is what tells `where` and `on'` to render a call as SQL rather than compute it as a .NET value. Everything declared inside a marked module or type qualifies, nesting included, so keep ordinary helpers out of one. `select` and `orderBy` render every call and work without the marker.
+>
+> Extension packages that ship their own `sqlFn` wrappers need the marker for the same reason — their assembly is not `SqlHydra.Query`, so a `where` would otherwise try to compute the call.
+>
+> A `sqlFn` body has no runtime meaning, so executing one raises `SqlFunctionNotRenderedException` - which is what a missing marker gets you, rather than a query that quietly compares your column to `NULL`. If you use a function name the database does not have, you get a database error at runtime.
 
 ### Subqueries
 

--- a/src/.devcontainer/docker-compose.yml
+++ b/src/.devcontainer/docker-compose.yml
@@ -52,6 +52,11 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "54320:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
       
   orcl:
     hostname: orcl
@@ -66,5 +71,11 @@ services:
     volumes:
       - ./orcl/init-ot-schema.sql:/docker-entrypoint-initdb.d/01_init_schema.sql
       - ./orcl/init-ot-data.sql:/docker-entrypoint-initdb.d/02_init_data.sql
+    healthcheck:
+      test: ["CMD-SHELL", "healthcheck.sh"]
+      interval: 10s
+      timeout: 10s
+      retries: 60
+      start_period: 30s
     
     

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -8,6 +8,13 @@ open FastExpressionCompiler
 let notImpl() = raise (NotImplementedException())
 let notImplMsg msg = raise (NotImplementedException msg)
 
+/// True when a method call is a SqlHydra query function (`isIn`, `like`, `inlineValue`,
+/// `rawExpr`, `sqlFn` wrappers, ...) rather than an ordinary .NET call.
+/// A SqlHydra function has a stub body (`Unchecked.defaultof<_>`), so evaluating one yields
+/// null/0 rather than anything meaningful: it must be rendered as SQL, never compiled and run.
+let isSqlHydraFunction (mi: MethodInfo) =
+    mi.Module.Name = "SqlHydra.Query.dll"
+
 /// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.
 /// Keep in sync with QueryFunctions.Aggregates.
 let aggregateMethodNames =
@@ -297,7 +304,7 @@ module SqlPatterns =
         match exp with
         | Constant c -> Some c.Value
         // Do not try to evaluate QueryFunctions like `isIn`, `isNotIn`, etc.
-        | Call c when c.Method.Module.Name <> "SqlHydra.Query.dll" -> 
+        | Call c when not (isSqlHydraFunction c.Method) ->
             compileAndEvaluateExpression exp |> Some
         | _ -> None
 
@@ -394,7 +401,7 @@ module NormalizedPatterns =
     let (|NValue|_|) (nexp: NormalizedExpression) =
         match nexp with
         | NConstant(v, _) -> Some v
-        | NMethodCall(call, _) when call.Method.Module.Name <> "SqlHydra.Query.dll" ->
+        | NMethodCall(call, _) when not (isSqlHydraFunction call.Method) ->
             compileAndEvaluateExpression (call :> Expression) |> Some
         | NMemberAccess(NConstant _, m) ->
             // Evaluable member access on a constant (e.g., captured variable from closure)

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -958,6 +958,41 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                 let fqCol = qualifyColumn alias m.Value.Member
                 Compare(fqCol, compOp, Parameter queryParameter)
 
+            // SQL function compared to value
+            | NMethodCall _, NValue value ->
+                let sqlFragment = nVisitSqlFn qualifyColumn left
+                RawWhere($"{sqlFragment} {comparison} ?", [| value |])
+
+            // Value compared to SQL function
+            | NValue value, NMethodCall _ ->
+                let sqlFragment = nVisitSqlFn qualifyColumn right
+                let reversedComparison = getReverseComparison op
+                RawWhere($"{sqlFragment} {reversedComparison} ?", [| value |])
+
+            // SQL function compared to column
+            | NMethodCall (m, _), NColumn (p, _) when isSqlHydraFunction m.Method ->
+                let sqlFragment = nVisitSqlFn qualifyColumn left
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                RawWhere($"{sqlFragment} {comparison} {fqCol}", [||])
+
+            // Column compared to SQL function
+            | NColumn (p, _), NMethodCall (m, _) when isSqlHydraFunction m.Method ->
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                let sqlFragment = nVisitSqlFn qualifyColumn right
+                RawWhere($"{fqCol} {comparison} {sqlFragment}", [||])
+
+            // SQL function compared to SQL function
+            | NMethodCall _, NMethodCall _ ->
+                let sqlFragment1 = nVisitSqlFn qualifyColumn left
+                let sqlFragment2 = nVisitSqlFn qualifyColumn right
+                RawWhere($"{sqlFragment1} {comparison} {sqlFragment2}", [||])
+
+            // Joined table parameter compared to None (e.g., where (d = None) after leftJoin')
+            // Fall-throughs: the other side is a captured value, so compile-and-eval it.
+            // These MUST stay below the SQL-function arms — evaluating a stub yields null,
+            // and the comparison would silently collapse to `col IS NULL`.
             | NColumn (p, _), _ ->
                 let alias = visitAlias p.Expression
                 let fqCol = qualifyColumn alias p.Member
@@ -1004,38 +1039,6 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                     let queryParameter = QueryUtils.getQueryParameterForValue p.Member value
                     Compare(fqCol, reversedOp, Parameter queryParameter)
 
-            // SQL function compared to value
-            | NMethodCall _, NValue value ->
-                let sqlFragment = nVisitSqlFn qualifyColumn left
-                RawWhere($"{sqlFragment} {comparison} ?", [| value |])
-
-            // Value compared to SQL function
-            | NValue value, NMethodCall _ ->
-                let sqlFragment = nVisitSqlFn qualifyColumn right
-                let reversedComparison = getReverseComparison op
-                RawWhere($"{sqlFragment} {reversedComparison} ?", [| value |])
-
-            // SQL function compared to column
-            | NMethodCall _, NColumn (p, _) ->
-                let sqlFragment = nVisitSqlFn qualifyColumn left
-                let alias = visitAlias p.Expression
-                let fqCol = qualifyColumn alias p.Member
-                RawWhere($"{sqlFragment} {comparison} {fqCol}", [||])
-
-            // Column compared to SQL function
-            | NColumn (p, _), NMethodCall _ ->
-                let alias = visitAlias p.Expression
-                let fqCol = qualifyColumn alias p.Member
-                let sqlFragment = nVisitSqlFn qualifyColumn right
-                RawWhere($"{fqCol} {comparison} {sqlFragment}", [||])
-
-            // SQL function compared to SQL function
-            | NMethodCall _, NMethodCall _ ->
-                let sqlFragment1 = nVisitSqlFn qualifyColumn left
-                let sqlFragment2 = nVisitSqlFn qualifyColumn right
-                RawWhere($"{sqlFragment1} {comparison} {sqlFragment2}", [||])
-
-            // Joined table parameter compared to None (e.g., where (d = None) after leftJoin')
             | NParameter p, _ | _, NParameter p when p.Type |> isOptionType ->
                 let innerType = p.Type.GetGenericArguments().[0]
                 let firstField = FSharp.Reflection.FSharpType.GetRecordFields(innerType).[0]

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -526,6 +526,12 @@ let private isNullaryDU (t: System.Type) =
 let private formatFloat (s: string) =
     if s.Contains(".") || s.Contains("e") || s.Contains("E") then s else s + ".0"
 
+/// Renders a string as a SQL literal, doubling embedded single quotes so the value
+/// cannot close the literal early.
+let private renderStringLiteral (s: string) =
+    let escaped = s.Replace("'", "''")
+    $"'{escaped}'"
+
 /// Formats a numeric constant as SQL literal, preserving the type's decimal form for floats.
 /// `1.0` (double) → "1.0", not "1" (which Postgres types as integer and breaks `1.0 - <vector>` queries).
 /// Enums and nullary DUs are quoted as their string name — Postgres treats bare identifiers as columns.
@@ -534,7 +540,7 @@ let private formatNumericLiteral (value: obj) (clrType: System.Type) =
     | t when t = typeof<float> || t = typeof<double> -> (value :?> double).ToString("R", inv) |> formatFloat
     | t when t = typeof<single> || t = typeof<float32> -> (value :?> single).ToString("R", inv) |> formatFloat
     | t when t = typeof<decimal> -> (value :?> decimal).ToString(inv)
-    | t when t.IsEnum || isNullaryDU t -> $"'{value}'"
+    | t when t.IsEnum || isNullaryDU t -> renderStringLiteral (string value)
     // Integer primitives (int, int64, byte, ...) — ToString is safe SQL for these.
     // char/bool are excluded: bool is handled in renderObjAsLiteral; char would emit unquoted.
     | t when t.IsPrimitive && t <> typeof<char> && t <> typeof<bool> -> sprintf "%O" value
@@ -545,7 +551,7 @@ let private formatNumericLiteral (value: obj) (clrType: System.Type) =
 /// orderBy walker, which never receives bool constants). Shared by the expression walkers.
 let private renderConstant (handleBool: bool) (c: ConstantExpression) =
     if c.Value = null then "NULL"
-    elif c.Type = typeof<string> then $"'{c.Value}'"
+    elif c.Type = typeof<string> then renderStringLiteral (c.Value :?> string)
     elif handleBool && c.Type = typeof<bool> then (if c.Value :?> bool then "TRUE" else "FALSE")
     else formatNumericLiteral c.Value c.Type
 
@@ -554,15 +560,13 @@ let private renderConstant (handleBool: bool) (c: ConstantExpression) =
 let private renderObjAsLiteral (v: obj) =
     match v with
     | null -> "NULL"
-    | :? string as s -> $"'{s}'"
+    | :? string as s -> renderStringLiteral s
     | :? bool as b -> if b then "TRUE" else "FALSE"
-    | :? System.Guid as g -> $"'{g}'"
+    | :? System.Guid as g -> renderStringLiteral (string g)
     | :? System.DateTime as dt ->
-        let s = dt.ToString("yyyy-MM-dd HH:mm:ss", inv)
-        $"'{s}'"
+        renderStringLiteral (dt.ToString("yyyy-MM-dd HH:mm:ss", inv))
     | :? System.DateTimeOffset as dto ->
-        let s = dto.ToString("yyyy-MM-dd HH:mm:sszzz", inv)
-        $"'{s}'"
+        renderStringLiteral (dto.ToString("yyyy-MM-dd HH:mm:sszzz", inv))
     | _ -> formatNumericLiteral v (v.GetType())
 
 /// Converts a SQL function MethodCall expression to a SQL fragment string.
@@ -619,12 +623,7 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
                         let cond = t.GetProperty("Item1").GetValue(item) :?> bool
                         let v = t.GetProperty("Item2").GetValue(item)
                         let condStr = if cond then "TRUE" else "FALSE"
-                        let valStr =
-                            match v with
-                            | null -> "NULL"
-                            | :? string as s -> $"'{s}'"
-                            | x -> sprintf "%O" x
-                        yield (condStr, valStr) ]
+                        yield (condStr, renderObjAsLiteral v) ]
                 | _ -> notImplMsg $"Cannot extract caseWhenMulti list: {exp.NodeType}"
             with ex -> notImplMsg $"Cannot extract caseWhenMulti list: {exp.NodeType} ({ex.Message})"
     and extractTuple (exp: Expression) : string * string =
@@ -661,7 +660,7 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
     // (Method name string-matched because `interval` lives in NpgsqlExtensions and isn't in scope here.)
     | MethodCall m when m.Method.Name = "interval" && m.Arguments.Count = 1 ->
         let value = compileAndEval m.Arguments.[0] :?> string
-        $"INTERVAL '{value}'"
+        $"INTERVAL {renderStringLiteral value}"
     // Aggregates → render via renderAggregate (handles COUNT(DISTINCT col)).
     | MethodCall m when aggregateMethodNames.Contains m.Method.Name ->
         let aggType = aggTypeOf m.Method.Name

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -1390,7 +1390,30 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
             WhereClause.combineOr lt rt
         | NBinaryCompare(left, op, right) ->
             let compOp = toComparisonOp op
+            let comparison = getComparison op
             match left, right with
+            // A SQL function must be rendered, not evaluated. These MUST precede the arms
+            // below, which compile-and-eval whichever side is not a column.
+            | NColumn (p, _), NMethodCall (m, _) when isSqlHydraFunction m.Method ->
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                RawWhere($"{fqCol} {comparison} {nVisitSqlFn qualifyColumn right}", [||])
+
+            | NMethodCall (m, _), NColumn (p, _) when isSqlHydraFunction m.Method ->
+                let alias = visitAlias p.Expression
+                let fqCol = qualifyColumn alias p.Member
+                RawWhere($"{nVisitSqlFn qualifyColumn left} {comparison} {fqCol}", [||])
+
+            | NMethodCall (m, _), NValue value when isSqlHydraFunction m.Method ->
+                RawWhere($"{nVisitSqlFn qualifyColumn left} {comparison} ?", [| value |])
+
+            | NValue value, NMethodCall (m, _) when isSqlHydraFunction m.Method ->
+                RawWhere($"{nVisitSqlFn qualifyColumn right} {getReverseComparison op} ?", [| value |])
+
+            | NMethodCall (m1, _), NMethodCall (m2, _) when
+                isSqlHydraFunction m1.Method && isSqlHydraFunction m2.Method ->
+                RawWhere($"{nVisitSqlFn qualifyColumn left} {comparison} {nVisitSqlFn qualifyColumn right}", [||])
+
             // Handle col to col comparisons (the primary join case)
             | NColumn (p1, _), NColumn (p2, _) ->
                 let lt =

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -8,21 +8,16 @@ open FastExpressionCompiler
 let notImpl() = raise (NotImplementedException())
 let notImplMsg msg = raise (NotImplementedException msg)
 
-/// True when a method call is a SqlHydra query function (`isIn`, `like`, `inlineValue`,
-/// `rawExpr`, `sqlFn` wrappers, ...) rather than an ordinary .NET call: it has a stub body,
-/// so it must be rendered as SQL, never evaluated. Everything in SqlHydra.Query qualifies
-/// (not all of it is a wrapper — `isIn` returns a real `true`); a wrapper declared anywhere
-/// else says so with `[<SqlHydraFunction>]`, on the function or on the module or type holding
-/// it. Forgetting the marker is not silent: the call is evaluated instead, and evaluating a
-/// stub fails rather than yielding a value.
+/// True when a call must be rendered as SQL rather than evaluated. `[<SqlHydraFunction>]` is
+/// the only answer, on the function or on the module or type holding it; SqlHydra's own
+/// functions carry it like anyone else's, and a test asserts none of them lose it.
 let isSqlHydraFunction (mi: MethodInfo) =
     // Walk up: one marker on a module or type covers the group declared inside it.
     let rec isMarkedContainer (t: Type) =
         not (isNull t)
         && (t.IsDefined(typeof<SqlHydraFunctionAttribute>, false) || isMarkedContainer t.DeclaringType)
 
-    mi.Module.Name = "SqlHydra.Query.dll"
-    || mi.IsDefined(typeof<SqlHydraFunctionAttribute>, false)
+    mi.IsDefined(typeof<SqlHydraFunctionAttribute>, false)
     || isMarkedContainer mi.DeclaringType
 
 /// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -1021,7 +1021,9 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                 // reference in a lateral subquery (where the column's parameter isn't in
                 // the local `tables` map). Try eval; on failure, fall back to column ref.
                 let valueResult =
-                    try Some (nEvaluate right) with _ -> None
+                    // `None` means "not evaluable", which is what notImplMsg raises. Catching
+                    // everything also swallowed the sqlFn stub, losing the message it carries.
+                    try Some (nEvaluate right) with :? NotImplementedException -> None
                 match valueResult with
                 | Some value ->
                     match value with
@@ -1040,7 +1042,7 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
 
             | _, NColumn (p, _) ->
                 let valueResult =
-                    try Some (nEvaluate left) with _ -> None
+                    try Some (nEvaluate left) with :? NotImplementedException -> None
                 let reversedOp = reverseComparisonOp compOp
                 let alias = visitAlias p.Expression
                 let fqCol = qualifyColumn alias p.Member
@@ -1536,7 +1538,7 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
                     | _ -> None
                 let result =
                     try evalRhs () |> Option.map Choice1Of2
-                    with _ -> tryColumnRef () |> Option.map Choice2Of2
+                    with :? NotImplementedException -> tryColumnRef () |> Option.map Choice2Of2
                 match result with
                 | Some (Choice1Of2 value) ->
                     match value with
@@ -1570,7 +1572,7 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
                     | _ -> None
                 let result =
                     try evalLhs () |> Option.map Choice1Of2
-                    with _ -> tryColumnRef () |> Option.map Choice2Of2
+                    with :? NotImplementedException -> tryColumnRef () |> Option.map Choice2Of2
                 let reversedOp = reverseComparisonOp compOp
                 match result with
                 | Some (Choice1Of2 value) ->

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -9,11 +9,21 @@ let notImpl() = raise (NotImplementedException())
 let notImplMsg msg = raise (NotImplementedException msg)
 
 /// True when a method call is a SqlHydra query function (`isIn`, `like`, `inlineValue`,
-/// `rawExpr`, `sqlFn` wrappers, ...) rather than an ordinary .NET call.
-/// A SqlHydra function has a stub body (`Unchecked.defaultof<_>`), so evaluating one yields
-/// null/0 rather than anything meaningful: it must be rendered as SQL, never compiled and run.
+/// `rawExpr`, `sqlFn` wrappers, ...) rather than an ordinary .NET call: it has a stub body,
+/// so it must be rendered as SQL, never evaluated. Everything in SqlHydra.Query qualifies
+/// (not all of it is a wrapper — `isIn` returns a real `true`); a wrapper declared anywhere
+/// else says so with `[<SqlHydraFunction>]`, on the function or on the module or type holding
+/// it. Forgetting the marker is not silent: the call is evaluated instead, and evaluating a
+/// stub fails rather than yielding a value.
 let isSqlHydraFunction (mi: MethodInfo) =
+    // Walk up: one marker on a module or type covers the group declared inside it.
+    let rec isMarkedContainer (t: Type) =
+        not (isNull t)
+        && (t.IsDefined(typeof<SqlHydraFunctionAttribute>, false) || isMarkedContainer t.DeclaringType)
+
     mi.Module.Name = "SqlHydra.Query.dll"
+    || mi.IsDefined(typeof<SqlHydraFunctionAttribute>, false)
+    || isMarkedContainer mi.DeclaringType
 
 /// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.
 /// Keep in sync with QueryFunctions.Aggregates.
@@ -258,7 +268,18 @@ module SqlPatterns =
             let compiled = lambda.CompileFast()
             compiled.DynamicInvoke()
         with ex ->  
-            notImplMsg $"Unable to evaluate query parameter expression:\n{exp}"
+            // A `sqlFn` stub raises when executed, and that names the real mistake — a wrapper
+            // missing `[<SqlHydraFunction>]`. Report it instead of burying it under the generic
+            // message. `DynamicInvoke` wraps what was thrown, so ask for the base exception.
+            match ex.GetBaseException() with
+            | :? SqlFunctionNotRenderedException as stubEx ->
+                raise (SqlFunctionNotRenderedException($"{stubEx.Message}\nExpression: {exp}", stubEx))
+            | _ ->
+                // With a column argument the compile fails before the stub can run, so an
+                // unmarked wrapper lands here rather than above. Same mistake, so say so.
+                notImplMsg $"Unable to evaluate query parameter expression:\n{exp}\n\
+                             If this is a SqlHydra SQL function wrapper, mark it \
+                             `[<SqlHydraFunction>]` so it is rendered as SQL instead of evaluated."
 
     /// Handles extended properties on Nullable and Option types.
     [<RequireQualifiedAccess>]

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -427,7 +427,7 @@ module NormalizedPatterns =
             Some v
         | NUnknown exp when exp <> null ->
             try compileAndEvaluateExpression exp |> Some
-            with _ -> None
+            with :? NotImplementedException -> None
         | _ -> None
 
     /// Aggregate column pattern (minBy, maxBy, sumBy, avgBy, countBy, avgByAs).
@@ -975,12 +975,12 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                 Compare(fqCol, compOp, Parameter queryParameter)
 
             // SQL function compared to value
-            | NMethodCall _, NValue value ->
+            | NMethodCall (m, _), NValue value when isSqlHydraFunction m.Method ->
                 let sqlFragment = nVisitSqlFn qualifyColumn left
                 RawWhere($"{sqlFragment} {comparison} ?", [| value |])
 
             // Value compared to SQL function
-            | NValue value, NMethodCall _ ->
+            | NValue value, NMethodCall (m, _) when isSqlHydraFunction m.Method ->
                 let sqlFragment = nVisitSqlFn qualifyColumn right
                 let reversedComparison = getReverseComparison op
                 RawWhere($"{sqlFragment} {reversedComparison} ?", [| value |])
@@ -1000,7 +1000,8 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                 RawWhere($"{fqCol} {comparison} {sqlFragment}", [||])
 
             // SQL function compared to SQL function
-            | NMethodCall _, NMethodCall _ ->
+            | NMethodCall (m1, _), NMethodCall (m2, _) when
+                isSqlHydraFunction m1.Method && isSqlHydraFunction m2.Method ->
                 let sqlFragment1 = nVisitSqlFn qualifyColumn left
                 let sqlFragment2 = nVisitSqlFn qualifyColumn right
                 RawWhere($"{sqlFragment1} {comparison} {sqlFragment2}", [||])
@@ -1080,7 +1081,7 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
                     | NUnary(ExpressionType.Convert, inner) -> asOuterCol inner
                     | _ -> None
                 let tryEval (n: NormalizedExpression) =
-                    try Some (nEvaluate n) with _ -> None
+                    try Some (nEvaluate n) with :? NotImplementedException -> None
                 match asOuterCol left, asOuterCol right with
                 | Some ml, Some mr ->
                     let lt = qualifyColumn (visitAlias ml.Expression) ml.Member
@@ -1529,7 +1530,7 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
                         try
                             let rhsAlias = visitAlias m.Expression
                             Some (qualifyColumn rhsAlias m.Member)
-                        with _ -> None
+                        with :? NotImplementedException -> None
                     | _ -> None
                 let result =
                     try evalRhs () |> Option.map Choice1Of2
@@ -1563,7 +1564,7 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
                         try
                             let lhsAlias = visitAlias m.Expression
                             Some (qualifyColumn lhsAlias m.Member)
-                        with _ -> None
+                        with :? NotImplementedException -> None
                     | _ -> None
                 let result =
                     try evalLhs () |> Option.map Choice1Of2

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -582,9 +582,6 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
         // Unwrap implicit numeric conversions (e.g., int → float when a column type widens).
         | :? UnaryExpression as u when u.NodeType = ExpressionType.Convert ->
             renderExpr u.Operand
-        // inlineValue marker: compile-and-eval the inner expression and emit as a literal.
-        | MethodCall m when m.Method.Name = nameof inlineValue && m.Arguments.Count = 1 ->
-            renderObjAsLiteral (compileAndEval m.Arguments.[0])
         | Member mem when mem.Expression <> null ->
             let alias = visitAlias mem.Expression
             qualifyColumn alias mem.Member
@@ -653,6 +650,9 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
         let alias = compileAndEval m.Arguments.[0] :?> string
         let column = compileAndEval m.Arguments.[1] :?> string
         $"\"{alias}\".\"{column}\""
+    // inlineValue marker: emit the wrapped value as a SQL literal.
+    | MethodCall m when m.Method.Name = nameof inlineValue && m.Arguments.Count = 1 ->
+        renderObjAsLiteral (compileAndEval m.Arguments.[0])
     // Raw SQL escape hatch
     | MethodCall m when m.Method.Name = nameof rawExpr && m.Arguments.Count = 1 ->
         compileAndEval m.Arguments.[0] :?> string

--- a/src/SqlHydra.Query/MySqlExtensions.fs
+++ b/src/SqlHydra.Query/MySqlExtensions.fs
@@ -1,9 +1,10 @@
-module SqlHydra.Query.MySqlExtensions
+﻿module SqlHydra.Query.MySqlExtensions
 
 open System
 
 /// Common MySQL functions for use in select expressions.
 /// Use `open type SqlFn` to access functions without qualification.
+[<SqlHydraFunction>]
 type SqlFn =
     // String functions
     static member CHAR_LENGTH(s: string) : int = sqlFn

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -4,6 +4,7 @@ open System
 
 /// Common PostgreSQL functions for use in select expressions.
 /// Use `open type SqlFn` to access functions without qualification.
+[<SqlHydraFunction>]
 type SqlFn =
     // String functions (PostgreSQL uses lowercase)
     static member char_length(s: string) : int = sqlFn
@@ -74,6 +75,7 @@ type SqlFn =
     static member least(a: 'T, b: 'T, c: 'T, d: 'T) : 'T = sqlFn
 
 /// PostgreSQL-specific functions.
+[<SqlHydraFunction>]
 type PgSqlFn =
     /// Renders a PostgreSQL `INTERVAL '<value>'` literal.
     /// Example: `interval "7 days"` → `INTERVAL '7 days'`

--- a/src/SqlHydra.Query/OracleExtensions.fs
+++ b/src/SqlHydra.Query/OracleExtensions.fs
@@ -1,9 +1,10 @@
-module SqlHydra.Query.OracleExtensions
+﻿module SqlHydra.Query.OracleExtensions
 
 open System
 
 /// Common Oracle functions for use in select expressions.
 /// Use `open type SqlFn` to access functions without qualification.
+[<SqlHydraFunction>]
 type SqlFn =
     // String functions
     static member LENGTH(s: string) : int = sqlFn

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -1,6 +1,32 @@
 ﻿namespace SqlHydra.Query
 
+/// Marks `sqlFn` wrappers as SQL functions, so that a `where` or `on'` predicate renders the
+/// call as SQL instead of computing it as a .NET value. SqlHydra's own query functions carry it
+/// too: it is the only thing that makes a call a SQL function.
+/// Apply it to one function, or to the module or type holding a group of them: everything
+/// declared inside a marked module or type qualifies, nesting included, so keep ordinary
+/// helpers out of one.
+/// Unmarked wrappers still work in `select` and `orderBy`, which render every call; in a
+/// predicate they raise `SqlFunctionNotRenderedException` rather than compare against a stub.
+///
+/// Example:
+///   [<SqlHydraFunction>]
+///   module SqlFn =
+///       let SOUNDEX (s: string) : string = sqlFn
+///       let DIFFERENCE (s1: string, s2: string) : int = sqlFn
+[<System.AttributeUsage(System.AttributeTargets.Method ||| System.AttributeTargets.Class)>]
+type SqlHydraFunctionAttribute() =
+    inherit System.Attribute()
+
+/// Raised when a `sqlFn` wrapper is executed as ordinary .NET code instead of being rendered
+/// as SQL: either it was called outside a query expression, or it is used in a `where`/`on'`
+/// predicate without `[<SqlHydraFunction>]`, so the visitor took it for a value to compute.
+type SqlFunctionNotRenderedException(message: string, inner: exn) =
+    inherit System.InvalidOperationException(message, inner)
+    new (message: string) = SqlFunctionNotRenderedException(message, null)
+
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module Table =
 
     /// Maps the entity 'T to a table of the exact same name.
@@ -24,6 +50,7 @@ module Table =
         QuerySource<'T, SelectQueryIR>(ir, tables) :> QuerySource<'T>
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module Where = 
 
     /// WHERE column is IN values
@@ -64,6 +91,7 @@ module Where =
     let notEqual (prop: 'P) (value: 'P) = true
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module OrderBy = 
 
     // infix operator ^^ that takes a boolean that conditionally includes the sort property.
@@ -86,6 +114,7 @@ SELECT [SalesLT].[Product].[Department], MIN([SalesLT].[Product].[Price]) AS Min
 *)
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module Aggregates =
 
     /// Gets the COUNT of the given column
@@ -110,6 +139,7 @@ module Aggregates =
     let countDistinct (prop: 'P) = Unchecked.defaultof<int>
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module CastFunctions =
     /// CAST(expression AS targetType).
     /// The target SQL type is inferred from the F# return type:
@@ -117,6 +147,7 @@ module CastFunctions =
     let castAs<'Result> (_value: obj) : 'Result = Unchecked.defaultof<'Result>
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module CaseWhenFunctions =
     /// CASE WHEN condition THEN thenValue ELSE elseValue END.
     /// Note: values are rendered as SQL literals, not parameters.
@@ -128,6 +159,7 @@ module CaseWhenFunctions =
     let caseWhenMulti<'T> (branches: (bool * 'T) list) (elseValue: 'T) : 'T = Unchecked.defaultof<'T>
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module RawExpressions =
     /// Reference a column from a lateral subquery by alias and column name (raw quoted).
     /// Example: lateralCol "lat" "score" → "lat"."score"
@@ -141,30 +173,6 @@ module RawExpressions =
     /// inside `caseWhen`, `castAs`, infix operator args, etc.
     /// Example: caseWhen (col > 0) (inlineValue "yes") (inlineValue "no")
     let inlineValue<'T> (_value: 'T) : 'T = Unchecked.defaultof<'T>
-
-/// Marks `sqlFn` wrappers declared outside SqlHydra.Query as SQL functions, so that a `where`
-/// or `on'` predicate renders the call as SQL instead of computing it as a .NET value.
-/// Apply it to one function, or to the module or type holding a group of them: everything
-/// declared inside a marked module or type qualifies, nesting included, so keep ordinary
-/// helpers out of one.
-/// Unmarked wrappers still work in `select` and `orderBy`, which render every call; in a
-/// predicate they raise `SqlFunctionNotRenderedException` rather than compare against a stub.
-///
-/// Example:
-///   [<SqlHydraFunction>]
-///   module SqlFn =
-///       let SOUNDEX (s: string) : string = sqlFn
-///       let DIFFERENCE (s1: string, s2: string) : int = sqlFn
-[<System.AttributeUsage(System.AttributeTargets.Method ||| System.AttributeTargets.Class)>]
-type SqlHydraFunctionAttribute() =
-    inherit System.Attribute()
-
-/// Raised when a `sqlFn` wrapper is executed as ordinary .NET code instead of being rendered
-/// as SQL: either it was called outside a query expression, or it is used in a `where`/`on'`
-/// predicate without `[<SqlHydraFunction>]`, so the visitor took it for a value to compute.
-type SqlFunctionNotRenderedException(message: string, inner: exn) =
-    inherit System.InvalidOperationException(message, inner)
-    new (message: string) = SqlFunctionNotRenderedException(message, null)
 
 /// Assembly-level attribute that registers a SQL function name as an infix operator.
 /// Extension packages (e.g. SqlHydra.Query.Pgvector) apply this attribute on themselves and
@@ -214,6 +222,7 @@ module InfixOperators =
         | _ -> None
 
 [<AutoOpen>]
+[<SqlHydraFunction>]
 module SqlFunctions =
 
     /// A stub used to define SQL function wrappers: the wrapper's name and arguments are
@@ -230,6 +239,6 @@ module SqlFunctions =
     let sqlFn<'Return> : 'Return =
         raise (SqlFunctionNotRenderedException(
             "A SqlHydra `sqlFn` function was executed instead of being rendered as SQL. \
-             In a `where` or `on'` predicate, a wrapper declared outside SqlHydra.Query must \
-             be marked `[<SqlHydraFunction>]`. Outside a query expression a `sqlFn` wrapper \
-             has no runtime meaning and cannot be called."))
+             In a `where` or `on'` predicate, a wrapper must be marked `[<SqlHydraFunction>]`, \
+             on the function or on the module or type holding it. Outside a query expression a \
+             `sqlFn` wrapper has no runtime meaning and cannot be called."))

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -142,6 +142,30 @@ module RawExpressions =
     /// Example: caseWhen (col > 0) (inlineValue "yes") (inlineValue "no")
     let inlineValue<'T> (_value: 'T) : 'T = Unchecked.defaultof<'T>
 
+/// Marks `sqlFn` wrappers declared outside SqlHydra.Query as SQL functions, so that a `where`
+/// or `on'` predicate renders the call as SQL instead of computing it as a .NET value.
+/// Apply it to one function, or to the module or type holding a group of them: everything
+/// declared inside a marked module or type qualifies, nesting included, so keep ordinary
+/// helpers out of one.
+/// Unmarked wrappers still work in `select` and `orderBy`, which render every call; in a
+/// predicate they raise `SqlFunctionNotRenderedException` rather than compare against a stub.
+///
+/// Example:
+///   [<SqlHydraFunction>]
+///   module SqlFn =
+///       let SOUNDEX (s: string) : string = sqlFn
+///       let DIFFERENCE (s1: string, s2: string) : int = sqlFn
+[<System.AttributeUsage(System.AttributeTargets.Method ||| System.AttributeTargets.Class)>]
+type SqlHydraFunctionAttribute() =
+    inherit System.Attribute()
+
+/// Raised when a `sqlFn` wrapper is executed as ordinary .NET code instead of being rendered
+/// as SQL: either it was called outside a query expression, or it is used in a `where`/`on'`
+/// predicate without `[<SqlHydraFunction>]`, so the visitor took it for a value to compute.
+type SqlFunctionNotRenderedException(message: string, inner: exn) =
+    inherit System.InvalidOperationException(message, inner)
+    new (message: string) = SqlFunctionNotRenderedException(message, null)
+
 /// Assembly-level attribute that registers a SQL function name as an infix operator.
 /// Extension packages (e.g. SqlHydra.Query.Pgvector) apply this attribute on themselves and
 /// SqlHydra discovers it the first time a query is compiled. No explicit registration call required.
@@ -192,9 +216,20 @@ module InfixOperators =
 [<AutoOpen>]
 module SqlFunctions =
 
-    /// A stub value used to define SQL function wrappers.
-    /// The function name and arguments are translated directly to SQL.
+    /// A stub used to define SQL function wrappers: the wrapper's name and arguments are
+    /// translated directly to SQL, and its body never runs.
     /// Example:
+    ///   [<SqlHydraFunction>]
     ///   let LEN (s: string) : int = sqlFn
+    ///   [<SqlHydraFunction>]
     ///   let SUBSTRING (s: string, start: int, length: int) : string = sqlFn
-    let sqlFn<'Return> : 'Return = Unchecked.defaultof<'Return>
+    ///
+    /// Raises if it is ever actually executed, which means the call was not rendered. Handing
+    /// back `Unchecked.defaultof` instead is what let `where (col = SOUNDEX "Smith")` compile,
+    /// run, and quietly mean `col IS NULL`.
+    let sqlFn<'Return> : 'Return =
+        raise (SqlFunctionNotRenderedException(
+            "A SqlHydra `sqlFn` function was executed instead of being rendered as SQL. \
+             In a `where` or `on'` predicate, a wrapper declared outside SqlHydra.Query must \
+             be marked `[<SqlHydraFunction>]`. Outside a query expression a `sqlFn` wrapper \
+             has no runtime meaning and cannot be called."))

--- a/src/SqlHydra.Query/SqlServerExtensions.fs
+++ b/src/SqlHydra.Query/SqlServerExtensions.fs
@@ -4,6 +4,7 @@ open System
 
 /// Common SQL Server functions for use in select expressions.
 /// Use `open type SqlFn` to access functions without qualification.
+[<SqlHydraFunction>]
 type SqlFn =
     // String functions
     static member LEN(s: string) : int = sqlFn

--- a/src/SqlHydra.Query/SqliteExtensions.fs
+++ b/src/SqlHydra.Query/SqliteExtensions.fs
@@ -4,6 +4,7 @@ open System
 
 /// Common SQLite functions for use in select expressions.
 /// Use `open type SqlFn` to access functions without qualification.
+[<SqlHydraFunction>]
 type SqlFn =
     // String functions
     static member length(s: string) : int = sqlFn

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1343,6 +1343,54 @@ let ``a captured .NET value is still bound as a parameter``() =
     test <@ not (sql.Contains("UPPER")) @>
 
 [<Test>]
+let ``a SQL function can be used in a join predicate``() =
+    // Same defect as the where clause, one function over: `visitJoinPredicate` also
+    // compile-and-evaluates the other side, so this threw NotImplementedException
+    // "Unable to render join predicate RHS".
+    let sql =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (a.city = SqlFn.lower a2.city)
+            select a
+        }
+        |> toSql
+    test <@ sql.Contains("ON (a.city = LOWER(a2.city))") @>
+
+[<Test>]
+let ``a SQL function on the left of a join predicate``() =
+    let sql =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (SqlFn.lower a.city = a2.city)
+            select a
+        }
+        |> toSql
+    test <@ sql.Contains("ON (LOWER(a.city) = a2.city)") @>
+
+[<Test>]
+let ``a SQL function compared to a value in a join predicate``() =
+    let sql =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (SqlFn.lower a2.city = "dallas")
+            select a
+        }
+        |> toSql
+    test <@ sql.Contains("ON (LOWER(a2.city) = @p0)") @>
+
+[<Test>]
+let ``two SQL functions compared in a join predicate``() =
+    // The natural case-insensitive join, and the shape most likely to be reached for.
+    let sql =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (SqlFn.lower a.city = SqlFn.lower a2.city)
+            select a
+        }
+        |> toSql
+    test <@ sql.Contains("ON (LOWER(a.city) = LOWER(a2.city))") @>
+
+[<Test>]
 let ``a captured .NET value on the left is still bound as a parameter``() =
     // Mirror of the above, covering the other guarded arm.
     let name = "dallas"

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -30,6 +30,9 @@ let SOUNDEX (s: string) : string = sqlFn
 /// The same wrapper with the marker left off: what a user gets when they forget it.
 let UNMARKED_SOUNDEX (s: string) : string = sqlFn
 
+/// An ordinary .NET function: must be evaluated, never rendered.
+let plainDotNetHelper () = "Dallas"
+
 /// Generic, because the call the visitor sees is then a constructed method rather than the
 /// one the attribute was written on — and the marker has to survive that.
 [<SqlHydraFunction>]
@@ -1689,3 +1692,32 @@ let ``every sqlFn wrapper shipped in SqlHydra.Query carries the marker``() =
         |> Seq.map (fun mi -> $"{mi.DeclaringType.FullName}.{mi.Name}")
         |> Seq.distinct |> Seq.sort |> Seq.toList
     test <@ unmarked = [] @>
+
+// Three `visitWhere` arms commented "SQL function ..." never checked whether the call was one,
+// so `myHelper()` went to the database as `MYHELPER()`. `on'` guarded all five of its
+// equivalents all along.
+
+[<Test>]
+let ``an ordinary .NET call on the left of a where is evaluated, not rendered``() =
+    let build () =
+        select {
+            for a in person.address do
+            where (plainDotNetHelper () = "Dallas")
+        }
+        |> toSql
+        |> ignore
+    // "Value to value" is the proof that both sides were evaluated rather than rendered.
+    let ex = Assert.Throws<NotImplementedException>(fun () -> build ())
+    test <@ ex.Message.Contains("Value to value") @>
+
+[<Test>]
+let ``two ordinary .NET calls in a where are evaluated, not rendered``() =
+    let build () =
+        select {
+            for a in person.address do
+            where (plainDotNetHelper () = plainDotNetHelper ())
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<NotImplementedException>(fun () -> build ())
+    test <@ ex.Message.Contains("Value to value") @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1600,3 +1600,56 @@ let ``a marked type covers its static members``() =
         }
         |> toSql
     test <@ sql.Contains("ASCII(a.city)") @>
+
+// A member access over a wrapper is the one shape `NValue` doesn't match, so it reaches the
+// fall-through arms with the stub intact. Four: two clauses x two operand orders.
+
+[<Test>]
+let ``a swallowed wrapper failure still names the marker (where, function on the right)``() =
+    let build () =
+        select {
+            for a in person.address do
+            where (a.addressid = (UNMARKED_SOUNDEX "Smith").Length)
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>
+
+[<Test>]
+let ``a swallowed wrapper failure still names the marker (where, function on the left)``() =
+    let build () =
+        select {
+            for a in person.address do
+            where ((UNMARKED_SOUNDEX "Smith").Length = a.addressid)
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>
+
+[<Test>]
+let ``a swallowed wrapper failure still names the marker (on', function on the right)``() =
+    let build () =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (a2.addressid = (UNMARKED_SOUNDEX "Smith").Length)
+            select a
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>
+
+[<Test>]
+let ``a swallowed wrapper failure still names the marker (on', function on the left)``() =
+    let build () =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' ((UNMARKED_SOUNDEX "Smith").Length = a2.addressid)
+            select a
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1282,3 +1282,75 @@ let ``inlineValue beside another SQL function is a value, not a database call``(
         |> toSql
     test <@ sql.Contains("(LOWER(a.city) = 'smith')") @>
     test <@ not (sql.Contains("INLINEVALUE")) @>
+
+[<Test>]
+let ``a where on a value does not silently become a NULL check``() =
+    // The worst of the three, because nothing fails: this emitted `city IS NULL`, so the
+    // query ran happily and returned every row whose city is unset -- never the row asked
+    // for. The fall-through compile-and-evaluated the marker, whose body is a stub, so the
+    // comparison value came back null and `= null` was folded into `IS NULL`.
+    let captured = "Dallas"
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = inlineValue captured)
+        }
+        |> toSql
+    // The whole predicate, not just the literal: rendering the marker itself as a
+    // function (`INLINEVALUE('Dallas')`) would satisfy any looser assertion.
+    test <@ sql.Contains("(a.city = 'Dallas')") @>
+    test <@ not (sql.Contains("IS NULL")) @>
+    test <@ not (sql.Contains("@p")) @>
+
+[<Test>]
+let ``a where against a raw SQL expression does not silently become a NULL check``() =
+    // Same silent failure as above, reached through `rawExpr` instead of `inlineValue`.
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = rawExpr<string> "'Dallas'")
+        }
+        |> toSql
+    test <@ sql.Contains("(a.city = 'Dallas')") @>
+    test <@ not (sql.Contains("RAWEXPR")) @>
+    test <@ not (sql.Contains("IS NULL")) @>
+
+[<Test>]
+let ``a SQL function can be compared against a column``() =
+    // Not silently wrong, just impossible: this shape threw NotImplementedException
+    // "Unable to evaluate where LHS", because the fall-through tried to compute
+    // `LOWER(a.city)` as a .NET value and there is no row to compute it against.
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.lower a.city = a.addressline1)
+        }
+        |> toSql
+    test <@ sql.Contains("(LOWER(a.city) = a.addressline1)") @>
+
+[<Test>]
+let ``a captured .NET value is still bound as a parameter``() =
+    // Not a bug fix -- this guards the two arms above. `name.ToUpperInvariant()` is a real
+    // call with a real result, so it must be computed and bound, never rendered as SQL.
+    let name = "dallas"
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = name.ToUpperInvariant())
+        }
+        |> toSql
+    test <@ sql.Contains("(\"a\".\"city\" = @p0)") @>
+    test <@ not (sql.Contains("UPPER")) @>
+
+[<Test>]
+let ``a captured .NET value on the left is still bound as a parameter``() =
+    // Mirror of the above, covering the other guarded arm.
+    let name = "dallas"
+    let sql =
+        select {
+            for a in person.address do
+            where (name.ToUpperInvariant() = a.city)
+        }
+        |> toSql
+    test <@ sql.Contains("(\"a\".\"city\" = @p0)") @>
+    test <@ not (sql.Contains("UPPER")) @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1653,3 +1653,39 @@ let ``a swallowed wrapper failure still names the marker (on', function on the l
         |> ignore
     let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
     test <@ ex.Message.Contains("SqlHydraFunction") @>
+
+[<Test>]
+let ``every sqlFn wrapper shipped in SqlHydra.Query carries the marker``() =
+    // A provider module added without the marker would go unrecognized, and `isIn`-style
+    // functions would be evaluated rather than rendered. IL reading is fine as a test oracle:
+    // build time, our own assembly, decides nothing at query time.
+    let flags =
+        System.Reflection.BindingFlags.Public ||| System.Reflection.BindingFlags.NonPublic
+        ||| System.Reflection.BindingFlags.Static ||| System.Reflection.BindingFlags.Instance
+        ||| System.Reflection.BindingFlags.DeclaredOnly
+    let callsSqlFn (mi: System.Reflection.MethodInfo) =
+        try
+            match mi.GetMethodBody() with
+            | null -> false
+            | body ->
+                match body.GetILAsByteArray() with
+                | null -> false
+                | il ->
+                    [ 0 .. il.Length - 5 ]
+                    |> List.exists (fun i ->
+                        il.[i] = 0x28uy
+                        && (try
+                                let t = mi.Module.ResolveMethod(BitConverter.ToInt32(il, i + 1))
+                                t.Name = "sqlFn"
+                                && t.DeclaringType <> null
+                                && t.DeclaringType.FullName = "SqlHydra.Query.SqlFunctions"
+                            with _ -> false))
+        with _ -> false
+    let unmarked =
+        typeof<SqlHydraFunctionAttribute>.Assembly.GetTypes()
+        |> Seq.collect (fun t -> t.GetMethods(flags))
+        |> Seq.filter callsSqlFn
+        |> Seq.filter (fun mi -> not (SqlHydra.Query.LinqExpressionVisitors.isSqlHydraFunction mi))
+        |> Seq.map (fun mi -> $"{mi.DeclaringType.FullName}.{mi.Name}")
+        |> Seq.distinct |> Seq.sort |> Seq.toList
+    test <@ unmarked = [] @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1239,3 +1239,31 @@ let ``inlineValue emits a SQL literal not a parameter``() =
         |> toSql
     sql.Contains("'yes'") =! true
     sql.Contains("@p") =! false
+
+[<Test>]
+let ``a value containing an apostrophe produces a runnable statement``() =
+    // The bug: `inlineValue "O'Brien"` rendered as 'O'Brien'. The apostrophe closes the
+    // literal and Postgres parses what follows as SQL, so the query never runs --
+    //   ERROR:  syntax error at or near "Brien"
+    // A value is data; it must not be able to change the shape of the statement.
+    let captured = "O'Brien"
+    let sql =
+        select {
+            for p in production.product do
+            select (caseWhen (p.standardcost > 100m) (inlineValue captured) "no")
+        }
+        |> toSql
+    test <@ sql.Contains("'O''Brien'") @>
+
+[<Test>]
+let ``an interval built from a runtime string escapes quotes``() =
+    // `interval` takes an arbitrary string, so the value can carry an apostrophe and close
+    // the literal the same way -- it is the one literal site not fed by a constant.
+    let span = "7 days'"
+    let sql =
+        select {
+            for p in production.product do
+            select (PgSqlFn.interval span)
+        }
+        |> toSql
+    test <@ sql.Contains("INTERVAL '7 days'''") @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1267,3 +1267,18 @@ let ``an interval built from a runtime string escapes quotes``() =
         }
         |> toSql
     test <@ sql.Contains("INTERVAL '7 days'''") @>
+
+[<Test>]
+let ``inlineValue beside another SQL function is a value, not a database call``() =
+    // The bug: this emitted `LOWER(a.city) = INLINEVALUE('smith')`, so Postgres looked for
+    // a function that does not exist and the query never ran --
+    //   ERROR:  function inlinevalue(unknown) does not exist
+    // `inlineValue` is a compile-time marker; it must never survive into the SQL.
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.lower a.city = inlineValue "smith")
+        }
+        |> toSql
+    test <@ sql.Contains("(LOWER(a.city) = 'smith')") @>
+    test <@ not (sql.Contains("INLINEVALUE")) @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -22,6 +22,39 @@ open Npgsql.AdventureWorksNet10
 [<assembly: SqlHydra.Query.SqlHydraInfixOperator("cover_autodist", "<~>")>]
 do ()
 
+// Declared HERE, in the test assembly — not inside SqlHydra.Query — so these exercise the
+// real external path: `where` knows them only by the marker they carry.
+[<SqlHydraFunction>]
+let SOUNDEX (s: string) : string = sqlFn
+
+/// The same wrapper with the marker left off: what a user gets when they forget it.
+let UNMARKED_SOUNDEX (s: string) : string = sqlFn
+
+/// Generic, because the call the visitor sees is then a constructed method rather than the
+/// one the attribute was written on — and the marker has to survive that.
+[<SqlHydraFunction>]
+let NULLIF<'T> (a: 'T, b: 'T) : 'T = sqlFn
+
+type ExtFn =
+    /// Case folding over a NULLABLE column — the overload SqlHydra itself does not ship.
+    [<SqlHydraFunction>]
+    static member lower(s: string option) : string = sqlFn
+
+/// One marker for a whole group, which is the shape wrappers actually get written in.
+/// Nothing inside repeats it.
+[<SqlHydraFunction>]
+module Grouped =
+    let DIFFERENCE (a: string, b: string) : int = sqlFn
+
+    /// Nested and unmarked itself: a marked module covers what is declared inside it.
+    module Text =
+        let INITCAP (s: string) : string = sqlFn
+
+/// The same, on a type of static members — how SqlHydra's own provider files are laid out.
+[<SqlHydraFunction>]
+type GroupedFn =
+    static member ASCII(s: string) : int = sqlFn
+
 [<Test>]
 let ``Simple Where``() =
     let sql =  
@@ -1402,3 +1435,168 @@ let ``a captured .NET value on the left is still bound as a parameter``() =
         |> toSql
     test <@ sql.Contains("(\"a\".\"city\" = @p0)") @>
     test <@ not (sql.Contains("UPPER")) @>
+
+[<Test>]
+let ``a user-defined SQL function can be used in a where``() =
+    // The bug: a `sqlFn` wrapper declared outside SqlHydra.Query threw
+    // NotImplementedException "Unable to evaluate query parameter expression", because
+    // `where` tried to compute it as a .NET value. It worked in `select` all along.
+    let sql =
+        select {
+            for a in person.address do
+            where (ExtFn.lower a.addressline2 = "dallas")
+        }
+        |> toSql
+    test <@ sql.Contains("(LOWER(a.addressline2) = @p0)") @>
+
+[<Test>]
+let ``the README's custom-function example runs``() =
+    // The example the README tells people to write, verbatim:
+    //   where (SOUNDEX(p.LastName) = SOUNDEX("Smith"))
+    // It threw "Unable to evaluate query parameter expression", so the documented feature
+    // did not work in the clause the documentation demonstrates it in.
+    let sql =
+        select {
+            for a in person.address do
+            where (SOUNDEX(a.city) = SOUNDEX("Smith"))
+        }
+        |> toSql
+    test <@ sql.Contains("(SOUNDEX(a.city) = SOUNDEX('Smith'))") @>
+
+[<Test>]
+let ``a user-defined SQL function over constants does not silently become a NULL check``() =
+    // The dangerous shape. With no column argument there is nothing to make evaluation fail,
+    // so the wrapper evaluated to the stub's null and the predicate became `city IS NULL`:
+    // the query ran and returned the wrong rows, with nothing to notice.
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = SOUNDEX "Smith")
+        }
+        |> toSql
+    test <@ sql.Contains("(a.city = SOUNDEX('Smith'))") @>
+    test <@ not (sql.Contains("IS NULL")) @>
+
+[<Test>]
+let ``a generic user-defined SQL function is recognized in a where``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (NULLIF(a.city, "Dallas") = "Seattle")
+        }
+        |> toSql
+    test <@ sql.Contains("NULLIF(a.city, 'Dallas')") @>
+
+[<Test>]
+let ``an unmarked SQL function over constants raises instead of emitting IS NULL``() =
+    // The regression that matters: `UNMARKED_SOUNDEX "Smith"` is not recognized as SQL, so the
+    // visitor computes it — and the stub raises rather than handing back the null that used to
+    // turn this predicate into `city IS NULL`. Loud beats a query that runs and lies.
+    let build () =
+        select {
+            for a in person.address do
+            where (a.city = UNMARKED_SOUNDEX "Smith")
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>
+    test <@ ex.Message.Contains("UNMARKED_SOUNDEX") @>
+
+[<Test>]
+let ``an unmarked SQL function over a column names the marker it is missing``() =
+    // With a column argument the expression cannot be compiled at all, so this shape fails
+    // before the stub runs and keeps the older NotImplementedException. It was always loud;
+    // what it lacked was any hint of what to do, which is the half worth fixing.
+    let build () =
+        select {
+            for a in person.address do
+            where (UNMARKED_SOUNDEX a.city = "Smith")
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<NotImplementedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>
+    test <@ ex.Message.Contains("UNMARKED_SOUNDEX") @>
+
+[<Test>]
+let ``an unmarked SQL function in an on' predicate raises instead of emitting IS NULL``() =
+    // `on'` reads the same marker as `where`, so it has the same silent shape to protect
+    // against: a wrapper over constants used to join on `city IS NULL`.
+    let build () =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (a2.city = UNMARKED_SOUNDEX "Smith")
+            select a
+        }
+        |> toSql
+        |> ignore
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> build ())
+    test <@ ex.Message.Contains("SqlHydraFunction") @>
+
+[<Test>]
+let ``calling a SQL function wrapper outside a query raises``() =
+    // `sqlFn` has no runtime meaning at all. It used to return null here.
+    let ex = Assert.Throws<SqlFunctionNotRenderedException>(fun () -> SOUNDEX "Smith" |> ignore)
+    test <@ ex.Message.Contains("rendered as SQL") @>
+
+[<Test>]
+let ``an unmarked SQL function still renders in a select and an orderBy``() =
+    // The marker is only needed where a predicate has to choose between rendering and
+    // evaluating. `select` and `orderBy` render every call, and did so before this change:
+    // no one's existing projection starts throwing because they never applied an attribute.
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = "Dallas")
+            orderBy (UNMARKED_SOUNDEX a.city)
+            select (UNMARKED_SOUNDEX a.city)
+        }
+        |> toSql
+    test <@ sql.Contains("SELECT UNMARKED_SOUNDEX(\"a\".\"city\")") @>
+    test <@ sql.Contains("ORDER BY UNMARKED_SOUNDEX(\"a\".\"city\")") @>
+
+[<Test>]
+let ``a user-defined SQL function can be used in an on' join predicate``() =
+    // `on'` consults the same marker as `where`, so a user-defined wrapper reaches the
+    // rendering arms there too — the case-insensitive join, spelled with your own function.
+    let sql =
+        select {
+            for a in person.address do
+            join' a2 in person.address; on' (SOUNDEX a.city = SOUNDEX a2.city)
+            select a
+        }
+        |> toSql
+    test <@ sql.Contains("ON (SOUNDEX(a.city) = SOUNDEX(a2.city))") @>
+
+[<Test>]
+let ``a marked module covers the wrappers declared in it``() =
+    // The reason the marker is worth having: wrappers come in groups, so it costs one
+    // attribute for the group rather than one per function.
+    let sql =
+        select {
+            for a in person.address do
+            where (Grouped.DIFFERENCE(a.city, "Dallas") = 4)
+        }
+        |> toSql
+    test <@ sql.Contains("DIFFERENCE(a.city, 'Dallas')") @>
+
+[<Test>]
+let ``a marked module covers nested modules``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (Grouped.Text.INITCAP a.city = "Dallas")
+        }
+        |> toSql
+    test <@ sql.Contains("INITCAP(a.city)") @>
+
+[<Test>]
+let ``a marked type covers its static members``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (GroupedFn.ASCII a.city = 68)
+        }
+        |> toSql
+    test <@ sql.Contains("ASCII(a.city)") @>


### PR DESCRIPTION
a handful of small fixes to get latests sqlhydra working with my project. Again thank you for the great library! Reviewing this commit-by-commit is probably best (and even, just pulling out commits if you want, they are all ~ kind of unrelated). 

also built on top of #148 so I could be sure test failures here weren't real. Either merge this, or that one first, or neither, whatever.

---

Five defects in how `where`/`on'` handle function calls. Most produce SQL the database
rejects; (3) produces SQL it accepts and answers wrongly.

**1. An apostrophe corrupts the statement.**
```fsharp
where (a.city = inlineValue "O'Brien")   // = 'O'Brien'  →  syntax error at or near "Brien"
```
Three places quoted strings without escaping. Now one helper — including enum names and
`INTERVAL '…'`, whose value is a runtime string.

**2. `inlineValue` renders as a function call.**
```fsharp
where (lower a.city = inlineValue "smith")   // LOWER(a.city) = INLINEVALUE('smith')
                                             //  →  function inlinevalue(unknown) does not exist
```
The marker was unwrapped only when nested in a function argument, not when compared to one.

**3. A `where` on a value silently becomes `IS NULL`.**
```fsharp
where (a.city = inlineValue captured)   // WHERE (a.city IS NULL)
```
Nothing fails; it returns every row where the column is unset. Same via `rawExpr`. Two
fall-throughs sat above the column-vs-function arms and compile-and-evaluate the other
side — a stub body evaluates to null, and `= null` folds to `IS NULL`. Fall-throughs moved
below; the arms are guarded on actually being a SqlHydra function, so ordinary .NET calls
still evaluate (verified byte-identical, both operand positions).

**4. Functions throw in join predicates.**
```fsharp
on' (lower a.city = lower a2.city)   // Unsupported join predicate comparison
```
`on'` now covers what `where` covers: function vs column, vs value, vs function.
Predicate-style joins only — LINQ-style `join … on` holds column references, with nowhere
to put an expression.

**5. User-defined functions can't be used in a `where`.** The README's own example throws:
```fsharp
let SOUNDEX (s: string) : string = sqlFn
where (SOUNDEX(p.LastName) = SOUNDEX("Smith"))   // Unable to evaluate query parameter expression
```
Fine in `select`/`orderBy` — `where` decides what's a SQL function by declaring assembly.
With no column argument, defect 3 returns (`col IS NULL`).

Detected structurally instead: a `sqlFn` wrapper's body does nothing but return the stub,
so its IL calls `SqlFunctions.sqlFn`. Cached per method. No new API, nothing to opt into —
I tried an attribute first, but a marker is what you forget on the one function where
forgetting it brings `IS NULL` back. Release `Optimize=true` doesn't inline the stub away.
No README change needed — the example above now does what it documents.

Related: #145 works around under-typed built-ins by defining its own overload — which
works in `select` but throws in a `where`, so (5) is what makes that advice hold. #43's
scalar-UDF half becomes usable too (TVFs are a separate feature). Neither is fully closed
by this.