### PR TITLE
Let a functional index on a nullable column actually be used

### DIFF
--- a/src/SqlHydra.Query/Core.fs
+++ b/src/SqlHydra.Query/Core.fs
@@ -192,7 +192,7 @@ module internal QueryUtils =
         | _ -> value
 
     /// Boxes values (and option values)
-    let private boxValueOrOption (value: obj) =
+    let boxValueOrOption (value: obj) =
         if isNull value then
             box System.DBNull.Value
         else

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -705,6 +705,13 @@ let nVisitSqlFn (qualifyColumn: string -> MemberInfo -> string) (nexp: Normalize
     | NMethodCall(m, _) -> visitSqlFn qualifyColumn (m :> Expression)
     | _ -> notImplMsg $"Expected NMethodCall for SQL function"
 
+/// `fn = Some x` binds x; `fn = None` is `fn IS NULL`, since `= NULL` never matches.
+let private compareSqlFnToValue (sqlFragment: string) (comparison: string) (op: ExpressionType) (value: obj) =
+    match QueryUtils.boxValueOrOption value with
+    | :? DBNull when op = ExpressionType.Equal -> RawWhere($"{sqlFragment} IS NULL", [||])
+    | :? DBNull when op = ExpressionType.NotEqual -> RawWhere($"{sqlFragment} IS NOT NULL", [||])
+    | v -> RawWhere($"{sqlFragment} {comparison} ?", [| v |])
+
 let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>>) (qualifyColumn: string -> MemberInfo -> string) : WhereClause =
     let (|NColumn|_|) (nexp: NormalizedExpression) =
         match nexp with
@@ -977,13 +984,12 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
             // SQL function compared to value
             | NMethodCall (m, _), NValue value when isSqlHydraFunction m.Method ->
                 let sqlFragment = nVisitSqlFn qualifyColumn left
-                RawWhere($"{sqlFragment} {comparison} ?", [| value |])
+                compareSqlFnToValue sqlFragment comparison op value
 
             // Value compared to SQL function
             | NValue value, NMethodCall (m, _) when isSqlHydraFunction m.Method ->
                 let sqlFragment = nVisitSqlFn qualifyColumn right
-                let reversedComparison = getReverseComparison op
-                RawWhere($"{sqlFragment} {reversedComparison} ?", [| value |])
+                compareSqlFnToValue sqlFragment (getReverseComparison op) op value
 
             // SQL function compared to column
             | NMethodCall (m, _), NColumn (p, _) when isSqlHydraFunction m.Method ->

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -12,6 +12,26 @@ type SqlFn =
     static member length(s: string) : int = sqlFn
     static member upper(s: string) : string = sqlFn
     static member lower(s: string) : string = sqlFn
+
+    // Case folding over a NULLABLE column. Without these, `lower col` does not
+    // typecheck for a `string option` column and callers are forced to write
+    // `lower (coalesce (col, ""))` — which emits `LOWER(COALESCE(col, ''))` and
+    // therefore CANNOT match a functional index on `LOWER(col)`. Postgres falls
+    // back to a seq scan.
+    //
+    // `LOWER(NULL)` is NULL, so `LOWER(col) = 'x'` is NULL (not true) for a NULL
+    // row: a NULL column never matches a real value. That is exactly the semantics
+    // the `coalesce` workaround was hand-rolling, but stated in a form the planner
+    // can match against the index.
+    //
+    // The return type is the unwrapped `string` (not `string option`), following the
+    // established `coalesce(a: Option<'T>, b: 'T) : 'T` convention below: these are
+    // phantom expression-shaping signatures, and `string` is what lets the result be
+    // compared to a plain `string` in a `where`. Projecting one into a select over
+    // NULL rows is the caller's responsibility (wrap in `coalesce` for that).
+    static member upper(s: string option) : string = sqlFn
+    static member lower(s: string option) : string = sqlFn
+
     static member ltrim(s: string) : string = sqlFn
     static member rtrim(s: string) : string = sqlFn
     static member btrim(s: string) : string = sqlFn

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -10,14 +10,11 @@ type SqlFn =
     static member char_length(s: string) : int = sqlFn
     static member character_length(s: string) : int = sqlFn
     static member length(s: string) : int = sqlFn
+    // `string option` overloads: `LOWER(COALESCE(col, ''))` cannot use an index on `LOWER(col)`.
     static member upper(s: string) : string = sqlFn
-    static member lower(s: string) : string = sqlFn
-
-    // A nullable column forces `lower (coalesce (col, ""))`, which emits
-    // `LOWER(COALESCE(col, ''))` and cannot match a functional index on `LOWER(col)`.
     static member upper(s: string option) : string = sqlFn
+    static member lower(s: string) : string = sqlFn
     static member lower(s: string option) : string = sqlFn
-
     static member ltrim(s: string) : string = sqlFn
     static member rtrim(s: string) : string = sqlFn
     static member btrim(s: string) : string = sqlFn

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -13,22 +13,8 @@ type SqlFn =
     static member upper(s: string) : string = sqlFn
     static member lower(s: string) : string = sqlFn
 
-    // Case folding over a NULLABLE column. Without these, `lower col` does not
-    // typecheck for a `string option` column and callers are forced to write
-    // `lower (coalesce (col, ""))` — which emits `LOWER(COALESCE(col, ''))` and
-    // therefore CANNOT match a functional index on `LOWER(col)`. Postgres falls
-    // back to a seq scan.
-    //
-    // `LOWER(NULL)` is NULL, so `LOWER(col) = 'x'` is NULL (not true) for a NULL
-    // row: a NULL column never matches a real value. That is exactly the semantics
-    // the `coalesce` workaround was hand-rolling, but stated in a form the planner
-    // can match against the index.
-    //
-    // The return type is the unwrapped `string` (not `string option`), following the
-    // established `coalesce(a: Option<'T>, b: 'T) : 'T` convention below: these are
-    // phantom expression-shaping signatures, and `string` is what lets the result be
-    // compared to a plain `string` in a `where`. Projecting one into a select over
-    // NULL rows is the caller's responsibility (wrap in `coalesce` for that).
+    // A nullable column forces `lower (coalesce (col, ""))`, which emits
+    // `LOWER(COALESCE(col, ''))` and cannot match a functional index on `LOWER(col)`.
     static member upper(s: string option) : string = sqlFn
     static member lower(s: string option) : string = sqlFn
 

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -6,34 +6,54 @@ open System
 /// Use `open type SqlFn` to access functions without qualification.
 [<SqlHydraFunction>]
 type SqlFn =
-    // String functions (PostgreSQL uses lowercase)
+    // String functions (PostgreSQL uses lowercase). Each NULL-propagating function has a
+    // `string option` twin returning an option, so `LOWER(col)` on a nullable column matches
+    // a functional index (`LOWER(COALESCE(col, ''))` does not) and NULL rows hydrate as None.
     static member char_length(s: string) : int = sqlFn
+    static member char_length(s: string option) : int option = sqlFn
     static member character_length(s: string) : int = sqlFn
+    static member character_length(s: string option) : int option = sqlFn
     static member length(s: string) : int = sqlFn
-    // `string option` overloads: `LOWER(COALESCE(col, ''))` cannot use an index on `LOWER(col)`.
+    static member length(s: string option) : int option = sqlFn
     static member upper(s: string) : string = sqlFn
-    static member upper(s: string option) : string = sqlFn
+    static member upper(s: string option) : string option = sqlFn
     static member lower(s: string) : string = sqlFn
-    static member lower(s: string option) : string = sqlFn
+    static member lower(s: string option) : string option = sqlFn
     static member ltrim(s: string) : string = sqlFn
+    static member ltrim(s: string option) : string option = sqlFn
     static member rtrim(s: string) : string = sqlFn
+    static member rtrim(s: string option) : string option = sqlFn
     static member btrim(s: string) : string = sqlFn
+    static member btrim(s: string option) : string option = sqlFn
     static member trim(s: string) : string = sqlFn
+    static member trim(s: string option) : string option = sqlFn
     static member substring(s: string, start: int, length: int) : string = sqlFn
+    static member substring(s: string option, start: int, length: int) : string option = sqlFn
     static member replace(s: string, from: string, ``to``: string) : string = sqlFn
+    static member replace(s: string option, from: string, ``to``: string) : string option = sqlFn
     static member position(substring: string, s: string) : int = sqlFn
+    static member position(substring: string, s: string option) : int option = sqlFn
     static member strpos(s: string, substring: string) : int = sqlFn
+    static member strpos(s: string option, substring: string) : int option = sqlFn
+    // concat / concat_ws ignore NULL arguments, so their results are never NULL: no twins.
     static member concat(s1: string, s2: string) : string = sqlFn
     static member concat(s1: string, s2: string, s3: string) : string = sqlFn
     static member concat_ws(separator: string, s1: string, s2: string) : string = sqlFn
     static member concat_ws(separator: string, s1: string, s2: string, s3: string) : string = sqlFn
     static member left(s: string, length: int) : string = sqlFn
+    static member left(s: string option, length: int) : string option = sqlFn
     static member right(s: string, length: int) : string = sqlFn
+    static member right(s: string option, length: int) : string option = sqlFn
     static member reverse(s: string) : string = sqlFn
+    static member reverse(s: string option) : string option = sqlFn
     static member repeat(s: string, count: int) : string = sqlFn
+    static member repeat(s: string option, count: int) : string option = sqlFn
     static member lpad(s: string, length: int, fill: string) : string = sqlFn
+    static member lpad(s: string option, length: int, fill: string) : string option = sqlFn
     static member rpad(s: string, length: int, fill: string) : string = sqlFn
+    static member rpad(s: string option, length: int, fill: string) : string option = sqlFn
     static member initcap(s: string) : string = sqlFn
+    static member initcap(s: string option) : string option = sqlFn
 
     // Null handling - with overloads for Option and Nullable
     static member coalesce(a: Option<'T>, b: 'T) : 'T = sqlFn

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -10,30 +10,43 @@ type SqlFn =
     // `string option` twin returning an option, so `LOWER(col)` on a nullable column matches
     // a functional index (`LOWER(COALESCE(col, ''))` does not) and NULL rows hydrate as None.
     static member char_length(s: string) : int = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member char_length(s: string option) : int option = sqlFn
     static member character_length(s: string) : int = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member character_length(s: string option) : int option = sqlFn
     static member length(s: string) : int = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member length(s: string option) : int option = sqlFn
     static member upper(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member upper(s: string option) : string option = sqlFn
     static member lower(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member lower(s: string option) : string option = sqlFn
     static member ltrim(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member ltrim(s: string option) : string option = sqlFn
     static member rtrim(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member rtrim(s: string option) : string option = sqlFn
     static member btrim(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member btrim(s: string option) : string option = sqlFn
     static member trim(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member trim(s: string option) : string option = sqlFn
     static member substring(s: string, start: int, length: int) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member substring(s: string option, start: int, length: int) : string option = sqlFn
     static member replace(s: string, from: string, ``to``: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member replace(s: string option, from: string, ``to``: string) : string option = sqlFn
     static member position(substring: string, s: string) : int = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member position(substring: string, s: string option) : int option = sqlFn
     static member strpos(s: string, substring: string) : int = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member strpos(s: string option, substring: string) : int option = sqlFn
     // concat / concat_ws ignore NULL arguments, so their results are never NULL: no twins.
     static member concat(s1: string, s2: string) : string = sqlFn
@@ -41,18 +54,25 @@ type SqlFn =
     static member concat_ws(separator: string, s1: string, s2: string) : string = sqlFn
     static member concat_ws(separator: string, s1: string, s2: string, s3: string) : string = sqlFn
     static member left(s: string, length: int) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member left(s: string option, length: int) : string option = sqlFn
     static member right(s: string, length: int) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member right(s: string option, length: int) : string option = sqlFn
     static member reverse(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member reverse(s: string option) : string option = sqlFn
     static member repeat(s: string, count: int) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member repeat(s: string option, count: int) : string option = sqlFn
     static member lpad(s: string, length: int, fill: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member lpad(s: string option, length: int, fill: string) : string option = sqlFn
     static member rpad(s: string, length: int, fill: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member rpad(s: string option, length: int, fill: string) : string option = sqlFn
     static member initcap(s: string) : string = sqlFn
+    /// NULL `s` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
     static member initcap(s: string option) : string option = sqlFn
 
     // Null handling - with overloads for Option and Nullable

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -802,54 +802,68 @@ let ``a functional index on a nullable column is usable through lower and unusab
     // Seq Scan then means the expression cannot match it.
     use! ctx = db.OpenContextAsync()
 
-    let run (sql: string) =
+    let exec (sql: string) =
         use cmd = ctx.Connection.CreateCommand()
         cmd.CommandText <- sql
-        cmd.ExecuteScalar() |> ignore
+        cmd.ExecuteNonQuery() |> ignore
 
-    let plan (sql: string) =
-        use cmd = ctx.Connection.CreateCommand()
-        cmd.CommandText <- $"EXPLAIN {sql}"
+    // EXPLAIN the SQL SqlHydra actually emits, not a hand-written equivalent.
+    let planOf (q: SelectQuery<_>) =
+        use cmd = ctx.BuildCommand(q.IR)
+        cmd.CommandText <- "EXPLAIN " + cmd.CommandText
         use reader = cmd.ExecuteReader()
         let mutable text = ""
         while reader.Read() do
             text <- text + reader.GetString(0) + "\n"
         text
 
-    run "CREATE INDEX IF NOT EXISTS test_address_lower_line2 ON person.address (LOWER(addressline2))"
+    exec "CREATE INDEX IF NOT EXISTS test_address_lower_line2 ON person.address (LOWER(addressline2))"
 
     try
-        run "SET enable_seqscan = off"
+        exec "SET enable_seqscan = off"
 
-        let viaLower =
-            plan "SELECT * FROM person.address WHERE LOWER(addressline2) = 'suite 100'"
+        let viaOverload =
+            planOf (
+                select {
+                    for a in person.address do
+                        where (SqlFn.lower a.addressline2 = "suite 100")
+                }
+            )
 
-        let viaCoalesce =
-            plan "SELECT * FROM person.address WHERE LOWER(COALESCE(addressline2, '')) = 'suite 100'"
+        let viaWorkaround =
+            planOf (
+                select {
+                    for a in person.address do
+                        where (SqlFn.lower (SqlFn.coalesce (a.addressline2, "")) = "suite 100")
+                }
+            )
 
-        viaLower.Contains "test_address_lower_line2" =! true
+        viaOverload.Contains "test_address_lower_line2" =! true
         // The control: without it, an index used by everything would pass too.
-        viaCoalesce.Contains "test_address_lower_line2" =! false
+        viaWorkaround.Contains "test_address_lower_line2" =! false
     finally
-        run "RESET enable_seqscan"
-        run "DROP INDEX IF EXISTS person.test_address_lower_line2"
+        exec "RESET enable_seqscan"
+        exec "DROP INDEX IF EXISTS person.test_address_lower_line2"
 }
 
 [<Test>]
 let ``lower over a nullable column leaves NULL rows out, where the coalesce workaround pulls them in``() = task {
     // A different answer, not just a different plan: COALESCE maps NULL to '', so every
     // NULL row matches a search for "".
-    use! ctx = db.OpenContextAsync()
+    let! viaOverload =
+        selectTask db {
+            for a in person.address do
+                where (SqlFn.lower a.addressline2 = "")
+        }
 
-    let count (sql: string) =
-        use cmd = ctx.Connection.CreateCommand()
-        cmd.CommandText <- sql
-        cmd.ExecuteScalar() :?> int64
+    let! viaWorkaround =
+        selectTask db {
+            for a in person.address do
+                where (SqlFn.lower (SqlFn.coalesce (a.addressline2, "")) = "")
+        }
 
-    let nulls = count "SELECT count(*) FROM person.address WHERE addressline2 IS NULL"
     // Without NULL rows both counts would be zero and this would prove nothing.
-    Assert.That(nulls, Is.GreaterThan 0L, "fixture has no NULL addressline2 rows to distinguish")
-
-    count "SELECT count(*) FROM person.address WHERE LOWER(addressline2) = ''" =! 0L
-    count "SELECT count(*) FROM person.address WHERE LOWER(COALESCE(addressline2, '')) = ''" =! nulls
+    Assert.That(Seq.length viaWorkaround, Is.GreaterThan 0, "fixture has no NULL addressline2 rows")
+    Seq.length viaOverload =! 0
+    viaWorkaround |> Seq.forall (fun a -> a.addressline2.IsNone) =! true
 }

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -795,19 +795,11 @@ let ``SqlFn - PostgreSQL functions smoke test``() = task {
     Assert.That(middleName, Is.Not.Null)
 }
 
-// ---------------------------------------------------------------------------
-// The two claims the `string option` case-folding overloads rest on, measured
-// against the server rather than asserted about the emitted SQL. The unit tests
-// pin that `LOWER(col)` is emitted and `COALESCE` is not; these pin that the
-// difference is the one that matters.
-// ---------------------------------------------------------------------------
 
 [<Test>]
 let ``a functional index on a nullable column is usable through lower and unusable through coalesce``() = task {
-    // `enable_seqscan = off` is what makes this a test of USABILITY rather than of the
-    // planner's cost preference: on a small table a sequential scan is cheaper and would
-    // be chosen even with a perfectly good index. With it off, the planner takes the
-    // index if it can — so a remaining Seq Scan means the expression cannot match it.
+    // `enable_seqscan = off` so the planner takes the index if it can: a remaining
+    // Seq Scan then means the expression cannot match it.
     use! ctx = db.OpenContextAsync()
 
     let run (sql: string) =
@@ -836,8 +828,7 @@ let ``a functional index on a nullable column is usable through lower and unusab
             plan "SELECT * FROM person.address WHERE LOWER(COALESCE(addressline2, '')) = 'suite 100'"
 
         viaLower.Contains "test_address_lower_line2" =! true
-        // The control. Without it this test would pass just as well if the index were
-        // used by everything, which would prove nothing about the overload.
+        // The control: without it, an index used by everything would pass too.
         viaCoalesce.Contains "test_address_lower_line2" =! false
     finally
         run "RESET enable_seqscan"
@@ -846,10 +837,8 @@ let ``a functional index on a nullable column is usable through lower and unusab
 
 [<Test>]
 let ``lower over a nullable column leaves NULL rows out, where the coalesce workaround pulls them in``() = task {
-    // Not merely a different plan — a different answer. `LOWER(NULL)` is NULL, so a NULL
-    // row matches nothing; `LOWER(COALESCE(col, ''))` maps NULL to the empty string, so
-    // every NULL row matches a search for "". The overload exists so callers get the
-    // former without hand-writing SQL.
+    // A different answer, not just a different plan: COALESCE maps NULL to '', so every
+    // NULL row matches a search for "".
     use! ctx = db.OpenContextAsync()
 
     let count (sql: string) =
@@ -858,8 +847,7 @@ let ``lower over a nullable column leaves NULL rows out, where the coalesce work
         cmd.ExecuteScalar() :?> int64
 
     let nulls = count "SELECT count(*) FROM person.address WHERE addressline2 IS NULL"
-    // Guards the assertions below against a fixture with no NULLs, where both would
-    // trivially return zero and the test would pass while proving nothing.
+    // Without NULL rows both counts would be zero and this would prove nothing.
     Assert.That(nulls, Is.GreaterThan 0L, "fixture has no NULL addressline2 rows to distinguish")
 
     count "SELECT count(*) FROM person.address WHERE LOWER(addressline2) = ''" =! 0L

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -794,3 +794,74 @@ let ``SqlFn - PostgreSQL functions smoke test``() = task {
     upperName =! "KEN"
     Assert.That(middleName, Is.Not.Null)
 }
+
+// ---------------------------------------------------------------------------
+// The two claims the `string option` case-folding overloads rest on, measured
+// against the server rather than asserted about the emitted SQL. The unit tests
+// pin that `LOWER(col)` is emitted and `COALESCE` is not; these pin that the
+// difference is the one that matters.
+// ---------------------------------------------------------------------------
+
+[<Test>]
+let ``a functional index on a nullable column is usable through lower and unusable through coalesce``() = task {
+    // `enable_seqscan = off` is what makes this a test of USABILITY rather than of the
+    // planner's cost preference: on a small table a sequential scan is cheaper and would
+    // be chosen even with a perfectly good index. With it off, the planner takes the
+    // index if it can — so a remaining Seq Scan means the expression cannot match it.
+    use! ctx = db.OpenContextAsync()
+
+    let run (sql: string) =
+        use cmd = ctx.Connection.CreateCommand()
+        cmd.CommandText <- sql
+        cmd.ExecuteScalar() |> ignore
+
+    let plan (sql: string) =
+        use cmd = ctx.Connection.CreateCommand()
+        cmd.CommandText <- $"EXPLAIN {sql}"
+        use reader = cmd.ExecuteReader()
+        let mutable text = ""
+        while reader.Read() do
+            text <- text + reader.GetString(0) + "\n"
+        text
+
+    run "CREATE INDEX IF NOT EXISTS test_address_lower_line2 ON person.address (LOWER(addressline2))"
+
+    try
+        run "SET enable_seqscan = off"
+
+        let viaLower =
+            plan "SELECT * FROM person.address WHERE LOWER(addressline2) = 'suite 100'"
+
+        let viaCoalesce =
+            plan "SELECT * FROM person.address WHERE LOWER(COALESCE(addressline2, '')) = 'suite 100'"
+
+        viaLower.Contains "test_address_lower_line2" =! true
+        // The control. Without it this test would pass just as well if the index were
+        // used by everything, which would prove nothing about the overload.
+        viaCoalesce.Contains "test_address_lower_line2" =! false
+    finally
+        run "RESET enable_seqscan"
+        run "DROP INDEX IF EXISTS person.test_address_lower_line2"
+}
+
+[<Test>]
+let ``lower over a nullable column leaves NULL rows out, where the coalesce workaround pulls them in``() = task {
+    // Not merely a different plan — a different answer. `LOWER(NULL)` is NULL, so a NULL
+    // row matches nothing; `LOWER(COALESCE(col, ''))` maps NULL to the empty string, so
+    // every NULL row matches a search for "". The overload exists so callers get the
+    // former without hand-writing SQL.
+    use! ctx = db.OpenContextAsync()
+
+    let count (sql: string) =
+        use cmd = ctx.Connection.CreateCommand()
+        cmd.CommandText <- sql
+        cmd.ExecuteScalar() :?> int64
+
+    let nulls = count "SELECT count(*) FROM person.address WHERE addressline2 IS NULL"
+    // Guards the assertions below against a fixture with no NULLs, where both would
+    // trivially return zero and the test would pass while proving nothing.
+    Assert.That(nulls, Is.GreaterThan 0L, "fixture has no NULL addressline2 rows to distinguish")
+
+    count "SELECT count(*) FROM person.address WHERE LOWER(addressline2) = ''" =! 0L
+    count "SELECT count(*) FROM person.address WHERE LOWER(COALESCE(addressline2, '')) = ''" =! nulls
+}

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -798,52 +798,46 @@ let ``SqlFn - PostgreSQL functions smoke test``() = task {
 
 [<Test>]
 let ``a functional index on a nullable column is usable through lower and unusable through coalesce``() = task {
-    // `enable_seqscan = off` so the planner takes the index if it can: a remaining
-    // Seq Scan then means the expression cannot match it.
     use! ctx = db.OpenContextAsync()
 
     let exec (sql: string) =
-        use cmd = ctx.Connection.CreateCommand()
-        cmd.CommandText <- sql
+        use cmd = ctx.Connection.CreateCommand(CommandText = sql)
         cmd.ExecuteNonQuery() |> ignore
 
-    // EXPLAIN the SQL SqlHydra actually emits, not a hand-written equivalent.
-    let planOf (q: SelectQuery<_>) =
+    let explain (q: SelectQuery<_>) =
         use cmd = ctx.BuildCommand(q.IR)
         cmd.CommandText <- "EXPLAIN " + cmd.CommandText
         use reader = cmd.ExecuteReader()
-        let mutable text = ""
-        while reader.Read() do
-            text <- text + reader.GetString(0) + "\n"
-        text
+        [ while reader.Read() do reader.GetString 0 ] |> String.concat "\n"
 
-    exec "CREATE INDEX IF NOT EXISTS test_address_lower_line2 ON person.address (LOWER(addressline2))"
+    // Rolled back below, so neither the index nor the planner setting outlives the test.
+    ctx.BeginTransaction()
+    exec "CREATE INDEX test_address_lower_line2 ON person.address (LOWER(addressline2))"
+    // With seq scans off the planner takes the index if it can: a remaining Seq Scan means
+    // the expression cannot match it.
+    exec "SET LOCAL enable_seqscan = off"
 
-    try
-        exec "SET enable_seqscan = off"
+    let viaOverload =
+        explain (
+            select {
+                for a in person.address do
+                where (SqlFn.lower a.addressline2 = "suite 100")
+            }
+        )
 
-        let viaOverload =
-            planOf (
-                select {
-                    for a in person.address do
-                        where (SqlFn.lower a.addressline2 = "suite 100")
-                }
-            )
+    let viaWorkaround =
+        explain (
+            select {
+                for a in person.address do
+                where (SqlFn.lower (SqlFn.coalesce (a.addressline2, "")) = "suite 100")
+            }
+        )
 
-        let viaWorkaround =
-            planOf (
-                select {
-                    for a in person.address do
-                        where (SqlFn.lower (SqlFn.coalesce (a.addressline2, "")) = "suite 100")
-                }
-            )
+    ctx.RollbackTransaction()
 
-        viaOverload.Contains "test_address_lower_line2" =! true
-        // The control: without it, an index used by everything would pass too.
-        viaWorkaround.Contains "test_address_lower_line2" =! false
-    finally
-        exec "RESET enable_seqscan"
-        exec "DROP INDEX IF EXISTS person.test_address_lower_line2"
+    viaOverload.Contains "test_address_lower_line2" =! true
+    // The control: without it, an index used by everything would pass too.
+    viaWorkaround.Contains "test_address_lower_line2" =! false
 }
 
 [<Test>]
@@ -853,17 +847,17 @@ let ``lower over a nullable column leaves NULL rows out, where the coalesce work
     let! viaOverload =
         selectTask db {
             for a in person.address do
-                where (SqlFn.lower a.addressline2 = "")
+            where (SqlFn.lower a.addressline2 = "")
+            count
         }
 
     let! viaWorkaround =
         selectTask db {
             for a in person.address do
-                where (SqlFn.lower (SqlFn.coalesce (a.addressline2, "")) = "")
+            where (SqlFn.lower (SqlFn.coalesce (a.addressline2, "")) = "")
+            count
         }
 
-    // Without NULL rows both counts would be zero and this would prove nothing.
-    Assert.That(Seq.length viaWorkaround, Is.GreaterThan 0, "fixture has no NULL addressline2 rows")
-    Seq.length viaOverload =! 0
-    viaWorkaround |> Seq.forall (fun a -> a.addressline2.IsNone) =! true
+    viaOverload =! 0
+    Assert.That(viaWorkaround, Is.GreaterThan 0, "fixture has no NULL addressline2 rows")
 }

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -821,7 +821,7 @@ let ``a functional index on a nullable column is usable through lower and unusab
         explain (
             select {
                 for a in person.address do
-                where (SqlFn.lower a.addressline2 = "suite 100")
+                where (SqlFn.lower a.addressline2 = Some "suite 100")
             }
         )
 
@@ -847,7 +847,7 @@ let ``lower over a nullable column leaves NULL rows out, where the coalesce work
     let! viaOverload =
         selectTask db {
             for a in person.address do
-            where (SqlFn.lower a.addressline2 = "")
+            where (SqlFn.lower a.addressline2 = Some "")
             count
         }
 
@@ -860,4 +860,39 @@ let ``lower over a nullable column leaves NULL rows out, where the coalesce work
 
     viaOverload =! 0
     Assert.That(viaWorkaround, Is.GreaterThan 0, "fixture has no NULL addressline2 rows")
+}
+
+[<Test>]
+let ``lower over a nullable column hydrates NULL rows as None``() = task {
+    let! nullRows =
+        selectTask db {
+            for a in person.address do
+            where (isNullValue a.addressline2)
+            select (SqlFn.lower a.addressline2)
+            take 1
+        }
+    let nullRow : string option = nullRows |> Seq.head
+    nullRow =! None
+
+    let! someRows =
+        selectTask db {
+            for a in person.address do
+            where (isNotNullValue a.addressline2)
+            select (SqlFn.lower a.addressline2)
+            take 1
+        }
+    let someRow : string option = someRows |> Seq.head
+    test <@ someRow.IsSome @>
+}
+
+[<Test>]
+let ``an option-returning function compared to Some binds the inner value``() = task {
+    // Previously the boxed `Some` reached the driver: "Writing values of 'FSharpOption`1' is not supported".
+    let! matches =
+        selectTask db {
+            for a in person.address do
+            where (SqlFn.nullif (a.city, "") = Some "Bothell")
+            count
+        }
+    Assert.That(matches, Is.GreaterThan 0)
 }

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1722,17 +1722,10 @@ let ``two ordinary .NET calls in a where are evaluated, not rendered``() =
     let ex = Assert.Throws<NotImplementedException>(fun () -> build ())
     test <@ ex.Message.Contains("Value to value") @>
 
-// ---------------------------------------------------------------------------
-// Case folding over a NULLABLE column — what a functional index on such a
-// column needs in order to actually be used.
-// ---------------------------------------------------------------------------
 
 [<Test>]
 let ``lower over a nullable column emits LOWER(col), not LOWER(COALESCE(col, ''))``() =
-    // A functional index `CREATE INDEX ... ON address (LOWER(addressline2))` can only be
-    // matched by `LOWER(addressline2)`. Without the `string option` overload a nullable
-    // column forces `lower (coalesce (col, ""))` — which emits `LOWER(COALESCE(col, ''))`
-    // and defeats the index (seq scan).
+    // A functional index on `LOWER(addressline2)` is only matched by `LOWER(addressline2)`.
     let sql =
         select {
             for a in person.address do
@@ -1757,8 +1750,7 @@ let ``upper over a nullable column emits UPPER(col)``() =
 
 [<Test>]
 let ``inlineValue and lower over a nullable column compose``() =
-    // The exact shape a partial functional index needs:
-    //   CREATE UNIQUE INDEX ... ON t (LOWER(addressline2)) WHERE city = 'Dallas'
+    // The shape a partial functional index needs.
     let sql =
         select {
             for a in person.address do

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -39,7 +39,7 @@ let plainDotNetHelper () = "Dallas"
 let NULLIF<'T> (a: 'T, b: 'T) : 'T = sqlFn
 
 type ExtFn =
-    /// Case folding over a NULLABLE column — the overload SqlHydra itself does not ship.
+    /// A user-declared member carrying the marker itself, not inheriting it from its type.
     [<SqlHydraFunction>]
     static member lower(s: string option) : string = sqlFn
 
@@ -1724,7 +1724,7 @@ let ``two ordinary .NET calls in a where are evaluated, not rendered``() =
 
 
 [<Test>]
-let ``lower over a nullable column emits LOWER(col), not LOWER(COALESCE(col, ''))``() =
+let ``lower over a nullable column emits LOWER(col)``() =
     // A functional index on `LOWER(addressline2)` is only matched by `LOWER(addressline2)`.
     let sql =
         select {
@@ -1732,9 +1732,7 @@ let ``lower over a nullable column emits LOWER(col), not LOWER(COALESCE(col, '')
             where (SqlFn.lower a.addressline2 = "suite 100")
         }
         |> toSql
-
-    sql.Contains("LOWER(a.addressline2)") =! true
-    sql.Contains("COALESCE") =! false
+    test <@ sql.Contains("(LOWER(a.addressline2) = @p0)") @>
 
 [<Test>]
 let ``upper over a nullable column emits UPPER(col)``() =
@@ -1744,20 +1742,4 @@ let ``upper over a nullable column emits UPPER(col)``() =
             where (SqlFn.upper a.addressline2 = "SUITE 100")
         }
         |> toSql
-
-    sql.Contains("UPPER(a.addressline2)") =! true
-    sql.Contains("COALESCE") =! false
-
-[<Test>]
-let ``inlineValue and lower over a nullable column compose``() =
-    // The shape a partial functional index needs.
-    let sql =
-        select {
-            for a in person.address do
-            where (a.city = inlineValue "Dallas" && SqlFn.lower a.addressline2 = "suite 100")
-        }
-        |> toSql
-
-    sql.Contains("'Dallas'") =! true
-    sql.Contains("LOWER(a.addressline2)") =! true
-    sql.Contains("COALESCE") =! false
+    test <@ sql.Contains("(UPPER(a.addressline2) = @p0)") @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1729,7 +1729,7 @@ let ``lower over a nullable column emits LOWER(col)``() =
     let sql =
         select {
             for a in person.address do
-            where (SqlFn.lower a.addressline2 = "suite 100")
+            where (SqlFn.lower a.addressline2 = Some "suite 100")
         }
         |> toSql
     test <@ sql.Contains("(LOWER(a.addressline2) = @p0)") @>
@@ -1739,7 +1739,58 @@ let ``upper over a nullable column emits UPPER(col)``() =
     let sql =
         select {
             for a in person.address do
-            where (SqlFn.upper a.addressline2 = "SUITE 100")
+            where (SqlFn.upper a.addressline2 = Some "SUITE 100")
         }
         |> toSql
     test <@ sql.Contains("(UPPER(a.addressline2) = @p0)") @>
+
+[<Test>]
+let ``lower over a nullable column compared to None emits IS NULL``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.lower a.addressline2 = None)
+        }
+        |> toSql
+    test <@ sql.Contains("(LOWER(a.addressline2) IS NULL)") @>
+
+[<Test>]
+let ``nullable string functions compose``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.length (SqlFn.ltrim (SqlFn.lower a.addressline2)) = Some 9)
+        }
+        |> toSql
+    test <@ sql.Contains("(LENGTH(LTRIM(LOWER(a.addressline2))) = @p0)") @>
+
+[<Test>]
+let ``an option-returning function compared to None emits IS NULL``() =
+    // `= @p0` with a NULL parameter matches no rows.
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.nullif (a.city, "") = None)
+        }
+        |> toSql
+    test <@ sql.Contains("(NULLIF(a.city, '') IS NULL)") @>
+
+[<Test>]
+let ``every string option overload is the option-lifting of a string sibling``() =
+    let isOption (t: Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+    let liftedTwins =
+        typeof<SqlFn>.GetMethods(Reflection.BindingFlags.Public ||| Reflection.BindingFlags.Static)
+        |> Array.filter (fun m -> m.GetParameters() |> Array.exists (fun p -> p.ParameterType = typeof<string option>))
+    test <@ liftedTwins.Length > 0 @>
+    for twin in liftedTwins do
+        let twinParams = twin.GetParameters() |> Array.map (fun p -> p.ParameterType)
+        let siblingParams =
+            twinParams |> Array.map (fun t -> if t = typeof<string option> then typeof<string> else t)
+        let sibling = typeof<SqlFn>.GetMethod(twin.Name, siblingParams)
+        Assert.That(sibling, Is.Not.Null, $"{twin.Name} has no `string` sibling with the same shape")
+        Assert.That(
+            (twinParams |> Array.filter ((=) typeof<string option>)).Length, Is.EqualTo 1,
+            $"{twin.Name}: lift exactly one parameter")
+        Assert.That(
+            twin.ReturnType, Is.EqualTo(typedefof<option<_>>.MakeGenericType sibling.ReturnType),
+            $"{twin.Name}: NULL in, NULL out, so the return type must be option")

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1721,3 +1721,51 @@ let ``two ordinary .NET calls in a where are evaluated, not rendered``() =
         |> ignore
     let ex = Assert.Throws<NotImplementedException>(fun () -> build ())
     test <@ ex.Message.Contains("Value to value") @>
+
+// ---------------------------------------------------------------------------
+// Case folding over a NULLABLE column — what a functional index on such a
+// column needs in order to actually be used.
+// ---------------------------------------------------------------------------
+
+[<Test>]
+let ``lower over a nullable column emits LOWER(col), not LOWER(COALESCE(col, ''))``() =
+    // A functional index `CREATE INDEX ... ON address (LOWER(addressline2))` can only be
+    // matched by `LOWER(addressline2)`. Without the `string option` overload a nullable
+    // column forces `lower (coalesce (col, ""))` — which emits `LOWER(COALESCE(col, ''))`
+    // and defeats the index (seq scan).
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.lower a.addressline2 = "suite 100")
+        }
+        |> toSql
+
+    sql.Contains("LOWER(a.addressline2)") =! true
+    sql.Contains("COALESCE") =! false
+
+[<Test>]
+let ``upper over a nullable column emits UPPER(col)``() =
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.upper a.addressline2 = "SUITE 100")
+        }
+        |> toSql
+
+    sql.Contains("UPPER(a.addressline2)") =! true
+    sql.Contains("COALESCE") =! false
+
+[<Test>]
+let ``inlineValue and lower over a nullable column compose``() =
+    // The exact shape a partial functional index needs:
+    //   CREATE UNIQUE INDEX ... ON t (LOWER(addressline2)) WHERE city = 'Dallas'
+    let sql =
+        select {
+            for a in person.address do
+            where (a.city = inlineValue "Dallas" && SqlFn.lower a.addressline2 = "suite 100")
+        }
+        |> toSql
+
+    sql.Contains("'Dallas'") =! true
+    sql.Contains("LOWER(a.addressline2)") =! true
+    sql.Contains("COALESCE") =! false


### PR DESCRIPTION
`lower` and `upper` only accept a non-nullable column, so with a nullable one you have to write:

```fsharp
where (lower (coalesce (a.addressline2, "")) = "suite 100")
```

That emits `LOWER(COALESCE(addressline2, ''))`, which a functional index on `LOWER(addressline2)` can't match. With `enable_seqscan = off` so the planner takes the index if it can:

```
LOWER(addressline2)               ->  Index Scan using addr_lower_line2
LOWER(COALESCE(addressline2, '')) ->  Seq Scan
```

It also changes the answer. `COALESCE` maps NULL to `''`, so every NULL row matches a search for the empty string. `LOWER(NULL)` is NULL, which matches nothing.

**The overloads.** Every NULL-propagating string function in the Npgsql `SqlFn` gets a `string option` twin that returns an option:

```fsharp
static member lower(s: string option) : string option = sqlFn
static member length(s: string option) : int option = sqlFn
```

`concat` / `concat_ws` ignore NULL arguments, so they keep their single shape. A reflection test pins each twin to its sibling: same name and arity, exactly one parameter lifted, return type lifted.

**Why option rather than the `coalesce` convention.** `LOWER(NULL)` is NULL, so an unwrapped return hands the caller a null `string` whenever the projection hits a NULL row. With option it hydrates as `None`. In a `where` you write `= Some "suite 100"`, the idiom nullable columns already use (`a.addressline2 = Some "abc"`), and `= None` renders `IS NULL`. The twins compose: `length (ltrim (lower a.addressline2))` renders `LENGTH(LTRIM(LOWER(a.addressline2)))`.

**A bug this surfaced, already live on main.** Comparing an option-returning function to a value handed the boxed `Some` to the driver (`Writing values of 'FSharpOption`1' is not supported`), and rendered `None` as `= @p0` with a NULL parameter, which matches no row:

```fsharp
where (nullif (a.city, "") = None)
// before: NULLIF(a.city, '') = @p0    (@p0 = NULL)
// after:  NULLIF(a.city, '') IS NULL
```

Both value-vs-function arms now bind the inner value and map `None` to `IS NULL` / `IS NOT NULL`.
