### PR TITLE
Let `select` hand back a state an extension operation can require

### DIFF
--- a/src/SqlHydra.Query/Core.fs
+++ b/src/SqlHydra.Query/Core.fs
@@ -147,6 +147,28 @@ type QuerySource<'T, 'Query>(query, tableMappings) =
     inherit QuerySource<'T>(tableMappings)
     member this.Query : 'Query = query
 
+/// The state a `select` leaves behind. It carries nothing `QuerySource<'T, SelectQueryIR>`
+/// does not, and every existing operation still accepts it, so queries read and run exactly
+/// as before. What it adds is a name a signature can ask for.
+///
+/// A custom operation that expands what `select` emitted — an extension projecting a system
+/// column onto the `SELECT alias.*` of a whole-entity select, say — means nothing before a
+/// projection exists. Taking `SelectedQuerySource<'T>` instead of `QuerySource<'T, SelectQueryIR>`
+/// says so in the type, and misplacement stops compiling rather than raising at
+/// query-construction time:
+///
+///     [<CustomOperation("withSystemColumns", MaintainsVariableSpace = true)>]
+///     member _.WithSystemColumns
+///         (state: SelectedQuerySource<'T>,
+///          [<ProjectionParameter>] columnSelector: Expression<Func<'T, 'Prop>>) = ...
+///
+/// The row type does the rest: after `select u.email` the state is `SelectedQuerySource<string>`,
+/// so a `u.xmin` selector fails to typecheck on its own. Note that the operations following a
+/// select return a plain `QuerySource`, so an operation constrained this way must come directly
+/// after `select`.
+type SelectedQuerySource<'T>(query, tableMappings) =
+    inherit QuerySource<'T, SelectQueryIR>(query, tableMappings)
+
 /// The type of join for predicate-style joins
 type JoinType =
     | Inner

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -224,7 +224,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
                     failwith "SelectedAs may only wrap SelectedColumn / SelectedExpression / SelectedExpressionWithParams"
             ) state.Query
 
-        QuerySource<'Selected, SelectQueryIR>(irWithSelectedColumns, state.TableMappings)
+        SelectedQuerySource<'Selected>(irWithSelectedColumns, state.TableMappings)
 
     /// Sets the ORDER BY for single column
     [<CustomOperation("orderBy", MaintainsVariableSpace = true)>]
@@ -746,6 +746,16 @@ type SelectTaskBuilder<'Selected, 'Mapped> (ct: ContextType) =
             finally ContextUtils.disposeIfNotShared ct ctx
         }
 
+    /// Run: default, for the `SelectedQuerySource` a bare `select` now returns.
+    /// Load-bearing, not a convenience. The overloads above discriminate purely on the shape
+    /// of the type argument (`'Selected` vs `'Selected option` vs `'Mapped list` ...), which
+    /// only resolves while the argument type is exactly `QuerySource<_, SelectQueryIR>`. Handed
+    /// a subtype, `select c.someNullableColumn` becomes ambiguous between `'Selected` and
+    /// `'Mapped option` (FS0041) in ordinary user code. Matching the derived type exactly
+    /// restores the resolution, and every result modifier (`toList`, `tryHead`, `count`, ...)
+    /// returns a plain `QuerySource`, so a bare `select` is the only ending that lands here.
+    member this.Run(state: SelectedQuerySource<'Selected>) = this.RunSelected(state.Query, id)
+
 
 /// A select builder that returns an Async result.
 type SelectAsyncBuilder<'Selected, 'Mapped> (ct: ContextType) =
@@ -836,6 +846,16 @@ type SelectAsyncBuilder<'Selected, 'Mapped> (ct: ContextType) =
     // Run: head - 'Mapped
     member this.Run(state: QuerySource<ResultModifier.Head<'Mapped>, SelectQueryIR>) =
         this.RunMapped(state.Query, Seq.head)
+
+    /// Run: default, for the `SelectedQuerySource` a bare `select` now returns.
+    /// Load-bearing, not a convenience. The overloads above discriminate purely on the shape
+    /// of the type argument (`'Selected` vs `'Selected option` vs `'Mapped list` ...), which
+    /// only resolves while the argument type is exactly `QuerySource<_, SelectQueryIR>`. Handed
+    /// a subtype, `select c.someNullableColumn` becomes ambiguous between `'Selected` and
+    /// `'Mapped option` (FS0041) in ordinary user code. Matching the derived type exactly
+    /// restores the resolution, and every result modifier (`toList`, `tryHead`, `count`, ...)
+    /// returns a plain `QuerySource`, so a bare `select` is the only ending that lands here.
+    member this.Run(state: SelectedQuerySource<'Selected>) = this.RunSelected(state.Query, id)
 
     // Run: count
     member this.Run(state: QuerySource<ResultModifier.Count<int>, SelectQueryIR>) =

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1721,3 +1721,68 @@ let ``two ordinary .NET calls in a where are evaluated, not rendered``() =
         |> ignore
     let ex = Assert.Throws<NotImplementedException>(fun () -> build ())
     test <@ ex.Message.Contains("Value to value") @>
+
+// `select` leaves a `SelectedQuerySource<'T>` behind, which is what lets an extension whose
+// operation only means something after a projection say so in its own signature. Declared HERE,
+// in the test assembly, so this is the path an extension package actually takes.
+
+[<AutoOpen>]
+module SelectStateExtension =
+
+    type SqlHydra.Query.SelectBuilders.SelectBuilder<'Selected, 'Mapped> with
+
+        /// Expands the `SELECT alias.*` that a whole-entity select emits with one more column
+        /// of the same table -- the shape a system-column or computed-column package needs.
+        /// Taking `SelectedQuerySource<'T>` rather than `QuerySource<'T, SelectQueryIR>` is the
+        /// whole point: there is no projection to expand before `select`, and now saying so is
+        /// the compiler's job rather than a `failwith` at query-construction time.
+        [<CustomOperation("withExtraColumn", MaintainsVariableSpace = true)>]
+        member _.WithExtraColumn
+            (
+                state: SelectedQuerySource<'T>,
+                [<ProjectionParameter>] columnSelector: Expression<Func<'T, 'Prop>>
+            ) : SelectedQuerySource<'T> =
+            match SelectBuilders.ExtensionHelpers.tryGetOrderByColumn columnSelector with
+            | Some (tableAlias, column) ->
+                let expanded =
+                    state.Query.Select
+                    |> List.collect (function
+                        | SelectColumn.AllColumns alias when alias = tableAlias ->
+                            [ SelectColumn.AllColumns alias
+                              SelectColumn.SpecificColumn $"%s{alias}.%s{column}" ]
+                        | c -> [ c ])
+                SelectedQuerySource<'T>({ state.Query with Select = expanded }, state.TableMappings)
+            | None -> failwith "withExtraColumn expects a single column, as in `withExtraColumn a.rowguid`."
+
+[<Test>]
+let ``an extension operation constrained to the select state expands the whole-entity projection``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = "Dallas")
+            select a
+            withExtraColumn a.rowguid
+        }
+        |> toSql
+    test <@ sql.Contains("\"a\".*, \"a\".\"rowguid\"") @>
+
+[<Test>]
+let ``select returns the state type an extension can require``() =
+    // The seam itself. `withExtraColumn` above compiles only because `Select` returns this;
+    // placed before `select` it does not compile at all, which is the point of the change.
+    let selectOp = typeof<SelectBuilder<obj, obj>>.GetMethod("Select")
+    test <@ selectOp.ReturnType.GetGenericTypeDefinition() = typedefof<SelectedQuerySource<_>> @>
+
+[<Test>]
+let ``a bare select of a nullable column still resolves to the seq Run overload``() =
+    // Regression guard for the mirrored `Run` overloads, and the reason they exist. The `Run`
+    // set discriminates on the shape of the type argument, which only resolves while the
+    // argument is exactly `QuerySource<_, SelectQueryIR>`; handed a subtype, this ordinary
+    // query goes ambiguous between `'Selected` and `'Mapped option` (FS0041).
+    // Never executed -- there is no database here. Type-checking is the assertion.
+    let build (db: ContextType) : System.Threading.Tasks.Task<seq<string option>> =
+        selectTask db {
+            for a in person.address do
+            select a.addressline2
+        }
+    test <@ box build <> null @>


### PR DESCRIPTION
**Closed — this doesn't work. Writing up why, for anyone who finds it later.**

**What I hoped to get:** turn a runtime error into a compile error.

A custom operation in an extension package gets `QuerySource<'T, SelectQueryIR>` — the same state every operation gets. So if it only makes sense after `select`, it can't say so, and has to check at runtime:

```fsharp
withSystemColumns u.xmin   // before `select` — builds, then throws
select u
```

The attempt: have `select` return `SelectedQuerySource<'T>`, a state an extension can require.

**Why it doesn't work:** the type can only say *"you come right after `select`"*. The real rule is *"the query selects whole rows"*. Not the same thing:

```fsharp
select u
orderBy u.email
withSystemColumns u.xmin   // valid — but this would reject it
```

`orderBy` hands back the ordinary state, so the marker is lost.

It also broke ordinary queries — `select c.ADDRESS` on a nullable column stopped compiling — until I added extra `Run` overloads to match. Any future `Run` overload would need the same treatment.

So it swaps a correct runtime check for an incorrect compile-time one, and changes `Select`'s return type to do it.
