### PR TITLE
Npgsql generate niladics

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,18 +399,18 @@ Oracle's `SYSDATE`, `SYSTIMESTAMP`, `CURRENT_DATE` and `CURRENT_TIMESTAMP` are m
 
 **PostgreSQL functions are generated from the catalog.** The members of the Npgsql `SqlFn` between `// <generated>` and `// </generated>` come from `pg_proc`: argument and return types, and `proisstrict` (NULL in means NULL out), which gives every parameter of a strict function a `'T option` twin. `src/SqlHydra.Query/codegen/NpgsqlSqlFn.allowlist` lists one overload per line and chooses which functions appear; the catalog decides their shape. Each member is executed once at generation, so a function that cannot be called as `NAME(args)` is never emitted, and a keyword-named one such as `position` renders schema-qualified.
 
+
+```
+lpad s:string length:int fill:string     # the (text, integer, text) overload, with parameter names
+trim=btrim s:string                      # `trim` is parser sugar; its shape lives under btrim
+concat s1:string s2:string               # a variadic function takes whatever list you write
+```
 A niladic function has no `pg_proc` row at all, so a parameterless line the catalog cannot resolve is offered to `SELECT pg_typeof(<name>)`, which proves the bare spelling parses and names its return type. Those come out `Niladic`. The allowlist never says which is which, so one plain list of names produces all three renderings:
 
 ```
 current_date        ->  CURRENT_DATE                  a keyword, no pg_proc row
 current_schema      ->  CURRENT_SCHEMA()              an ordinary function
 current_user        ->  pg_catalog.current_user()     a function the parser reads as a keyword
-```
-
-```
-lpad s:string length:int fill:string     # the (text, integer, text) overload, with parameter names
-trim=btrim s:string                      # `trim` is parser sugar; its shape lives under btrim
-concat s1:string s2:string               # a variadic function takes whatever list you write
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -388,6 +388,15 @@ type TextFn =
 >
 > A `sqlFn` body has no runtime meaning, so executing one raises `SqlFunctionNotRenderedException` - which is what a missing marker gets you, rather than a query that quietly compares your column to `NULL`. If you use a function name the database does not have, you get a database error at runtime.
 
+**Functions that are keywords, not calls.** SQL's niladic functions - `CURRENT_DATE`, `CURRENT_TIMESTAMP`, Oracle's `SYSDATE` - are parsed as keywords and take no argument list at all, so `CURRENT_DATE()` is a syntax error. Mark such a wrapper `Niladic` and only its name is rendered:
+
+```fsharp
+[<SqlHydraFunction(Niladic = true)>]
+static member current_date() : DateTime = sqlFn   // CURRENT_DATE, not CURRENT_DATE()
+```
+
+The built-in `current_date`, `current_time` and `current_timestamp` (Npgsql) and `SYSDATE`, `SYSTIMESTAMP`, `CURRENT_DATE` and `CURRENT_TIMESTAMP` (Oracle) are already marked. PostgreSQL's `now()` is an ordinary function and keeps its parentheses.
+
 **PostgreSQL functions are generated from the catalog.** The members of the Npgsql `SqlFn` between `// <generated>` and `// </generated>` come from `pg_proc`: argument and return types, and `proisstrict` (NULL in means NULL out), which gives every parameter of a strict function a `'T option` twin. `src/SqlHydra.Query/codegen/NpgsqlSqlFn.allowlist` lists one overload per line and chooses which functions appear; the catalog decides their shape. Each member is executed once at generation, so a function that cannot be called as `NAME(args)` is never emitted, and a keyword-named one such as `position` renders schema-qualified.
 
 ```

--- a/README.md
+++ b/README.md
@@ -395,9 +395,17 @@ type TextFn =
 static member current_date() : DateTime = sqlFn   // CURRENT_DATE, not CURRENT_DATE()
 ```
 
-The built-in `current_date`, `current_time` and `current_timestamp` (Npgsql) and `SYSDATE`, `SYSTIMESTAMP`, `CURRENT_DATE` and `CURRENT_TIMESTAMP` (Oracle) are already marked. PostgreSQL's `now()` is an ordinary function and keeps its parentheses.
+Oracle's `SYSDATE`, `SYSTIMESTAMP`, `CURRENT_DATE` and `CURRENT_TIMESTAMP` are marked by hand. The PostgreSQL ones are generated, and nothing in the allowlist says so - see below.
 
 **PostgreSQL functions are generated from the catalog.** The members of the Npgsql `SqlFn` between `// <generated>` and `// </generated>` come from `pg_proc`: argument and return types, and `proisstrict` (NULL in means NULL out), which gives every parameter of a strict function a `'T option` twin. `src/SqlHydra.Query/codegen/NpgsqlSqlFn.allowlist` lists one overload per line and chooses which functions appear; the catalog decides their shape. Each member is executed once at generation, so a function that cannot be called as `NAME(args)` is never emitted, and a keyword-named one such as `position` renders schema-qualified.
+
+A niladic function has no `pg_proc` row at all, so a parameterless line the catalog cannot resolve is offered to `SELECT pg_typeof(<name>)`, which proves the bare spelling parses and names its return type. Those come out `Niladic`. The allowlist never says which is which, so one plain list of names produces all three renderings:
+
+```
+current_date        ->  CURRENT_DATE                  a keyword, no pg_proc row
+current_schema      ->  CURRENT_SCHEMA()              an ordinary function
+current_user        ->  pg_catalog.current_user()     a function the parser reads as a keyword
+```
 
 ```
 lpad s:string length:int fill:string     # the (text, integer, text) overload, with parameter names

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -36,10 +36,11 @@ let sqlFunctionName (mi: MethodInfo) = nameFrom mi (sqlFunctionAttribute mi)
 /// `NAME(args)`, or the bare name for a function marked `Niladic`: `CURRENT_DATE` and its
 /// siblings are keywords, and the databases that parse them as such reject `CURRENT_DATE()`.
 /// One attribute lookup, since this runs for every rendered call.
-let renderSqlFunctionCall (mi: MethodInfo) (args: string) =
+let renderSqlFunctionCall (mi: MethodInfo) (args: string seq) =
     let att = sqlFunctionAttribute mi
     let name = nameFrom mi att
-    if att |> Option.exists (fun a -> a.Niladic) then name else $"{name}({args})"
+    if att |> Option.exists (fun a -> a.Niladic) then name
+    else $"""{name}({String.concat ", " args})"""
 
 /// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.
 /// Keep in sync with QueryFunctions.Aggregates.
@@ -715,8 +716,7 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
         | Some op ->
             $"({renderExpr m.Arguments.[0]} {op} {renderExpr m.Arguments.[1]})"
         | None ->
-            let args = m.Arguments |> Seq.map renderExpr |> String.concat ", "
-            renderSqlFunctionCall m.Method args
+            renderSqlFunctionCall m.Method (m.Arguments |> Seq.map renderExpr)
     | _ ->
         notImplMsg $"Expected a method call expression but got: {exp.NodeType}"
 
@@ -1341,8 +1341,7 @@ let visitOrderByPropertySelector<'T, 'Prop> (propertySelector: Expression<Func<'
                     let aggType = aggTypeOf mc.Method.Name
                     renderAggregate aggType (render mc.Arguments.[0])
                 | :? MethodCallExpression as mc ->
-                    let args = mc.Arguments |> Seq.map render |> String.concat ", "
-                    renderSqlFunctionCall mc.Method args
+                    renderSqlFunctionCall mc.Method (mc.Arguments |> Seq.map render)
                 | _ ->
                     notImplMsg $"Unsupported expression in orderBy method-call: {e.NodeType}"
             let frag = render (m :> Expression)
@@ -1656,8 +1655,7 @@ let private renderSelectExpression (exp: Expression) : string * obj[] =
             // generic "name(args)" form only if visitSqlFn explicitly rejects the shape.
             try visitSqlFn qualifyColumn (mc :> Expression)
             with :? System.NotImplementedException ->
-                let args = mc.Arguments |> Seq.map render |> String.concat ", "
-                renderSqlFunctionCall mc.Method args
+                renderSqlFunctionCall mc.Method (mc.Arguments |> Seq.map render)
         | _ ->
             notImplMsg $"Unsupported expression in select projection: {e.NodeType}"
     let frag = render exp

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -21,10 +21,22 @@ let isSqlHydraFunction (mi: MethodInfo) =
     || isMarkedContainer mi.DeclaringType
 
 /// `[<SqlHydraFunction("pg_catalog.position")>]` renders that spelling; otherwise the member name upper-cased.
-let sqlFunctionName (mi: MethodInfo) =
+let private sqlFunctionAttribute (mi: MethodInfo) =
     match Attribute.GetCustomAttribute(mi, typeof<SqlHydraFunctionAttribute>, false) with
-    | :? SqlHydraFunctionAttribute as att when not (isNull att.SqlName) -> att.SqlName
+    | :? SqlHydraFunctionAttribute as att -> Some att
+    | _ -> None
+
+let sqlFunctionName (mi: MethodInfo) =
+    match sqlFunctionAttribute mi with
+    | Some att when not (isNull att.SqlName) -> att.SqlName
     | _ -> mi.Name.ToUpperInvariant()
+
+/// `NAME(args)`, or the bare name for a function marked `Niladic`: `CURRENT_DATE` and its
+/// siblings are keywords, and the databases that parse them as such reject `CURRENT_DATE()`.
+let renderSqlFunctionCall (mi: MethodInfo) (args: string) =
+    match sqlFunctionAttribute mi with
+    | Some att when att.Niladic -> sqlFunctionName mi
+    | _ -> $"{sqlFunctionName mi}({args})"
 
 /// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.
 /// Keep in sync with QueryFunctions.Aggregates.
@@ -701,7 +713,7 @@ let rec visitSqlFn (qualifyColumn: string -> MemberInfo -> string) (exp: Express
             $"({renderExpr m.Arguments.[0]} {op} {renderExpr m.Arguments.[1]})"
         | None ->
             let args = m.Arguments |> Seq.map renderExpr |> String.concat ", "
-            $"{sqlFunctionName m.Method}({args})"
+            renderSqlFunctionCall m.Method args
     | _ ->
         notImplMsg $"Expected a method call expression but got: {exp.NodeType}"
 
@@ -1327,7 +1339,7 @@ let visitOrderByPropertySelector<'T, 'Prop> (propertySelector: Expression<Func<'
                     renderAggregate aggType (render mc.Arguments.[0])
                 | :? MethodCallExpression as mc ->
                     let args = mc.Arguments |> Seq.map render |> String.concat ", "
-                    $"{sqlFunctionName mc.Method}({args})"
+                    renderSqlFunctionCall mc.Method args
                 | _ ->
                     notImplMsg $"Unsupported expression in orderBy method-call: {e.NodeType}"
             let frag = render (m :> Expression)
@@ -1642,7 +1654,7 @@ let private renderSelectExpression (exp: Expression) : string * obj[] =
             try visitSqlFn qualifyColumn (mc :> Expression)
             with :? System.NotImplementedException ->
                 let args = mc.Arguments |> Seq.map render |> String.concat ", "
-                $"{sqlFunctionName mc.Method}({args})"
+                renderSqlFunctionCall mc.Method args
         | _ ->
             notImplMsg $"Unsupported expression in select projection: {e.NodeType}"
     let frag = render exp

--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -20,23 +20,26 @@ let isSqlHydraFunction (mi: MethodInfo) =
     mi.IsDefined(typeof<SqlHydraFunctionAttribute>, false)
     || isMarkedContainer mi.DeclaringType
 
-/// `[<SqlHydraFunction("pg_catalog.position")>]` renders that spelling; otherwise the member name upper-cased.
 let private sqlFunctionAttribute (mi: MethodInfo) =
     match Attribute.GetCustomAttribute(mi, typeof<SqlHydraFunctionAttribute>, false) with
     | :? SqlHydraFunctionAttribute as att -> Some att
     | _ -> None
 
-let sqlFunctionName (mi: MethodInfo) =
-    match sqlFunctionAttribute mi with
-    | Some att when not (isNull att.SqlName) -> att.SqlName
+let private nameFrom (mi: MethodInfo) (att: SqlHydraFunctionAttribute option) =
+    match att with
+    | Some a when not (isNull a.SqlName) -> a.SqlName
     | _ -> mi.Name.ToUpperInvariant()
+
+/// `[<SqlHydraFunction("pg_catalog.position")>]` renders that spelling; otherwise the member name upper-cased.
+let sqlFunctionName (mi: MethodInfo) = nameFrom mi (sqlFunctionAttribute mi)
 
 /// `NAME(args)`, or the bare name for a function marked `Niladic`: `CURRENT_DATE` and its
 /// siblings are keywords, and the databases that parse them as such reject `CURRENT_DATE()`.
+/// One attribute lookup, since this runs for every rendered call.
 let renderSqlFunctionCall (mi: MethodInfo) (args: string) =
-    match sqlFunctionAttribute mi with
-    | Some att when att.Niladic -> sqlFunctionName mi
-    | _ -> $"{sqlFunctionName mi}({args})"
+    let att = sqlFunctionAttribute mi
+    let name = nameFrom mi att
+    if att |> Option.exists (fun a -> a.Niladic) then name else $"{name}({args})"
 
 /// Aggregate method names recognized by the visitor. Used by visitSqlFn / pattern matchers.
 /// Keep in sync with QueryFunctions.Aggregates.

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -144,6 +144,25 @@ type SqlFn =
     static member concat_ws(separator: string, s1: string, s2: string) : string = sqlFn
     static member concat_ws(separator: string, s1: string, s2: string, s3: string) : string = sqlFn
     static member now() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member current_date() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member current_time() : DateTimeOffset = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member current_timestamp() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member localtime() : TimeSpan = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member localtimestamp() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member current_catalog() : string = sqlFn
+    static member current_schema() : string = sqlFn
+    [<SqlHydraFunction("pg_catalog.current_user")>]
+    static member current_user() : string = sqlFn
+    [<SqlHydraFunction("pg_catalog.session_user")>]
+    static member session_user() : string = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
+    static member user() : string = sqlFn
     [<SqlHydraFunction("pg_catalog.extract")>]
     static member extract(field: string, source: DateTime) : decimal = sqlFn
     /// NULL `field` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`.
@@ -207,17 +226,6 @@ type SqlFn =
     static member mod'(n: 'T, divisor: 'T) : 'T when 'T : struct = sqlFn
     static member trunc(n: 'T) : 'T when 'T : struct = sqlFn
     static member trunc(n: 'T, decimals: int) : 'T when 'T : struct = sqlFn
-
-    // Date/time functions. These three are niladic: PostgreSQL parses them as keywords and
-    // rejects `CURRENT_DATE()`. `now()` is an ordinary function and is generated above.
-    [<SqlHydraFunction(Niladic = true)>]
-    static member current_date() : DateTime = sqlFn
-    /// `time with time zone`, which Npgsql reads as DateTimeOffset. `localtime` is the
-    /// `time without time zone` sibling, and would be a TimeSpan.
-    [<SqlHydraFunction(Niladic = true)>]
-    static member current_time() : DateTimeOffset = sqlFn
-    [<SqlHydraFunction(Niladic = true)>]
-    static member current_timestamp() : DateTime = sqlFn
 
     // GREATEST / LEAST — variadic standard SQL functions
     static member greatest(a: 'T, b: 'T) : 'T = sqlFn

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -212,8 +212,10 @@ type SqlFn =
     // rejects `CURRENT_DATE()`. `now()` is an ordinary function and is generated above.
     [<SqlHydraFunction(Niladic = true)>]
     static member current_date() : DateTime = sqlFn
+    /// `time with time zone`, which Npgsql reads as DateTimeOffset. `localtime` is the
+    /// `time without time zone` sibling, and would be a TimeSpan.
     [<SqlHydraFunction(Niladic = true)>]
-    static member current_time() : TimeSpan = sqlFn
+    static member current_time() : DateTimeOffset = sqlFn
     [<SqlHydraFunction(Niladic = true)>]
     static member current_timestamp() : DateTime = sqlFn
 

--- a/src/SqlHydra.Query/NpgsqlExtensions.fs
+++ b/src/SqlHydra.Query/NpgsqlExtensions.fs
@@ -208,9 +208,13 @@ type SqlFn =
     static member trunc(n: 'T) : 'T when 'T : struct = sqlFn
     static member trunc(n: 'T, decimals: int) : 'T when 'T : struct = sqlFn
 
-    // Date/time functions
+    // Date/time functions. These three are niladic: PostgreSQL parses them as keywords and
+    // rejects `CURRENT_DATE()`. `now()` is an ordinary function and is generated above.
+    [<SqlHydraFunction(Niladic = true)>]
     static member current_date() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
     static member current_time() : TimeSpan = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
     static member current_timestamp() : DateTime = sqlFn
 
     // GREATEST / LEAST — variadic standard SQL functions

--- a/src/SqlHydra.Query/OracleExtensions.fs
+++ b/src/SqlHydra.Query/OracleExtensions.fs
@@ -55,10 +55,15 @@ type SqlFn =
     static member TRUNC(n: 'T) : 'T when 'T : struct = sqlFn
     static member TRUNC(n: 'T, decimals: int) : 'T when 'T : struct = sqlFn
 
-    // Date/time functions
+    // Date/time functions. The first four are niladic: Oracle parses them as keywords and
+    // accepts no argument list, so `SYSDATE()` is a syntax error.
+    [<SqlHydraFunction(Niladic = true)>]
     static member SYSDATE() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
     static member SYSTIMESTAMP() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
     static member CURRENT_DATE() : DateTime = sqlFn
+    [<SqlHydraFunction(Niladic = true)>]
     static member CURRENT_TIMESTAMP() : DateTime = sqlFn
     static member EXTRACT(field: string, source: DateTime) : int = sqlFn
     static member ADD_MONTHS(date: DateTime, months: int) : DateTime = sqlFn

--- a/src/SqlHydra.Query/OracleExtensions.fs
+++ b/src/SqlHydra.Query/OracleExtensions.fs
@@ -55,8 +55,8 @@ type SqlFn =
     static member TRUNC(n: 'T) : 'T when 'T : struct = sqlFn
     static member TRUNC(n: 'T, decimals: int) : 'T when 'T : struct = sqlFn
 
-    // Date/time functions. The first four are niladic: Oracle parses them as keywords and
-    // accepts no argument list, so `SYSDATE()` is a syntax error.
+    // Date/time functions. Oracle parses the marked ones as keywords and accepts no argument
+    // list for them, so `SYSDATE()` is a syntax error.
     [<SqlHydraFunction(Niladic = true)>]
     static member SYSDATE() : DateTime = sqlFn
     [<SqlHydraFunction(Niladic = true)>]

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -21,6 +21,10 @@ type SqlHydraFunctionAttribute(sqlName: string) =
     /// Rendered instead of the member name, e.g. `pg_catalog.position` for a function whose
     /// plain spelling is keyword syntax.
     member _.SqlName = sqlName
+    /// SQL's niladic functions — `CURRENT_DATE`, `CURRENT_TIMESTAMP`, `SYSDATE` — are keywords,
+    /// not calls, and a database that parses them as such rejects `CURRENT_DATE()`. Set this on
+    /// a member that takes no arguments to render the name on its own.
+    member val Niladic = false with get, set
 
 /// Raised when a `sqlFn` wrapper is executed as ordinary .NET code instead of being rendered
 /// as SQL: either it was called outside a query expression, or it is used in a `where`/`on'`

--- a/src/SqlHydra.Query/codegen/NpgsqlSqlFn.allowlist
+++ b/src/SqlHydra.Query/codegen/NpgsqlSqlFn.allowlist
@@ -33,6 +33,16 @@ concat s1:string s2:string s3:string
 concat_ws separator:string s1:string s2:string
 concat_ws separator:string s1:string s2:string s3:string
 now
+current_date
+current_time
+current_timestamp
+localtime
+localtimestamp
+current_catalog
+current_schema
+current_user
+session_user
+user
 extract field:string source:DateTime
 date_trunc field:string source:DateTime
 date_part field:string source:DateTime

--- a/src/SqlHydra.Query/codegen/NpgsqlSqlFn.fsx
+++ b/src/SqlHydra.Query/codegen/NpgsqlSqlFn.fsx
@@ -121,16 +121,22 @@ let catalog =
 
 let describe (o: Overload) = $"""({String.Join(", ", o.Args)}) -> {o.Ret}"""
 
-/// A member to emit: the allowlist line, its catalog overload, and the catalog types to probe with.
-/// `Overload` is None for a niladic keyword, which has no `pg_proc` row to resolve against.
-type Member = { Entry: Entry; Overload: Overload option; ProbeArgs: string []; Ret: string; SqlName: string option }
+/// What the database says a member is: an ordinary function backed by a `pg_proc` row, or a
+/// keyword the parser accepts on its own and that no row describes.
+type Shape =
+    | Call of Overload
+    | Keyword
 
-/// A name with no `pg_proc` row may still be a niladic keyword. `SELECT pg_typeof(current_date)`
-/// settles both questions at once: that the bare spelling parses, and what it returns.
-let niladicType (name: string) =
+/// A member to emit: the allowlist line, what it turned out to be, and the catalog types to probe with.
+type Member = { Entry: Entry; Shape: Shape; ProbeArgs: string []; Ret: string; SqlName: string option }
+
+/// Only a parameterless name can be a keyword, and `SELECT pg_typeof(current_date)` settles both
+/// questions at once: that the bare spelling parses, and what it returns.
+let keywordType (e: Entry) =
+    if not e.Params.IsEmpty then None else
     try
         use cmd = db.CreateCommand()
-        cmd.CommandText <- $"SELECT pg_typeof({name})::text"
+        cmd.CommandText <- $"SELECT pg_typeof({e.Catalog})::text"
         Some (cmd.ExecuteScalar() :?> string)
     with :? PostgresException as ex when ex.SqlState = "42601" || ex.SqlState = "42703" -> None
 
@@ -141,38 +147,40 @@ let resolve (e: Entry) =
         fsharpType pg |> Option.defaultWith (fun () -> failwith $"{e.Member}: return type {pg} has no F# type; add --map {pg}=<Type>")
     let exact = candidates |> List.tryFind (fun o -> not o.Variadic && (o.Args |> Array.map fsharpType |> List.ofArray) = List.map Some wanted)
     match exact, candidates |> List.tryFind (fun o -> o.Variadic) with
-    | Some o, _ -> { Entry = e; Overload = Some o; ProbeArgs = o.Args; Ret = ret o.Ret; SqlName = None }
+    | Some o, _ -> { Entry = e; Shape = Call o; ProbeArgs = o.Args; Ret = ret o.Ret; SqlName = None }
     | None, Some o ->
         let probeArgs =
             wanted |> List.map (fun t -> catalogType t |> Option.defaultWith (fun () -> failwith $"{e.Member}: no catalog type maps to {t}; add --map <pgtype>={t}"))
-        { Entry = e; Overload = Some o; ProbeArgs = List.toArray probeArgs; Ret = ret o.Ret; SqlName = None }
+        { Entry = e; Shape = Call o; ProbeArgs = List.toArray probeArgs; Ret = ret o.Ret; SqlName = None }
     | None, None when candidates.IsEmpty ->
-        match (if e.Params.IsEmpty then niladicType e.Catalog else None) with
-        | Some pg -> { Entry = e; Overload = None; ProbeArgs = [||]; Ret = ret pg; SqlName = None }
+        match keywordType e with
+        | Some pg -> { Entry = e; Shape = Keyword; ProbeArgs = [||]; Ret = ret pg; SqlName = None }
+        | None when e.Params.IsEmpty ->
+            failwith $"""{e.Catalog}: neither a plain function in {String.Join("/", schemas)} nor a bare keyword pg_typeof accepts. Keyword sugar has a catalog name (trim=btrim); expression nodes (coalesce, nullif) are hand-written."""
         | None ->
-            failwith $"""{e.Catalog}: neither a plain function in {String.Join("/", schemas)} nor a niladic keyword. Keyword sugar has a catalog name (trim=btrim); expression nodes (coalesce, nullif) are hand-written."""
+            failwith $"""{e.Catalog}: not a plain function in {String.Join("/", schemas)}. Keyword sugar has a catalog name (trim=btrim); expression nodes (coalesce, nullif) are hand-written. Only a parameterless line is offered to pg_typeof as a keyword."""
     | None, None ->
         failwith $"""{e.Member}({String.Join(", ", wanted)}): no such overload. The catalog has {String.Join("; ", candidates |> List.map describe)}"""
 
-/// Runs `name(NULL::t1, …)` once. A spelling PostgreSQL rejects as syntax (`position(a, b)`) is
-/// retried schema-qualified, and the member then renders that spelling.
+/// Runs `name(NULL::t1, …)` once for a Call. A spelling PostgreSQL rejects as syntax
+/// (`position(a, b)`) is retried schema-qualified, and the member then renders that spelling.
+/// A Keyword was already executed by `keywordType`, so there is nothing left to ask.
 let probe (m: Member) =
-    match m.Overload with
-    | None -> m // pg_typeof already ran it
-    | Some overload ->
-
-    let nulls = m.ProbeArgs |> Array.map (fun t -> $"NULL::{t}") |> String.concat ", "
-    let parses (spelling: string) =
-        try
-            use cmd = db.CreateCommand()
-            cmd.CommandText <- $"SELECT {spelling}({nulls})"
-            cmd.ExecuteScalar() |> ignore
-            true
-        with :? PostgresException as ex when ex.SqlState = "42601" -> false
-    let qualified = $"{overload.Schema}.{overload.Name}"
-    if parses m.Entry.Member then m
-    elif parses qualified then { m with SqlName = Some qualified }
-    else failwith $"{m.Entry.Member}({nulls}) cannot be called as a function, even as {qualified}"
+    match m.Shape with
+    | Keyword -> m
+    | Call overload ->
+        let nulls = m.ProbeArgs |> Array.map (fun t -> $"NULL::{t}") |> String.concat ", "
+        let parses (spelling: string) =
+            try
+                use cmd = db.CreateCommand()
+                cmd.CommandText <- $"SELECT {spelling}({nulls})"
+                cmd.ExecuteScalar() |> ignore
+                true
+            with :? PostgresException as ex when ex.SqlState = "42601" -> false
+        let qualified = $"{overload.Schema}.{overload.Name}"
+        if parses m.Entry.Member then m
+        elif parses qualified then { m with SqlName = Some qualified }
+        else failwith $"{m.Entry.Member}({nulls}) cannot be called as a function, even as {qualified}"
 
 let members = entries |> List.map (resolve >> probe)
 db.Close()
@@ -181,18 +189,20 @@ db.Close()
 
 let memberLines (m: Member) =
     let attribute =
-        match m.Overload, m.SqlName with
-        | None, _ -> [ "    [<SqlHydraFunction(Niladic = true)>]" ]
-        | Some _, s -> s |> Option.map (fun n -> $"    [<SqlHydraFunction(\"{n}\")>]") |> Option.toList
+        match m.Shape with
+        | Keyword -> [ "    [<SqlHydraFunction(Niladic = true)>]" ]
+        | Call _ -> m.SqlName |> Option.map (fun n -> $"    [<SqlHydraFunction(\"{n}\")>]") |> Option.toList
     let line (ps: (string * string) list) ret =
         let plist = ps |> List.map (fun (n, t) -> $"{n}: {t}") |> String.concat ", "
         attribute @ [ $"    static member {m.Entry.Member}({plist}) : {ret} = sqlFn" ]
     [ yield! line m.Entry.Params m.Ret
-      if m.Overload |> Option.exists (fun o -> o.Strict) then
+      match m.Shape with
+      | Call o when o.Strict ->
           for i in 0 .. m.Entry.Params.Length - 1 do
               let lifted = fst m.Entry.Params.[i]
               yield $"    /// NULL `{lifted}` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`."
-              yield! line (m.Entry.Params |> List.mapi (fun j (n, t) -> if i = j then n, $"{t} option" else n, t)) $"{m.Ret} option" ]
+              yield! line (m.Entry.Params |> List.mapi (fun j (n, t) -> if i = j then n, $"{t} option" else n, t)) $"{m.Ret} option"
+      | _ -> () ]
 
 let header = "    // <generated> by codegen/NpgsqlSqlFn.fsx from pg_proc; edit the allowlist, not this block."
 let footer = "    // </generated>"

--- a/src/SqlHydra.Query/codegen/NpgsqlSqlFn.fsx
+++ b/src/SqlHydra.Query/codegen/NpgsqlSqlFn.fsx
@@ -5,6 +5,12 @@
 // that cannot be called as `NAME(args)` is emitted; a keyword-named function such as `position`
 // renders schema-qualified instead.
 //
+// SQL's niladic functions (`current_date`, `user`) have no `pg_proc` row at all: the parser reads
+// them as keywords, and `CURRENT_DATE()` is a syntax error. An allowlist line with no parameters
+// that the catalog cannot resolve is offered to `SELECT pg_typeof(<name>)`, which proves the bare
+// spelling parses and names its return type. Those members are emitted `Niladic`, so the visitor
+// renders the name on its own. Nothing in the allowlist marks them; PostgreSQL decides.
+//
 //   dotnet fsi NpgsqlSqlFn.fsx                    rewrite the generated region of NpgsqlExtensions.fs
 //   dotnet fsi NpgsqlSqlFn.fsx --check            exit 1 if that region is stale (CI)
 //   dotnet fsi NpgsqlSqlFn.fsx --conn "..." --allowlist my-fns.txt --schema public \
@@ -53,7 +59,7 @@ let builtinTypes =
       "double precision", "float"; "real", "float32"; "numeric", "decimal"; "money", "decimal"
       "boolean", "bool"; "uuid", "Guid"; "bytea", "byte[]"
       "timestamp without time zone", "DateTime"; "timestamp with time zone", "DateTime"; "date", "DateTime"
-      "interval", "TimeSpan"; "time without time zone", "TimeSpan" ]
+      "interval", "TimeSpan"; "time without time zone", "TimeSpan"; "time with time zone", "DateTimeOffset" ]
 
 let userTypes =
     optValues "--map" args
@@ -116,7 +122,17 @@ let catalog =
 let describe (o: Overload) = $"""({String.Join(", ", o.Args)}) -> {o.Ret}"""
 
 /// A member to emit: the allowlist line, its catalog overload, and the catalog types to probe with.
-type Member = { Entry: Entry; Overload: Overload; ProbeArgs: string []; Ret: string; SqlName: string option }
+/// `Overload` is None for a niladic keyword, which has no `pg_proc` row to resolve against.
+type Member = { Entry: Entry; Overload: Overload option; ProbeArgs: string []; Ret: string; SqlName: string option }
+
+/// A name with no `pg_proc` row may still be a niladic keyword. `SELECT pg_typeof(current_date)`
+/// settles both questions at once: that the bare spelling parses, and what it returns.
+let niladicType (name: string) =
+    try
+        use cmd = db.CreateCommand()
+        cmd.CommandText <- $"SELECT pg_typeof({name})::text"
+        Some (cmd.ExecuteScalar() :?> string)
+    with :? PostgresException as ex when ex.SqlState = "42601" || ex.SqlState = "42703" -> None
 
 let resolve (e: Entry) =
     let candidates = catalog |> List.filter (fun o -> o.Name = e.Catalog)
@@ -125,19 +141,28 @@ let resolve (e: Entry) =
         fsharpType o.Ret |> Option.defaultWith (fun () -> failwith $"{e.Member}: return type {o.Ret} has no F# type; add --map {o.Ret}=<Type>")
     let exact = candidates |> List.tryFind (fun o -> not o.Variadic && (o.Args |> Array.map fsharpType |> List.ofArray) = List.map Some wanted)
     match exact, candidates |> List.tryFind (fun o -> o.Variadic) with
-    | Some o, _ -> { Entry = e; Overload = o; ProbeArgs = o.Args; Ret = ret o; SqlName = None }
+    | Some o, _ -> { Entry = e; Overload = Some o; ProbeArgs = o.Args; Ret = ret o; SqlName = None }
     | None, Some o ->
         let probeArgs =
             wanted |> List.map (fun t -> catalogType t |> Option.defaultWith (fun () -> failwith $"{e.Member}: no catalog type maps to {t}; add --map <pgtype>={t}"))
-        { Entry = e; Overload = o; ProbeArgs = List.toArray probeArgs; Ret = ret o; SqlName = None }
+        { Entry = e; Overload = Some o; ProbeArgs = List.toArray probeArgs; Ret = ret o; SqlName = None }
     | None, None when candidates.IsEmpty ->
-        failwith $"""{e.Catalog}: not a plain function in {String.Join("/", schemas)}. Keyword sugar has a catalog name (trim=btrim); expression nodes (coalesce, nullif) and bare keywords (current_date) are hand-written."""
+        match (if e.Params.IsEmpty then niladicType e.Catalog else None) with
+        | Some pg ->
+            let fs = fsharpType pg |> Option.defaultWith (fun () -> failwith $"{e.Member}: return type {pg} has no F# type; add --map {pg}=<Type>")
+            { Entry = e; Overload = None; ProbeArgs = [||]; Ret = fs; SqlName = None }
+        | None ->
+            failwith $"""{e.Catalog}: neither a plain function in {String.Join("/", schemas)} nor a niladic keyword. Keyword sugar has a catalog name (trim=btrim); expression nodes (coalesce, nullif) are hand-written."""
     | None, None ->
         failwith $"""{e.Member}({String.Join(", ", wanted)}): no such overload. The catalog has {String.Join("; ", candidates |> List.map describe)}"""
 
 /// Runs `name(NULL::t1, …)` once. A spelling PostgreSQL rejects as syntax (`position(a, b)`) is
 /// retried schema-qualified, and the member then renders that spelling.
 let probe (m: Member) =
+    match m.Overload with
+    | None -> m // pg_typeof already ran it
+    | Some overload ->
+
     let nulls = m.ProbeArgs |> Array.map (fun t -> $"NULL::{t}") |> String.concat ", "
     let parses (spelling: string) =
         try
@@ -146,7 +171,7 @@ let probe (m: Member) =
             cmd.ExecuteScalar() |> ignore
             true
         with :? PostgresException as ex when ex.SqlState = "42601" -> false
-    let qualified = $"{m.Overload.Schema}.{m.Overload.Name}"
+    let qualified = $"{overload.Schema}.{overload.Name}"
     if parses m.Entry.Member then m
     elif parses qualified then { m with SqlName = Some qualified }
     else failwith $"{m.Entry.Member}({nulls}) cannot be called as a function, even as {qualified}"
@@ -157,12 +182,15 @@ db.Close()
 // ---------------------------------------------------------------- emit
 
 let memberLines (m: Member) =
-    let attribute = m.SqlName |> Option.map (fun n -> $"    [<SqlHydraFunction(\"{n}\")>]") |> Option.toList
+    let attribute =
+        match m.Overload, m.SqlName with
+        | None, _ -> [ "    [<SqlHydraFunction(Niladic = true)>]" ]
+        | Some _, s -> s |> Option.map (fun n -> $"    [<SqlHydraFunction(\"{n}\")>]") |> Option.toList
     let line (ps: (string * string) list) ret =
         let plist = ps |> List.map (fun (n, t) -> $"{n}: {t}") |> String.concat ", "
         attribute @ [ $"    static member {m.Entry.Member}({plist}) : {ret} = sqlFn" ]
     [ yield! line m.Entry.Params m.Ret
-      if m.Overload.Strict then
+      if m.Overload |> Option.exists (fun o -> o.Strict) then
           for i in 0 .. m.Entry.Params.Length - 1 do
               let lifted = fst m.Entry.Params.[i]
               yield $"    /// NULL `{lifted}` is NULL out: hydrates as None, and `= None` renders IS NULL; compare with `= Some x`."

--- a/src/SqlHydra.Query/codegen/NpgsqlSqlFn.fsx
+++ b/src/SqlHydra.Query/codegen/NpgsqlSqlFn.fsx
@@ -137,20 +137,18 @@ let niladicType (name: string) =
 let resolve (e: Entry) =
     let candidates = catalog |> List.filter (fun o -> o.Name = e.Catalog)
     let wanted = e.Params |> List.map snd
-    let ret (o: Overload) =
-        fsharpType o.Ret |> Option.defaultWith (fun () -> failwith $"{e.Member}: return type {o.Ret} has no F# type; add --map {o.Ret}=<Type>")
+    let ret pg =
+        fsharpType pg |> Option.defaultWith (fun () -> failwith $"{e.Member}: return type {pg} has no F# type; add --map {pg}=<Type>")
     let exact = candidates |> List.tryFind (fun o -> not o.Variadic && (o.Args |> Array.map fsharpType |> List.ofArray) = List.map Some wanted)
     match exact, candidates |> List.tryFind (fun o -> o.Variadic) with
-    | Some o, _ -> { Entry = e; Overload = Some o; ProbeArgs = o.Args; Ret = ret o; SqlName = None }
+    | Some o, _ -> { Entry = e; Overload = Some o; ProbeArgs = o.Args; Ret = ret o.Ret; SqlName = None }
     | None, Some o ->
         let probeArgs =
             wanted |> List.map (fun t -> catalogType t |> Option.defaultWith (fun () -> failwith $"{e.Member}: no catalog type maps to {t}; add --map <pgtype>={t}"))
-        { Entry = e; Overload = Some o; ProbeArgs = List.toArray probeArgs; Ret = ret o; SqlName = None }
+        { Entry = e; Overload = Some o; ProbeArgs = List.toArray probeArgs; Ret = ret o.Ret; SqlName = None }
     | None, None when candidates.IsEmpty ->
         match (if e.Params.IsEmpty then niladicType e.Catalog else None) with
-        | Some pg ->
-            let fs = fsharpType pg |> Option.defaultWith (fun () -> failwith $"{e.Member}: return type {pg} has no F# type; add --map {pg}=<Type>")
-            { Entry = e; Overload = None; ProbeArgs = [||]; Ret = fs; SqlName = None }
+        | Some pg -> { Entry = e; Overload = None; ProbeArgs = [||]; Ret = ret pg; SqlName = None }
         | None ->
             failwith $"""{e.Catalog}: neither a plain function in {String.Join("/", schemas)} nor a niladic keyword. Keyword sugar has a catalog name (trim=btrim); expression nodes (coalesce, nullif) are hand-written."""
     | None, None ->

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -1310,6 +1310,7 @@ let ``PostgreSQL accepts a niladic function``() = task {
             for a in person.address do
             where (a.modifieddate < current_timestamp())
             select (current_date(), current_time(), current_timestamp(), localtime(), localtimestamp())
+            take 1
         }
 
     gt0 rows
@@ -1323,6 +1324,7 @@ let ``PostgreSQL accepts a niladic function that names the current session``() =
         selectTask db {
             for a in person.address do
             select (current_catalog(), current_schema(), current_user(), session_user(), user())
+            take 1
         }
 
     gt0 rows

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -1299,3 +1299,15 @@ let ``onConflictDoUpdateCoalesceWrite: a null in the new row keeps the existing 
 
     do! WriteRecordFixture.exec ctx DoUpdateWriteFixture.dropDdl
 }
+
+[<Test>]
+let ``PostgreSQL accepts a niladic function``() = task {
+    // The parenthesised spelling is a syntax error, so this query never reached the server.
+    let! addresses =
+        selectTask db {
+            for a in person.address do
+            where (a.modifieddate < current_timestamp())
+        }
+
+    gt0 addresses
+}

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -1323,3 +1323,27 @@ let ``a niladic function hydrates as the type PostgreSQL returns``() = task {
 
     gt0 times
 }
+
+[<Test>]
+let ``the generated date and time keywords round-trip``() = task {
+    let! rows =
+        selectTask db {
+            for a in person.address do
+            select (current_date(), current_time(), current_timestamp(), localtime(), localtimestamp())
+        }
+
+    gt0 rows
+}
+
+[<Test>]
+let ``the generated name keywords round-trip``() = task {
+    // current_user and session_user are ordinary catalog functions that the parser reads as
+    // keywords, so they render schema-qualified rather than bare. current_schema is neither.
+    let! rows =
+        selectTask db {
+            for a in person.address do
+            select (current_catalog(), current_schema(), current_user(), session_user(), user())
+        }
+
+    gt0 rows
+}

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -1311,3 +1311,15 @@ let ``PostgreSQL accepts a niladic function``() = task {
 
     gt0 addresses
 }
+
+[<Test>]
+let ``a niladic function hydrates as the type PostgreSQL returns``() = task {
+    // current_time is `time with time zone`, which Npgsql reads as DateTimeOffset.
+    let! times =
+        selectTask db {
+            for a in person.address do
+            select (current_time())
+        }
+
+    gt0 times
+}

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -1303,32 +1303,12 @@ let ``onConflictDoUpdateCoalesceWrite: a null in the new row keeps the existing 
 [<Test>]
 let ``PostgreSQL accepts a niladic function``() = task {
     // The parenthesised spelling is a syntax error, so this query never reached the server.
-    let! addresses =
-        selectTask db {
-            for a in person.address do
-            where (a.modifieddate < current_timestamp())
-        }
-
-    gt0 addresses
-}
-
-[<Test>]
-let ``a niladic function hydrates as the type PostgreSQL returns``() = task {
-    // current_time is `time with time zone`, which Npgsql reads as DateTimeOffset.
-    let! times =
-        selectTask db {
-            for a in person.address do
-            select (current_time())
-        }
-
-    gt0 times
-}
-
-[<Test>]
-let ``the generated date and time keywords round-trip``() = task {
+    // Hydration is part of the claim: current_time is `time with time zone`, which Npgsql
+    // reads as DateTimeOffset, not the TimeSpan of `time without time zone`.
     let! rows =
         selectTask db {
             for a in person.address do
+            where (a.modifieddate < current_timestamp())
             select (current_date(), current_time(), current_timestamp(), localtime(), localtimestamp())
         }
 
@@ -1336,7 +1316,7 @@ let ``the generated date and time keywords round-trip``() = task {
 }
 
 [<Test>]
-let ``the generated name keywords round-trip``() = task {
+let ``PostgreSQL accepts a niladic function that names the current session``() = task {
     // current_user and session_user are ordinary catalog functions that the parser reads as
     // keywords, so they render schema-qualified rather than bare. current_schema is neither.
     let! rows =

--- a/src/Tests/Npgsql/QueryIntegrationTests.fs
+++ b/src/Tests/Npgsql/QueryIntegrationTests.fs
@@ -1320,6 +1320,7 @@ let ``PostgreSQL accepts a niladic function``() = task {
 let ``PostgreSQL accepts a niladic function that names the current session``() = task {
     // current_user and session_user are ordinary catalog functions that the parser reads as
     // keywords, so they render schema-qualified rather than bare. current_schema is neither.
+    // No Oracle twin: SqlHydra wraps no Oracle function that names the session.
     let! rows =
         selectTask db {
             for a in person.address do

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1768,6 +1768,39 @@ let ``a keyword-named function renders schema-qualified``() =
     test <@ sql.Contains("(pg_catalog.position(a.city, 'a') > @p0)") @>
 
 [<Test>]
+let ``a niladic function renders as a bare keyword in a where``() =
+    // CURRENT_DATE is a keyword, not a call: PostgreSQL rejects `CURRENT_DATE()`.
+    let sql =
+        select {
+            for a in person.address do
+            where (SqlFn.current_date() > System.DateTime.MinValue)
+        }
+        |> toSql
+    test <@ sql.Contains("(CURRENT_DATE > @p0)") @>
+
+[<Test>]
+let ``a niladic function renders as a bare keyword in a select``() =
+    let sql =
+        select {
+            for a in person.address do
+            select (a.city, SqlFn.current_timestamp())
+        }
+        |> toSql
+    test <@ sql.Contains("CURRENT_TIMESTAMP") @>
+    test <@ not (sql.Contains "CURRENT_TIMESTAMP()") @>
+
+[<Test>]
+let ``a niladic function renders as a bare keyword in an orderBy``() =
+    let sql =
+        select {
+            for a in person.address do
+            orderBy (SqlFn.current_time())
+        }
+        |> toSql
+    test <@ sql.Contains("CURRENT_TIME") @>
+    test <@ not (sql.Contains "CURRENT_TIME()") @>
+
+[<Test>]
 let ``every option overload is the option-lifting of one sibling``() =
     let isOption (t: Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
     let twins =

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1767,6 +1767,9 @@ let ``a keyword-named function renders schema-qualified``() =
         |> toSql
     test <@ sql.Contains("(pg_catalog.position(a.city, 'a') > @p0)") @>
 
+// Niladic functions, one test per site the visitor renders a call from. Each assertion carries the
+// token that follows the name, so a stray `()` breaks the match instead of hiding inside it.
+
 [<Test>]
 let ``a niladic function renders as a bare keyword in a where``() =
     // CURRENT_DATE is a keyword, not a call: PostgreSQL rejects `CURRENT_DATE()`.
@@ -1776,7 +1779,7 @@ let ``a niladic function renders as a bare keyword in a where``() =
             where (SqlFn.current_date() > System.DateTime.MinValue)
         }
         |> toSql
-    test <@ sql.Contains("(CURRENT_DATE > @p0)") @>
+    test <@ sql.Contains "WHERE (CURRENT_DATE > @p0)" @>
 
 [<Test>]
 let ``a niladic function renders as a bare keyword in a select``() =
@@ -1786,8 +1789,7 @@ let ``a niladic function renders as a bare keyword in a select``() =
             select (a.city, SqlFn.current_timestamp())
         }
         |> toSql
-    test <@ sql.Contains("CURRENT_TIMESTAMP") @>
-    test <@ not (sql.Contains "CURRENT_TIMESTAMP()") @>
+    test <@ sql.Contains "CURRENT_TIMESTAMP FROM" @>
 
 [<Test>]
 let ``a niladic function renders as a bare keyword in an orderBy``() =
@@ -1797,8 +1799,7 @@ let ``a niladic function renders as a bare keyword in an orderBy``() =
             orderBy (SqlFn.current_time())
         }
         |> toSql
-    test <@ sql.Contains("CURRENT_TIME") @>
-    test <@ not (sql.Contains "CURRENT_TIME()") @>
+    test <@ sql.EndsWith "ORDER BY CURRENT_TIME" @>
 
 [<Test>]
 let ``every option overload is the option-lifting of one sibling``() =

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1802,6 +1802,20 @@ let ``a niladic function renders as a bare keyword in an orderBy``() =
     test <@ sql.EndsWith "ORDER BY CURRENT_TIME" @>
 
 [<Test>]
+let ``a niladic member takes no arguments``() =
+    // renderSqlFunctionCall drops the argument list for a Niladic member, so marking one that
+    // takes arguments would render SQL that silently loses them. Nothing else catches that.
+    let niladic =
+        typeof<SqlFn>.GetMethods(Reflection.BindingFlags.Public ||| Reflection.BindingFlags.Static)
+        |> Array.filter (fun m ->
+            match Attribute.GetCustomAttribute(m, typeof<SqlHydraFunctionAttribute>, false) with
+            | :? SqlHydraFunctionAttribute as att -> att.Niladic
+            | _ -> false)
+    test <@ niladic.Length > 0 @>
+    for m in niladic do
+        Assert.That(m.GetParameters().Length, Is.EqualTo 0, $"{m.Name} is marked Niladic but takes arguments")
+
+[<Test>]
 let ``every option overload is the option-lifting of one sibling``() =
     let isOption (t: Type) = t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
     let twins =

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1782,14 +1782,14 @@ let ``a niladic function renders as a bare keyword in a where``() =
     test <@ sql.Contains "WHERE (CURRENT_DATE > @p0)" @>
 
 [<Test>]
-let ``a niladic function renders as a bare keyword in a select``() =
+let ``every niladic date and time member renders as a bare keyword in a select``() =
     let sql =
         select {
             for a in person.address do
-            select (a.city, SqlFn.current_timestamp())
+            select (SqlFn.current_date(), SqlFn.current_time(), SqlFn.current_timestamp(), SqlFn.localtime(), SqlFn.localtimestamp())
         }
         |> toSql
-    test <@ sql.Contains "CURRENT_TIMESTAMP FROM" @>
+    test <@ sql.Contains "SELECT CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, LOCALTIME, LOCALTIMESTAMP FROM" @>
 
 [<Test>]
 let ``a niladic function renders as a bare keyword in an orderBy``() =

--- a/src/Tests/Oracle/QueryIntegrationTests.fs
+++ b/src/Tests/Oracle/QueryIntegrationTests.fs
@@ -425,3 +425,15 @@ let ``SqlFn - Oracle functions smoke test``() = task {
     Assert.That(upperName, Is.EqualTo(name.ToUpper()))
     Assert.That(website, Is.Not.Null)
 }
+
+[<Test>]
+let ``Oracle accepts the niladic date functions``() = task {
+    // Oracle takes no argument list for any of these, so `SYSDATE()` never reached the server.
+    let! rows =
+        selectTask db {
+            for c in OT.CUSTOMERS do
+            select (SYSDATE(), SYSTIMESTAMP(), CURRENT_DATE(), CURRENT_TIMESTAMP())
+        }
+
+    gt0 rows
+}

--- a/src/Tests/Oracle/QueryIntegrationTests.fs
+++ b/src/Tests/Oracle/QueryIntegrationTests.fs
@@ -427,8 +427,8 @@ let ``SqlFn - Oracle functions smoke test``() = task {
 }
 
 [<Test>]
-let ``Oracle accepts the niladic date functions``() = task {
-    // Oracle takes no argument list for any of these, so `SYSDATE()` never reached the server.
+let ``Oracle accepts a niladic function``() = task {
+    // The parenthesised spelling is a syntax error, so this query never reached the server.
     let! rows =
         selectTask db {
             for c in OT.CUSTOMERS do

--- a/src/Tests/Oracle/QueryIntegrationTests.fs
+++ b/src/Tests/Oracle/QueryIntegrationTests.fs
@@ -429,9 +429,13 @@ let ``SqlFn - Oracle functions smoke test``() = task {
 [<Test>]
 let ``Oracle accepts a niladic function``() = task {
     // The parenthesised spelling is a syntax error, so this query never reached the server.
+    // The Npgsql twin compares a column to the function; here the function is compared to a
+    // value instead, because `where (col < FN())` renders the column unquoted and Oracle then
+    // folds it to upper case and cannot find it. That is a separate, pre-existing bug.
     let! rows =
         selectTask db {
-            for c in OT.CUSTOMERS do
+            for o in OT.ORDERS do
+            where (SYSDATE() > System.DateTime.MinValue)
             select (SYSDATE(), SYSTIMESTAMP(), CURRENT_DATE(), CURRENT_TIMESTAMP())
             take 1
         }

--- a/src/Tests/Oracle/QueryIntegrationTests.fs
+++ b/src/Tests/Oracle/QueryIntegrationTests.fs
@@ -433,6 +433,7 @@ let ``Oracle accepts a niladic function``() = task {
         selectTask db {
             for c in OT.CUSTOMERS do
             select (SYSDATE(), SYSTIMESTAMP(), CURRENT_DATE(), CURRENT_TIMESTAMP())
+            take 1
         }
 
     gt0 rows

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -473,3 +473,17 @@ let ``a niladic function renders as a bare keyword in a select``() =
         }
         |> toSql
     test <@ sql.Contains "SELECT SYSDATE, SYSTIMESTAMP, CURRENT_DATE, CURRENT_TIMESTAMP FROM" @>
+
+[<Test>]
+let ``a niladic member takes no arguments``() =
+    // renderSqlFunctionCall drops the argument list for a Niladic member, so marking one that
+    // takes arguments would render SQL that silently loses them. Nothing else catches that.
+    let niladic =
+        typeof<SqlFn>.GetMethods(Reflection.BindingFlags.Public ||| Reflection.BindingFlags.Static)
+        |> Array.filter (fun m ->
+            match Attribute.GetCustomAttribute(m, typeof<SqlHydraFunctionAttribute>, false) with
+            | :? SqlHydraFunctionAttribute as att -> att.Niladic
+            | _ -> false)
+    test <@ niladic.Length > 0 @>
+    for m in niladic do
+        Assert.That(m.GetParameters().Length, Is.EqualTo 0, $"{m.Name} is marked Niladic but takes arguments")

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -456,3 +456,24 @@ let ``Inline Aggregates``() =
         |> toSql
 
     sql =! "SELECT COUNT(\"o\".\"ORDER_ID\") AS __hydra_expr_0 FROM \"OT\".\"ORDERS\" \"o\"".RemoveHydraExpr()
+
+[<Test>]
+let ``Niladic date functions render as bare keywords``() =
+    // Oracle parses these as keywords and takes no argument list for any of them,
+    // so `SYSDATE()` never reaches a result set.
+    let sql =
+        select {
+            for o in OT.ORDERS do
+            select (SqlHydra.Query.OracleExtensions.SqlFn.SYSDATE(),
+                    SqlHydra.Query.OracleExtensions.SqlFn.SYSTIMESTAMP(),
+                    SqlHydra.Query.OracleExtensions.SqlFn.CURRENT_DATE(),
+                    SqlHydra.Query.OracleExtensions.SqlFn.CURRENT_TIMESTAMP())
+        }
+        |> toSql
+
+    sql.Contains "SYSDATE()" =! false
+    sql.Contains "SYSTIMESTAMP()" =! false
+    sql.Contains "CURRENT_DATE()" =! false
+    sql.Contains "CURRENT_TIMESTAMP()" =! false
+    sql.Contains "SYSDATE" =! true
+    sql.Contains "CURRENT_TIMESTAMP" =! true

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -459,13 +459,22 @@ let ``Inline Aggregates``() =
 
     sql =! "SELECT COUNT(\"o\".\"ORDER_ID\") AS __hydra_expr_0 FROM \"OT\".\"ORDERS\" \"o\"".RemoveHydraExpr()
 
-// The visitor is shared, so the where and orderBy sites are covered once, in the Npgsql tests.
-// What is Oracle's own is which members are marked, so all four are named here.
+// Niladic functions, one test per site the visitor renders a call from. Each assertion carries the
+// token that follows the name, so a stray `()` breaks the match instead of hiding inside it.
 
 [<Test>]
-let ``a niladic function renders as a bare keyword in a select``() =
-    // Oracle parses these as keywords and takes no argument list for any of them,
-    // so `SYSDATE()` never reaches a result set.
+let ``a niladic function renders as a bare keyword in a where``() =
+    // SYSDATE is a keyword, not a call: Oracle rejects `SYSDATE()`.
+    let sql =
+        select {
+            for o in OT.ORDERS do
+            where (SYSDATE() > System.DateTime.MinValue)
+        }
+        |> toSql
+    test <@ sql.Contains "WHERE (SYSDATE > :p0)" @>
+
+[<Test>]
+let ``every niladic date and time member renders as a bare keyword in a select``() =
     let sql =
         select {
             for o in OT.ORDERS do
@@ -473,6 +482,16 @@ let ``a niladic function renders as a bare keyword in a select``() =
         }
         |> toSql
     test <@ sql.Contains "SELECT SYSDATE, SYSTIMESTAMP, CURRENT_DATE, CURRENT_TIMESTAMP FROM" @>
+
+[<Test>]
+let ``a niladic function renders as a bare keyword in an orderBy``() =
+    let sql =
+        select {
+            for o in OT.ORDERS do
+            orderBy (SYSTIMESTAMP())
+        }
+        |> toSql
+    test <@ sql.EndsWith "ORDER BY SYSTIMESTAMP" @>
 
 [<Test>]
 let ``a niladic member takes no arguments``() =

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -3,6 +3,8 @@
 open System
 open Swensen.Unquote
 open SqlHydra.Query
+open SqlHydra.Query.OracleExtensions
+open type SqlFn
 open NUnit.Framework
 open DB
 
@@ -457,23 +459,17 @@ let ``Inline Aggregates``() =
 
     sql =! "SELECT COUNT(\"o\".\"ORDER_ID\") AS __hydra_expr_0 FROM \"OT\".\"ORDERS\" \"o\"".RemoveHydraExpr()
 
+// The visitor is shared, so the where and orderBy sites are covered once, in the Npgsql tests.
+// What is Oracle's own is which members are marked, so all four are named here.
+
 [<Test>]
-let ``Niladic date functions render as bare keywords``() =
+let ``a niladic function renders as a bare keyword in a select``() =
     // Oracle parses these as keywords and takes no argument list for any of them,
     // so `SYSDATE()` never reaches a result set.
     let sql =
         select {
             for o in OT.ORDERS do
-            select (SqlHydra.Query.OracleExtensions.SqlFn.SYSDATE(),
-                    SqlHydra.Query.OracleExtensions.SqlFn.SYSTIMESTAMP(),
-                    SqlHydra.Query.OracleExtensions.SqlFn.CURRENT_DATE(),
-                    SqlHydra.Query.OracleExtensions.SqlFn.CURRENT_TIMESTAMP())
+            select (SYSDATE(), SYSTIMESTAMP(), CURRENT_DATE(), CURRENT_TIMESTAMP())
         }
         |> toSql
-
-    sql.Contains "SYSDATE()" =! false
-    sql.Contains "SYSTIMESTAMP()" =! false
-    sql.Contains "CURRENT_DATE()" =! false
-    sql.Contains "CURRENT_TIMESTAMP()" =! false
-    sql.Contains "SYSDATE" =! true
-    sql.Contains "CURRENT_TIMESTAMP" =! true
+    test <@ sql.Contains "SELECT SYSDATE, SYSTIMESTAMP, CURRENT_DATE, CURRENT_TIMESTAMP FROM" @>


### PR DESCRIPTION
the onslaught of PRs continues...

In this addition: handling niladic functions correctly, with a regression test and some niladics generators

(niladic: a special type of function that takes no args, including no parens in this case)

---

`SqlFn.current_date()` produces `CURRENT_DATE()`, which no database accepts:

```
PostgreSQL   42601: syntax error at or near "("
Oracle       ORA-00923: FROM keyword not found where expected
```

`CURRENT_DATE` is a keyword, not a function call. SQL has a handful of these and they take no parentheses at all, so every member wrapping one produced SQL that could not run.

**The fix.** `[<SqlHydraFunction(Niladic = true)>]` renders the name on its own, and one helper now builds every function call, so `where`, `select` and `orderBy` agree.

**A wrong type it was hiding.** `current_time` returns `time with time zone`, which Npgsql reads as `DateTimeOffset`. The member said `TimeSpan`. Nobody hit it, because the query never got past the parser.

**PostgreSQL now identifies these itself.** `SELECT pg_typeof(current_date)` proves the bare spelling parses and says what it returns, so the generator works them out rather than being told. One undifferentiated list of names, three different results:

```
current_date     ->  CURRENT_DATE
current_schema   ->  CURRENT_SCHEMA()
current_user     ->  pg_catalog.current_user()
```

That also adds `localtime`, `localtimestamp`, `current_catalog`, `current_schema`, `current_user`, `session_user` and `user`.

**Oracle** gets the same for `SYSDATE`, `SYSTIMESTAMP`, `CURRENT_DATE` and `CURRENT_TIMESTAMP`, marked by hand since it has no generator. MySQL accepts both spellings and SQL Server's `SYSDATETIME()` is a real function, so neither changes.
