### PR TITLE
Type PostgreSQL base tables as tables, not views

### DIFF
--- a/src/SqlHydra.Cli/Npgsql/NpgsqlSchemaProvider.fs
+++ b/src/SqlHydra.Cli/Npgsql/NpgsqlSchemaProvider.fs
@@ -4,6 +4,18 @@ open System.Data
 open SqlHydra.Domain
 open SqlHydra
 
+/// True for an ordinary base table, false for a view.
+///
+/// Npgsql's `GetSchema("Tables")` reports TABLE_TYPE straight from
+/// `information_schema.tables`, so a plain table arrives as the SQL-standard
+/// "BASE TABLE" — never the literal "table" this used to test for, which meant every
+/// PostgreSQL table was typed as a view. The `views` and `materialized views` rows
+/// appended further down carry our own "view" / "materialized view" labels instead, so
+/// testing by exclusion keeps this right regardless of how a future Npgsql spells the
+/// base-table case.
+let isBaseTableType tableType =
+    tableType <> "view" && tableType <> "materialized view"
+
 let getSchema (cfg: Config, isLegacy: bool, extensions: IExtendTypeMapping list) : Schema =
     use conn = new Npgsql.NpgsqlConnection(cfg.ConnectionString)
     conn.Open()
@@ -273,7 +285,7 @@ let getSchema (cfg: Config, isLegacy: bool, extensions: IExtendTypeMapping list)
                     TableSchema.Catalog = tbl.Catalog
                     TableSchema.Schema = tbl.Schema
                     TableSchema.Name = tbl.Name
-                    TableSchema.Type = if tbl.Type = "table" then TableType.Table else TableType.View
+                    TableSchema.Type = if isBaseTableType tbl.Type then TableType.Table else TableType.View
                     TableSchema.Columns = tableCols
                 }
 
@@ -337,7 +349,7 @@ let getSchema (cfg: Config, isLegacy: bool, extensions: IExtendTypeMapping list)
                     Table.Catalog = tbl.Catalog
                     Table.Schema = tbl.Schema
                     Table.Name =  tbl.Name
-                    Table.Type = if tbl.Type = "table" then TableType.Table else TableType.View
+                    Table.Type = if isBaseTableType tbl.Type then TableType.Table else TableType.View
                     Table.Columns = filteredColumns
                     Table.TotalColumns = tableCols |> List.length
                 }

--- a/src/Tests/Npgsql/Generation.fs
+++ b/src/Tests/Npgsql/Generation.fs
@@ -8,6 +8,17 @@ open VerifyTests
 open VerifyNUnit
 open SqlHydra.Npgsql
 
+// ==========================================
+// Base table vs. view.
+// ==========================================
+
+[<TestCase("BASE TABLE", true)>]
+[<TestCase("table", true)>]
+[<TestCase("view", false)>]
+[<TestCase("materialized view", false)>]
+let ``Npgsql table types distinguish base tables from appended views`` tableType expected =
+    NpgsqlSchemaProvider.isBaseTableType tableType =! expected
+
 //let cfg = 
 //    {
 //        ConnectionString = DB.connectionString


### PR DESCRIPTION
`GetSchema("Tables")` reports `TABLE_TYPE` straight from `information_schema.tables`, so a plain table arrives as the SQL-standard `BASE TABLE`, never the literal `table` the Npgsql provider tested for. Every PostgreSQL table was therefore typed `TableType.View`. The SQL Server provider already tests for `BASE TABLE`; only Npgsql was out of step.

Nothing downstream reads `Table.Type` today, which is why it went unnoticed; it is a trap for anything that starts to (the write-record work in #149 was the first thing to look).

The test asserts by exclusion against the `view` / `materialized view` labels the appended view rows carry, so it stays right however a future Npgsql spells the base-table case.

Split out of #149 at your request.