### PR TITLE
Column-level nullability for leftJoin via generated left-view records

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ An unmatched left join hydrates the view with every column `None`. To recover th
 let orders = rows |> Seq.map (fun (o, d) -> o, d.ToOption())  // d.ToOption() : SalesOrderDetail option
 ```
 
+`ToOption()` is generated as an extension member, so it is available whenever the generated namespace is `open`ed (which query code already requires).
+
 The classic `leftJoin ... on (o.Id = d.Value.Id)` form (whole record as `Option`) still works; both forms can be mixed per join site, so queries can be migrated one at a time.
 
 ### Selecting Columns

--- a/README.md
+++ b/README.md
@@ -248,6 +248,33 @@ selectTask db {
 
 > **Note:** In join `on` clauses, put the known (left) table on the left side of the `=`.
 
+### Left Joins with Left-Views
+
+Enabling `left_joined_views = true` under `[sqlhydra_query_integration]` in your `.toml` config generates a `LeftJoined` module inside each schema module, containing a "left-view" of each table record: the same record with every column in its nullable form. (The init wizard enables it for new configs.)
+
+Left-joining a left-view applies nullability at the **column** level (as SQL does) instead of wrapping the whole record in an `Option`, which removes the `.Value` theater from join conditions and projections:
+
+```fsharp
+selectTask db {
+    for o in Sales.SalesOrderHeader do
+    // The ON clause binds the plain record: no `.Value`, no `Some`.
+    leftJoin d in Sales.LeftJoined.SalesOrderDetail on (o.SalesOrderID = d.SalesOrderID)
+    // Downstream, d's columns behave like any nullable column.
+    where (d.OrderQty = Some 2s)
+    // "no match" is a column IS NULL check, the classic SQL anti-join idiom:
+    // where (isNullValue d.SalesOrderDetailID)
+    select (o, d)
+}
+```
+
+An unmatched left join hydrates the view with every column `None`. To recover the whole-record option after materialization, use the generated `ToOption()`:
+
+```fsharp
+let orders = rows |> Seq.map (fun (o, d) -> o, d.ToOption())  // d.ToOption() : SalesOrderDetail option
+```
+
+The classic `leftJoin ... on (o.Id = d.Value.Id)` form (whole record as `Option`) still works; both forms can be mixed per join site, so queries can be migrated one at a time.
+
 ### Selecting Columns
 
 ```fsharp

--- a/src/SqlHydra.Cli/Console.fs
+++ b/src/SqlHydra.Cli/Console.fs
@@ -49,6 +49,7 @@ let newConfigWizard (args: Args) =
             Config.NullablePropertyType = NullablePropertyType.Option
             Config.ProviderDbTypeAttributes = true
             Config.TableDeclarations = true
+            Config.LeftJoinedViews = true // Default-on for new configs; existing configs opt in.
             Config.Readers = None
             Config.Filters = Filters.Empty // User must manually configure filter in .toml file
             Config.TypeMappingExtensions = []
@@ -156,5 +157,11 @@ let run (args: Args) =
     File.WriteAllText(outputFile.FullName, generatedCode)
     Fsproj.addFileToProject args.Project cfg
     AnsiConsole.WriteLine()
+
+    // Left-views are Option-shaped by design, so a Nullable-typed config silently gets none;
+    // say so rather than leaving the user to wonder where the LeftJoined modules went.
+    if cfg.LeftJoinedViews && cfg.NullablePropertyType = NullablePropertyType.Nullable then
+        AnsiConsole.MarkupLine($"[yellow]- `left_joined_views` requires `nullable_property_type = \"option\"`; no LeftJoined views were generated.[/]")
+
     AnsiConsole.MarkupLine($"[gray]https://github.com/JordanMarr/SqlHydra/wiki/TOML-Configuration[/]")
     AnsiConsole.MarkupLine($"[green1]Generated: \"{outputFile.FullName}\"![/]")

--- a/src/SqlHydra.Cli/SchemaTemplate.fs
+++ b/src/SqlHydra.Cli/SchemaTemplate.fs
@@ -183,9 +183,9 @@ let mkTable cfg db (table: Table) schema tableName columnName = stringBuffer {
 }
 
 /// Emits the per-schema `LeftJoined` module: for each table, a left-view record — the same
-/// record with every column in its nullable form — implementing `ILeftViewOf<base>`, plus a
-/// `ToOption()` that recovers the whole-record option after materialization, and (with
+/// record with every column in its nullable form — implementing `ILeftViewOf<base>`, and (with
 /// table_declarations) a `leftTable` token for use as a `leftJoin` source.
+/// `ToOption()` is emitted separately in `mkLeftViewExtensions`, after the schema modules close.
 /// Only generated for `NullablePropertyType.Option` configs.
 let mkLeftJoinedViews (cfg: Config) (tables: Table list) tableName columnName = stringBuffer {
     "/// Left-views for `leftJoin`: each table record with every column in its nullable form,"
@@ -222,27 +222,57 @@ let mkLeftJoinedViews (cfg: Config) (tables: Table list) tableName columnName = 
                 }
                 "}"
                 $"interface ILeftViewOf<{baseAlias}>"
+            }
+            ""
 
-                // The match witness may be any NOT NULL column: a missed join makes every column
-                // None; a matched row makes every NOT NULL column Some. Prefer the PK. A table
-                // whose columns are all nullable gets no ToOption: a row of all NULLs is
-                // indistinguishable from a missed join, in SQL itself.
-                let witness =
-                    table.Columns
-                    |> List.tryFind (fun col -> col.IsPK && not col.IsNullable)
-                    |> Option.orElseWith (fun () -> table.Columns |> List.tryFind (fun col -> not col.IsNullable))
+            if cfg.TableDeclarations then
+                $"let {tblName} = leftTable<{baseAlias}, {tblName}>"
+                ""
+    }
+}
 
-                match witness with
-                | Some w ->
-                    ""
+/// Emits `[<AutoOpen>] module LeftViewExtensions`: one `ToOption()` extension member per left-view,
+/// declared after the schema modules close. Inside `LeftJoined` the view shadows its base record's
+/// name (and F# forbids referencing the enclosing module by qualified path from within itself), so
+/// an inline `ToOption` could only name the base through a `(base)` alias — out here both types are
+/// addressable by their real paths and the signature reads `Schema.Table option`, as users expect.
+/// AutoOpen activates when the generated namespace is opened, which query code already requires.
+let mkLeftViewExtensions (tablesBySchema: (string * Table list) list) tableName columnName = stringBuffer {
+    // The match witness may be any NOT NULL column: a missed join makes every column None; a
+    // matched row makes every NOT NULL column Some. Prefer the PK. A table whose columns are all
+    // nullable gets no ToOption: a row of all NULLs is indistinguishable from a missed join, in
+    // SQL itself.
+    let witnessOf (table: Table) =
+        table.Columns
+        |> List.tryFind (fun col -> col.IsPK && not col.IsNullable)
+        |> Option.orElseWith (fun () -> table.Columns |> List.tryFind (fun col -> not col.IsNullable))
+
+    let eligible =
+        tablesBySchema
+        |> List.collect (fun (schema, tables) ->
+            tables |> List.choose (fun table -> witnessOf table |> Option.map (fun w -> schema, table, w)))
+
+    if not eligible.IsEmpty then
+        "[<AutoOpen>]"
+        "module LeftViewExtensions ="
+        indent {
+            for (schema, table, w) in eligible do
+                let rawFieldName (col: Column) = columnName { NamingContext.Table = table; Column = Some col }
+                let fieldName (col: Column) = backticks (rawFieldName col)
+                let tblName = backticks (tableName { NamingContext.Table = table; Column = None })
+                let baseType = $"{backticks schema}.{tblName}"
+                let viewType = $"{backticks schema}.LeftJoined.{tblName}"
+
+                $"type {viewType} with"
+                indent {
                     "/// Recovers the whole-record option after materialization (pure .NET, not SQL):"
                     "/// Some when the left join matched, None when it did not."
-                    $"member this.ToOption() : {baseAlias} option ="
+                    $"member this.ToOption() : {baseType} option ="
                     indent {
                         $"match this.{fieldName w} with"
                         "| Some value ->"
                         indent {
-                            $"let record : {baseAlias} ="
+                            $"let record : {baseType} ="
                             indent {
                                 "{"
                                 indent {
@@ -257,14 +287,9 @@ let mkLeftJoinedViews (cfg: Config) (tables: Table list) tableName columnName = 
                         }
                         "| None -> None"
                     }
-                | None -> ()
-            }
-            ""
-
-            if cfg.TableDeclarations then
-                $"let {tblName} = leftTable<{baseAlias}, {tblName}>"
+                }
                 ""
-    }
+        }
 }
 
 let generate (cfg: Config) (provider: ISqlHydraDbProvider) (db: Schema) (version: Version.InformationalVersion) (namingExtensions: IExtendNaming list) = stringBuffer {
@@ -328,6 +353,16 @@ namespace {{cfg.Namespace}}
                 mkLeftJoinedViews cfg tables tableName columnName
                 newLine
         }
+
+    // The left-views' ToOption() lives outside the schema modules: see mkLeftViewExtensions.
+    if cfg.LeftJoinedViews && cfg.NullablePropertyType = NullablePropertyType.Option then
+        let tablesBySchema =
+            schemas
+            |> List.map (fun schema -> schema, filteredTables |> List.filter (fun t -> t.Schema = schema))
+            |> List.filter (fun (_, tables) -> not tables.IsEmpty)
+
+        mkLeftViewExtensions tablesBySchema tableName columnName
+        newLine
 
     // If the user configures ProviderDbTypeAttributes, we know they are using SqlHydra.Query.
     if cfg.ProviderDbTypeAttributes then

--- a/src/SqlHydra.Cli/SchemaTemplate.fs
+++ b/src/SqlHydra.Cli/SchemaTemplate.fs
@@ -60,19 +60,30 @@ type RecordDeclaration =
     | OpensGroup
     | ContinuesGroup
 
+/// The CLR type of a column, with array type names normalized:
+/// "byte[]", "string[]", "int[]", "int []", "int array" → "byte []", etc.
+let clrBaseType (col: Column) =
+    if col.TypeMapping.ClrType.EndsWith "[]" || col.TypeMapping.ClrType.EndsWith "array" then
+        let baseTypeNm = col.TypeMapping.ClrType.Split([| "[]"; " []"; " array" |], System.StringSplitOptions.RemoveEmptyEntries) |> Array.head
+        $"{baseTypeNm} []"
+    else
+        col.TypeMapping.ClrType
+
+/// `[<ProviderDbType(...)>]` for a column, when the schema declared one and the config wants them.
+let providerDbTypeAttribute (cfg: Config) (col: Column) =
+    match col.TypeMapping.ProviderDbType with
+    | Some providerDbType when cfg.ProviderDbTypeAttributes ->
+        Some $"[<ProviderDbType(\"{providerDbType}\")>]"
+    | _ ->
+        None
+
 let mkTable cfg db (table: Table) schema tableName columnName = stringBuffer {
     let tableType =
         db.Tables
         |> List.find (fun t -> t.Schema = schema && t.Name = table.Name)
 
     let columnPropertyType (col: Column) =
-        let baseType =
-            // Handles array types: "byte[]", "string[]", "int[]", "int []", "int array"
-            if col.TypeMapping.ClrType.EndsWith "[]" || col.TypeMapping.ClrType.EndsWith "array" then
-                let baseTypeNm = col.TypeMapping.ClrType.Split([| "[]"; " []"; " array" |], System.StringSplitOptions.RemoveEmptyEntries) |> Array.head
-                $"{baseTypeNm} []"
-            else
-                col.TypeMapping.ClrType
+        let baseType = clrBaseType col
 
         if col.IsNullable then
             match cfg.NullablePropertyType with
@@ -85,12 +96,7 @@ let mkTable cfg db (table: Table) schema tableName columnName = stringBuffer {
         else
             baseType
 
-    let providerDbTypeAttribute (col: Column) =
-        match col.TypeMapping.ProviderDbType with
-        | Some providerDbType when cfg.ProviderDbTypeAttributes ->
-            Some $"[<ProviderDbType(\"{providerDbType}\")>]"
-        | _ ->
-            None
+    let providerDbTypeAttribute = providerDbTypeAttribute cfg
 
     let rawFieldName (col: Column) = columnName { NamingContext.Table = table; Column = Some col }
     let fieldName (col: Column) = backticks (rawFieldName col)
@@ -176,6 +182,91 @@ let mkTable cfg db (table: Table) schema tableName columnName = stringBuffer {
         mkRecord ContinuesGroup writeName writableColumns (Some writeMembers)
 }
 
+/// Emits the per-schema `LeftJoined` module: for each table, a left-view record — the same
+/// record with every column in its nullable form — implementing `ILeftViewOf<base>`, plus a
+/// `ToOption()` that recovers the whole-record option after materialization, and (with
+/// table_declarations) a `leftTable` token for use as a `leftJoin` source.
+/// Only generated for `NullablePropertyType.Option` configs.
+let mkLeftJoinedViews (cfg: Config) (tables: Table list) tableName columnName = stringBuffer {
+    "/// Left-views for `leftJoin`: each table record with every column in its nullable form,"
+    "/// so an unmatched row reads as None per column instead of one Option around the record."
+    "module LeftJoined ="
+    indent {
+        for table in tables do
+            let rawFieldName (col: Column) = columnName { NamingContext.Table = table; Column = Some col }
+            let fieldName (col: Column) = backticks (rawFieldName col)
+            let rawTblName = tableName { NamingContext.Table = table; Column = None }
+            let tblName = backticks rawTblName
+            // The base record, aliased before the view of the same name shadows it. The enclosing
+            // schema module cannot be referenced by its qualified path from within itself.
+            let baseAlias = backticks $"{rawTblName} (base)"
+
+            $"type private {baseAlias} = {tblName}"
+            ""
+            // NoEquality/NoComparison: the views are transient query artifacts users never
+            // construct; comparisons go through columns — and it halves their compile cost.
+            if cfg.IsCLIMutable
+            then "[<CLIMutable; NoEquality; NoComparison>]"
+            else "[<NoEquality; NoComparison>]"
+            $"type {tblName} ="
+            indent {
+                "{"
+                indent {
+                    for col in table.Columns do
+                        match providerDbTypeAttribute cfg col with
+                        | Some attribute -> attribute
+                        | None -> ()
+                        // An already-nullable column stays a single Option: a NULL from a
+                        // missed join is indistinguishable from a stored NULL, as in SQL.
+                        $"""{if cfg.IsMutableProperties then "mutable " else ""}{fieldName col}: Option<{clrBaseType col}>"""
+                }
+                "}"
+                $"interface ILeftViewOf<{baseAlias}>"
+
+                // The match witness may be any NOT NULL column: a missed join makes every column
+                // None; a matched row makes every NOT NULL column Some. Prefer the PK. A table
+                // whose columns are all nullable gets no ToOption: a row of all NULLs is
+                // indistinguishable from a missed join, in SQL itself.
+                let witness =
+                    table.Columns
+                    |> List.tryFind (fun col -> col.IsPK && not col.IsNullable)
+                    |> Option.orElseWith (fun () -> table.Columns |> List.tryFind (fun col -> not col.IsNullable))
+
+                match witness with
+                | Some w ->
+                    ""
+                    "/// Recovers the whole-record option after materialization (pure .NET, not SQL):"
+                    "/// Some when the left join matched, None when it did not."
+                    $"member this.ToOption() : {baseAlias} option ="
+                    indent {
+                        $"match this.{fieldName w} with"
+                        "| Some value ->"
+                        indent {
+                            $"let record : {baseAlias} ="
+                            indent {
+                                "{"
+                                indent {
+                                    for col in table.Columns do
+                                        if col.Name = w.Name then $"{fieldName col} = value"
+                                        elif col.IsNullable then $"{fieldName col} = this.{fieldName col}"
+                                        else $"{fieldName col} = this.{fieldName col}.Value"
+                                }
+                                "}"
+                            }
+                            "Some record"
+                        }
+                        "| None -> None"
+                    }
+                | None -> ()
+            }
+            ""
+
+            if cfg.TableDeclarations then
+                $"let {tblName} = leftTable<{baseAlias}, {tblName}>"
+                ""
+    }
+}
+
 let generate (cfg: Config) (provider: ISqlHydraDbProvider) (db: Schema) (version: Version.InformationalVersion) (namingExtensions: IExtendNaming list) = stringBuffer {
     let tableName =
         let baseFn (ctx: NamingContext) = ctx.Table.Name
@@ -231,6 +322,11 @@ namespace {{cfg.Namespace}}
                     let tblName = tableName { NamingContext.Table = table; Column = None }
                     $"let {backticks tblName} = table<{backticks tblName}>"
                     newLine
+
+            // Left-views are Option-shaped by design; Nullable-typed configs skip them.
+            if cfg.LeftJoinedViews && cfg.NullablePropertyType = NullablePropertyType.Option && not tables.IsEmpty then
+                mkLeftJoinedViews cfg tables tableName columnName
+                newLine
         }
 
     // If the user configures ProviderDbTypeAttributes, we know they are using SqlHydra.Query.

--- a/src/SqlHydra.Cli/TomlConfigParser.fs
+++ b/src/SqlHydra.Cli/TomlConfigParser.fs
@@ -46,13 +46,19 @@ let read(toml: string) =
             match queryIntegrationTableMaybe with
             | Some queryIntegrationTable -> queryIntegrationTable.Get "provider_db_type_attributes"
             | None -> true // Default to true if missing
-        Config.TableDeclarations = 
+        Config.TableDeclarations =
             match queryIntegrationTableMaybe with
-            | Some queryIntegrationTable -> 
+            | Some queryIntegrationTable ->
                 match queryIntegrationTable.TryGet "table_declarations" with
                 | Some tblDecl -> tblDecl
                 | None -> true // Default to true [sqlhydra_query_integration] table already exists
             | None -> false // Default to false if [sqlhydra_query_integration] table is missing
+        Config.LeftJoinedViews =
+            // Absent means false so existing codebases see no change; the init wizard writes
+            // `left_joined_views = true` into new configs.
+            queryIntegrationTableMaybe
+            |> Option.bind (fun queryIntegrationTable -> queryIntegrationTable.TryGet "left_joined_views")
+            |> Option.defaultValue false
         Config.Readers = 
             readersTableMaybe
             |> Option.map (fun rdrsTbl -> 
@@ -106,6 +112,7 @@ let save(cfg: Config) =
     let queryInt = TableSyntax("sqlhydra_query_integration")
     queryInt.Items.Add("provider_db_type_attributes", cfg.ProviderDbTypeAttributes)
     queryInt.Items.Add("table_declarations", cfg.TableDeclarations)
+    queryInt.Items.Add("left_joined_views", cfg.LeftJoinedViews)
     doc.Tables.Add(queryInt)
 
     cfg.Readers |> Option.iter (fun readersConfig ->

--- a/src/SqlHydra.Domain/Domain.fs
+++ b/src/SqlHydra.Domain/Domain.fs
@@ -135,6 +135,10 @@ type Config =
         /// SqlHydra.Query Integration: creates a SqlHydra.Query table declaration for each table
         TableDeclarations: bool
 
+        /// SqlHydra.Query Integration: generates a `LeftJoined` module per schema with a
+        /// left-view record per table (every column nullable), for `leftJoin` sources.
+        LeftJoinedViews: bool
+
         /// Readers: provides a Db provider specific IDataReader type (for access to Db-specific features)
         Readers: ReadersConfig option
         

--- a/src/SqlHydra.Domain/ILeftViewOf.fs
+++ b/src/SqlHydra.Domain/ILeftViewOf.fs
@@ -1,0 +1,8 @@
+namespace SqlHydra
+
+/// The left-view of table record 'Table: the same record with every column in its nullable
+/// form. A `leftJoin` over a left-view token binds the ON clause against plain 'Table and the
+/// rest of the query against the view, so an unmatched row reads as None per column instead of
+/// one Option<'Table> around the whole record. Generated views implement it, so the query
+/// layer can map the view back to its physical table.
+type ILeftViewOf<'Table> = interface end

--- a/src/SqlHydra.Domain/SqlHydra.Domain.fsproj
+++ b/src/SqlHydra.Domain/SqlHydra.Domain.fsproj
@@ -14,6 +14,7 @@
         <Compile Include="Domain.fs" />
         <Compile Include="ProviderDbTypeAttribute.fs" />
         <Compile Include="IWriteOf.fs" />
+        <Compile Include="ILeftViewOf.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SqlHydra.Query/Core.fs
+++ b/src/SqlHydra.Query/Core.fs
@@ -4,15 +4,35 @@ open System.Reflection
 open System.Collections.Generic
 open System
 
+/// Resolves a generated left-view record (one implementing `SqlHydra.ILeftViewOf<'Table>`)
+/// to its base table record, so the view maps to the same physical table.
+module LeftViews =
+
+    let private cache = Collections.Concurrent.ConcurrentDictionary<Type, Type option>()
+
+    /// Returns the base table record type when `t` is a left-view record, else None.
+    let tryBaseTable (t: Type) : Type option =
+        if isNull t then None
+        else
+            cache.GetOrAdd(t, fun t ->
+                t.GetInterfaces()
+                |> Array.tryFind (fun i -> i.IsGenericType && i.GetGenericTypeDefinition() = typedefof<SqlHydra.ILeftViewOf<_>>)
+                |> Option.map (fun i -> i.GetGenericArguments().[0]))
+
 type TableMapping =
     {
         Name: string
         Schema: string
     }
     member this.IsInTable (m: Linq.Expressions.MemberExpression) =
-        m.Member.ReflectedType.DeclaringType <> null &&
-        m.Member.ReflectedType.DeclaringType.Name = this.Schema &&
-        m.Member.ReflectedType.Name = this.Name
+        // A left-view record lives in a nested `LeftJoined` module; judge it by its base table.
+        let t =
+            match LeftViews.tryBaseTable m.Member.ReflectedType with
+            | Some baseTable -> baseTable
+            | None -> m.Member.ReflectedType
+        t.DeclaringType <> null &&
+        t.DeclaringType.Name = this.Schema &&
+        t.Name = this.Name
 
 type TableMappingKey =
     | Root
@@ -149,6 +169,15 @@ type QuerySource<'T>(tableMappings) =
 type QuerySource<'T, 'Query>(query, tableMappings) =
     inherit QuerySource<'T>(tableMappings)
     member this.Query : 'Query = query
+
+/// A table token for the left-view 'View of table record 'Table, mapped to 'Table's physical
+/// table. Produced by `leftTable`; the `leftJoin` overload keyed on it binds the ON clause
+/// against plain 'Table and the downstream variable space against 'View, whose columns are
+/// each nullable.
+/// Deliberately NOT a QuerySource: were it one, both `leftJoin` overloads would apply and
+/// overload resolution could not commit before typing the ON lambda (FS0072).
+type LeftViewQuerySource<'Table, 'View>(tableMappings) =
+    member this.TableMappings : Map<TableMappingKey, TableMapping> = tableMappings
 
 /// The type of join for predicate-style joins
 type JoinType =

--- a/src/SqlHydra.Query/QueryFunctions.fs
+++ b/src/SqlHydra.Query/QueryFunctions.fs
@@ -42,6 +42,14 @@ module Table =
         let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name}]
         QuerySource<'T>(tables)
 
+    /// Maps the generated left-view record 'View to the physical table of its base record
+    /// 'Table. Use it as the source of a `leftJoin`: the ON clause binds plain 'Table columns
+    /// (no `.Value`), and downstream the joined row is 'View, whose columns are each nullable.
+    let leftTable<'Table, 'View when 'View :> SqlHydra.ILeftViewOf<'Table>> : LeftViewQuerySource<'Table, 'View> =
+        let ent = typeof<'Table>
+        let tables = Map [Root, { Name = ent.Name; Schema = ent.DeclaringType.Name }]
+        LeftViewQuerySource<'Table, 'View>(tables)
+
     /// Creates a CTE source: `WITH alias AS (innerQuery) SELECT ... FROM alias`.
     /// The inner query's row type matches the outer 'T.
     let cte<'T> (alias: string) (innerQuery: SelectQuery<'T>) : QuerySource<'T> =

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -422,6 +422,55 @@ type SelectBuilder<'Selected, 'Mapped> () =
         let joinClause = { Kind = LeftJoin; Table = innerTableNameAsAlias; Subquery = None; Condition = joinCondition }
         QuerySource<'JoinResult, SelectQueryIR>({ ir with Joins = ir.Joins @ [joinClause] }, mergedTables)
 
+    /// LEFT JOIN a generated left-view (`Schema.LeftJoined.tbl`) on one or more columns.
+    /// The ON clause binds the plain 'Table record (no `.Value`); downstream, the joined row
+    /// is the 'View record, whose columns are each nullable.
+    [<CustomOperation("leftJoin", MaintainsVariableSpace = true, IsLikeJoin = true, JoinConditionWord = "on")>]
+    member this.LeftJoin (outerSource: QuerySource<'Outer>,
+                          innerSource: LeftViewQuerySource<'Table, 'View>,
+                          outerKeySelector: Expression<Func<'Outer,'Key>>,
+                          innerKeySelector: Expression<Func<'Table,'Key>>,
+                          resultSelector: Expression<Func<'Outer,'View,'JoinResult>> ) =
+
+        let outerProperties = LinqExpressionVisitors.visitJoin<'Outer, 'Key> outerKeySelector
+        let innerProperties = LinqExpressionVisitors.visitJoin<'Table, 'Key> innerKeySelector
+
+        let mergedTables =
+            // Update outer table mappings with join aliases
+            let outerTableMappings =
+                outerProperties
+                |> List.fold (fun (mappings: Map<TableMappingKey, TableMapping>) joinPI ->
+                    let _, updatedMappings = TableMappings.tryGetByRootOrAlias joinPI.Alias mappings
+                    updatedMappings
+                ) outerSource.TableMappings
+
+            // Update inner table mappings with join aliases
+            let innerTableMappings =
+                innerProperties
+                |> List.fold (fun (mappings: Map<TableMappingKey, TableMapping>) joinPI ->
+                    let _, updatedMappings = TableMappings.tryGetByRootOrAlias joinPI.Alias mappings
+                    updatedMappings
+                ) innerSource.TableMappings
+
+            mergeTableMappings (outerTableMappings, innerTableMappings)
+
+        let ir = outerSource |> getQueryOrDefault
+        let innerTableNameAsAlias =
+            innerProperties
+            |> Seq.map (fun p -> p, mergedTables[TableAliasKey p.Alias])
+            |> Seq.map (fun (p, tbl) -> $"%s{FQ.qualifiedTable tbl} AS %s{p.Alias}")
+            |> Seq.head
+
+        let joinCondition =
+            List.zip outerProperties innerProperties
+            |> List.fold (fun (acc: WhereClause) (outerProp, innerProp) ->
+                let cond = CompareColumns($"%s{outerProp.Alias}.%s{outerProp.Member.Name}", Eq, $"%s{innerProp.Alias}.%s{innerProp.Member.Name}")
+                WhereClause.combineAndFlat acc cond
+            ) WhereClause.Empty
+
+        let joinClause = { Kind = LeftJoin; Table = innerTableNameAsAlias; Subquery = None; Condition = joinCondition }
+        QuerySource<'JoinResult, SelectQueryIR>({ ir with Joins = ir.Joins @ [joinClause] }, mergedTables)
+
     /// References a table variable from a correlated parent query from within a subquery.
     [<CustomOperation("correlate", MaintainsVariableSpace = true, IsLikeZip = true)>]
     member this.Correlate (outerSource: QuerySource<'Outer>,

--- a/src/Tests/Npgsql/AdventureWorksNet10.fs
+++ b/src/Tests/Npgsql/AdventureWorksNet10.fs
@@ -62,6 +62,85 @@ module ext =
 
     let person = table<person>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``arrays (base)`` = arrays
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type arrays =
+            { [<ProviderDbType("Text")>]
+              id: Option<string>
+              [<ProviderDbType("Text,Array")>]
+              text_array: Option<string[]>
+              [<ProviderDbType("Integer,Array")>]
+              integer_array: Option<int[]> }
+
+            interface ILeftViewOf<``arrays (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``arrays (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``arrays (base)`` =
+                        { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
+
+                    Some record
+                | None -> None
+
+        let arrays = leftTable<``arrays (base)``, arrays>
+
+        type private ``jsonsupport (base)`` = jsonsupport
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type jsonsupport =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Json")>]
+              json_field: Option<string>
+              [<ProviderDbType("Jsonb")>]
+              jsonb_field: Option<string> }
+
+            interface ILeftViewOf<``jsonsupport (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``jsonsupport (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``jsonsupport (base)`` =
+                        { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
+
+                    Some record
+                | None -> None
+
+        let jsonsupport = leftTable<``jsonsupport (base)``, jsonsupport>
+
+        type private ``person (base)`` = person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type person =
+            { [<ProviderDbType("Text")>]
+              name: Option<string>
+              currentmood: Option<mood> }
+
+            interface ILeftViewOf<``person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``person (base)`` option =
+                match this.name with
+                | Some value ->
+                    let record: ``person (base)`` =
+                        { name = value; currentmood = this.currentmood.Value }
+
+                    Some record
+                | None -> None
+
+        let person = leftTable<``person (base)``, person>
+
+
 module humanresources =
 
     [<CLIMutable>]
@@ -514,6 +593,445 @@ module humanresources =
 
     let vjobcandidateemployment = table<vjobcandidateemployment>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``department (base)`` = department
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type department =
+            { [<ProviderDbType("Integer")>]
+              departmentid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``department (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``department (base)`` option =
+                match this.departmentid with
+                | Some value ->
+                    let record: ``department (base)`` =
+                        { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let department = leftTable<``department (base)``, department>
+
+        type private ``employee (base)`` = employee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employee =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              nationalidnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              loginid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Date")>]
+              birthdate: Option<System.DateOnly>
+              [<ProviderDbType("Char")>]
+              maritalstatus: Option<string>
+              [<ProviderDbType("Char")>]
+              gender: Option<string>
+              [<ProviderDbType("Date")>]
+              hiredate: Option<System.DateOnly>
+              [<ProviderDbType("Boolean")>]
+              salariedflag: Option<bool>
+              [<ProviderDbType("Smallint")>]
+              vacationhours: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              sickleavehours: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              currentflag: Option<bool>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              organizationnode: Option<string> }
+
+            interface ILeftViewOf<``employee (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employee (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employee (base)`` =
+                        { businessentityid = value
+                          nationalidnumber = this.nationalidnumber.Value
+                          loginid = this.loginid.Value
+                          jobtitle = this.jobtitle.Value
+                          birthdate = this.birthdate.Value
+                          maritalstatus = this.maritalstatus.Value
+                          gender = this.gender.Value
+                          hiredate = this.hiredate.Value
+                          salariedflag = this.salariedflag.Value
+                          vacationhours = this.vacationhours.Value
+                          sickleavehours = this.sickleavehours.Value
+                          currentflag = this.currentflag.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value
+                          organizationnode = this.organizationnode }
+
+                    Some record
+                | None -> None
+
+        let employee = leftTable<``employee (base)``, employee>
+
+        type private ``employeedepartmenthistory (base)`` = employeedepartmenthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employeedepartmenthistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              departmentid: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              shiftid: Option<int16>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              enddate: Option<System.DateOnly>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``employeedepartmenthistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employeedepartmenthistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employeedepartmenthistory (base)`` =
+                        { businessentityid = value
+                          departmentid = this.departmentid.Value
+                          shiftid = this.shiftid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let employeedepartmenthistory =
+            leftTable<``employeedepartmenthistory (base)``, employeedepartmenthistory>
+
+        type private ``employeepayhistory (base)`` = employeepayhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employeepayhistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              ratechangedate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              rate: Option<decimal>
+              [<ProviderDbType("Smallint")>]
+              payfrequency: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``employeepayhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employeepayhistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employeepayhistory (base)`` =
+                        { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let employeepayhistory =
+            leftTable<``employeepayhistory (base)``, employeepayhistory>
+
+        type private ``jobcandidate (base)`` = jobcandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type jobcandidate =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Xml")>]
+              resume: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``jobcandidate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``jobcandidate (base)`` option =
+                match this.jobcandidateid with
+                | Some value ->
+                    let record: ``jobcandidate (base)`` =
+                        { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let jobcandidate = leftTable<``jobcandidate (base)``, jobcandidate>
+
+        type private ``shift (base)`` = shift
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shift =
+            { [<ProviderDbType("Integer")>]
+              shiftid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Time")>]
+              starttime: Option<System.TimeOnly>
+              [<ProviderDbType("Time")>]
+              endtime: Option<System.TimeOnly>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shift (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shift (base)`` option =
+                match this.shiftid with
+                | Some value ->
+                    let record: ``shift (base)`` =
+                        { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shift = leftTable<``shift (base)``, shift>
+
+        type private ``vemployee (base)`` = vemployee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployee =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string> }
+
+            interface ILeftViewOf<``vemployee (base)``>
+
+        let vemployee = leftTable<``vemployee (base)``, vemployee>
+
+        type private ``vemployeedepartment (base)`` = vemployeedepartment
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployeedepartment =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              department: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly> }
+
+            interface ILeftViewOf<``vemployeedepartment (base)``>
+
+        let vemployeedepartment =
+            leftTable<``vemployeedepartment (base)``, vemployeedepartment>
+
+        type private ``vemployeedepartmenthistory (base)`` = vemployeedepartmenthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployeedepartmenthistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              shift: Option<string>
+              [<ProviderDbType("Varchar")>]
+              department: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              enddate: Option<System.DateOnly> }
+
+            interface ILeftViewOf<``vemployeedepartmenthistory (base)``>
+
+        let vemployeedepartmenthistory =
+            leftTable<``vemployeedepartmenthistory (base)``, vemployeedepartmenthistory>
+
+        type private ``vjobcandidate (base)`` = vjobcandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidate =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Prefix``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.First``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Middle``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Last``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Suffix``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Skills: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.City``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.PostalCode``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              EMail: Option<string>
+              [<ProviderDbType("Varchar")>]
+              WebSite: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vjobcandidate (base)``>
+
+        let vjobcandidate = leftTable<``vjobcandidate (base)``, vjobcandidate>
+
+        type private ``vjobcandidateeducation (base)`` = vjobcandidateeducation
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidateeducation =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Level``: Option<string>
+              [<ProviderDbType("Date")>]
+              ``Edu.StartDate``: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              ``Edu.EndDate``: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Degree``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Major``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Minor``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.GPA``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.GPAScale``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.School``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.City``: Option<string> }
+
+            interface ILeftViewOf<``vjobcandidateeducation (base)``>
+
+        let vjobcandidateeducation =
+            leftTable<``vjobcandidateeducation (base)``, vjobcandidateeducation>
+
+        type private ``vjobcandidateemployment (base)`` = vjobcandidateemployment
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidateemployment =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Date")>]
+              ``Emp.StartDate``: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              ``Emp.EndDate``: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.OrgName``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.JobTitle``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Responsibility``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.FunctionCategory``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.IndustryCategory``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.City``: Option<string> }
+
+            interface ILeftViewOf<``vjobcandidateemployment (base)``>
+
+        let vjobcandidateemployment =
+            leftTable<``vjobcandidateemployment (base)``, vjobcandidateemployment>
+
+
 module network_sample =
 
     [<CLIMutable>]
@@ -538,6 +1056,40 @@ module network_sample =
                   { WriteColumn.Name = "net_macaddr8"; Value = box this.net_macaddr8; ProviderDbType = Some "MacAddr8" } ]
 
     let network_addresses = table<network_addresses>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``network_addresses (base)`` = network_addresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type network_addresses =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Cidr")>]
+              net_cidr: Option<System.Net.IPNetwork>
+              [<ProviderDbType("Inet")>]
+              net_inet: Option<System.Net.IPAddress>
+              [<ProviderDbType("MacAddr")>]
+              net_macaddr: Option<System.Net.NetworkInformation.PhysicalAddress>
+              [<ProviderDbType("MacAddr8")>]
+              net_macaddr8: Option<System.Net.NetworkInformation.PhysicalAddress> }
+
+            interface ILeftViewOf<``network_addresses (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``network_addresses (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``network_addresses (base)`` =
+                        { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
+
+                    Some record
+                | None -> None
+
+        let network_addresses = leftTable<``network_addresses (base)``, network_addresses>
+
 
 module pe =
 
@@ -890,6 +1442,334 @@ module pe =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let sp = table<sp>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``a (base)`` = a
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type a =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              spatiallocation: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``a (base)``>
+
+        let a = leftTable<``a (base)``, a>
+
+        type private ``at (base)`` = at
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type at =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``at (base)``>
+
+        let at = leftTable<``at (base)``, at>
+
+        type private ``be (base)`` = be
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type be =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``be (base)``>
+
+        let be = leftTable<``be (base)``, be>
+
+        type private ``bea (base)`` = bea
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bea =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bea (base)``>
+
+        let bea = leftTable<``bea (base)``, bea>
+
+        type private ``bec (base)`` = bec
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bec =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bec (base)``>
+
+        let bec = leftTable<``bec (base)``, bec>
+
+        type private ``cr (base)`` = cr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cr =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cr (base)``>
+
+        let cr = leftTable<``cr (base)``, cr>
+
+        type private ``ct (base)`` = ct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ct =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ct (base)``>
+
+        let ct = leftTable<``ct (base)``, ct>
+
+        type private ``e (base)`` = e
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type e =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              emailaddressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``e (base)``>
+
+        let e = leftTable<``e (base)``, e>
+
+        type private ``p (base)`` = p
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type p =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Char")>]
+              persontype: Option<string>
+              [<ProviderDbType("Boolean")>]
+              namestyle: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``p (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``p (base)`` option =
+                match this.namestyle with
+                | Some value ->
+                    let record: ``p (base)`` =
+                        { id = this.id
+                          businessentityid = this.businessentityid
+                          persontype = this.persontype
+                          namestyle = value
+                          title = this.title
+                          firstname = this.firstname
+                          middlename = this.middlename
+                          lastname = this.lastname
+                          suffix = this.suffix
+                          emailpromotion = this.emailpromotion
+                          additionalcontactinfo = this.additionalcontactinfo
+                          demographics = this.demographics
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let p = leftTable<``p (base)``, p>
+
+        type private ``pa (base)`` = pa
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pa =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              passwordhash: Option<string>
+              [<ProviderDbType("Varchar")>]
+              passwordsalt: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pa (base)``>
+
+        let pa = leftTable<``pa (base)``, pa>
+
+        type private ``pnt (base)`` = pnt
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pnt =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pnt (base)``>
+
+        let pnt = leftTable<``pnt (base)``, pnt>
+
+        type private ``pp (base)`` = pp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pp (base)``>
+
+        let pp = leftTable<``pp (base)``, pp>
+
+        type private ``sp (base)`` = sp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Char")>]
+              stateprovincecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Boolean")>]
+              isonlystateprovinceflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sp (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``sp (base)`` option =
+                match this.isonlystateprovinceflag with
+                | Some value ->
+                    let record: ``sp (base)`` =
+                        { id = this.id
+                          stateprovinceid = this.stateprovinceid
+                          stateprovincecode = this.stateprovincecode
+                          countryregioncode = this.countryregioncode
+                          isonlystateprovinceflag = value
+                          name = this.name
+                          territoryid = this.territoryid
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let sp = leftTable<``sp (base)``, sp>
+
 
 module person =
 
@@ -1288,6 +2168,507 @@ module person =
                   { WriteColumn.Name = "countryregionname"; Value = box this.countryregionname; ProviderDbType = Some "Name" } ]
 
     let vstateprovincecountryregion = table<vstateprovincecountryregion>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``address (base)`` = address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type address =
+            { [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              spatiallocation: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``address (base)`` option =
+                match this.addressid with
+                | Some value ->
+                    let record: ``address (base)`` =
+                        { addressid = value
+                          addressline1 = this.addressline1.Value
+                          addressline2 = this.addressline2
+                          city = this.city.Value
+                          stateprovinceid = this.stateprovinceid.Value
+                          postalcode = this.postalcode.Value
+                          spatiallocation = this.spatiallocation
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let address = leftTable<``address (base)``, address>
+
+        type private ``addresstype (base)`` = addresstype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type addresstype =
+            { [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``addresstype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``addresstype (base)`` option =
+                match this.addresstypeid with
+                | Some value ->
+                    let record: ``addresstype (base)`` =
+                        { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let addresstype = leftTable<``addresstype (base)``, addresstype>
+
+        type private ``businessentity (base)`` = businessentity
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentity =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentity (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentity (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentity (base)`` =
+                        { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentity = leftTable<``businessentity (base)``, businessentity>
+
+        type private ``businessentityaddress (base)`` = businessentityaddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentityaddress =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentityaddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentityaddress (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentityaddress (base)`` =
+                        { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentityaddress =
+            leftTable<``businessentityaddress (base)``, businessentityaddress>
+
+        type private ``businessentitycontact (base)`` = businessentitycontact
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentitycontact =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentitycontact (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentitycontact (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentitycontact (base)`` =
+                        { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentitycontact =
+            leftTable<``businessentitycontact (base)``, businessentitycontact>
+
+        type private ``contacttype (base)`` = contacttype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type contacttype =
+            { [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``contacttype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``contacttype (base)`` option =
+                match this.contacttypeid with
+                | Some value ->
+                    let record: ``contacttype (base)`` =
+                        { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let contacttype = leftTable<``contacttype (base)``, contacttype>
+
+        type private ``countryregion (base)`` = countryregion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type countryregion =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``countryregion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``countryregion (base)`` option =
+                match this.countryregioncode with
+                | Some value ->
+                    let record: ``countryregion (base)`` =
+                        { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let countryregion = leftTable<``countryregion (base)``, countryregion>
+
+        type private ``emailaddress (base)`` = emailaddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type emailaddress =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              emailaddressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``emailaddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``emailaddress (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``emailaddress (base)`` =
+                        { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let emailaddress = leftTable<``emailaddress (base)``, emailaddress>
+
+        type private ``password (base)`` = password
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type password =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              passwordhash: Option<string>
+              [<ProviderDbType("Varchar")>]
+              passwordsalt: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``password (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``password (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``password (base)`` =
+                        { businessentityid = value
+                          passwordhash = this.passwordhash.Value
+                          passwordsalt = this.passwordsalt.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let password = leftTable<``password (base)``, password>
+
+        type private ``person (base)`` = person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type person =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Char")>]
+              persontype: Option<string>
+              [<ProviderDbType("Boolean")>]
+              namestyle: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``person (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``person (base)`` =
+                        { businessentityid = value
+                          persontype = this.persontype.Value
+                          namestyle = this.namestyle.Value
+                          title = this.title
+                          firstname = this.firstname.Value
+                          middlename = this.middlename
+                          lastname = this.lastname.Value
+                          suffix = this.suffix
+                          emailpromotion = this.emailpromotion.Value
+                          additionalcontactinfo = this.additionalcontactinfo
+                          demographics = this.demographics
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let person = leftTable<``person (base)``, person>
+
+        type private ``personphone (base)`` = personphone
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type personphone =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``personphone (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``personphone (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``personphone (base)`` =
+                        { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let personphone = leftTable<``personphone (base)``, personphone>
+
+        type private ``phonenumbertype (base)`` = phonenumbertype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type phonenumbertype =
+            { [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``phonenumbertype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``phonenumbertype (base)`` option =
+                match this.phonenumbertypeid with
+                | Some value ->
+                    let record: ``phonenumbertype (base)`` =
+                        { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let phonenumbertype = leftTable<``phonenumbertype (base)``, phonenumbertype>
+
+        type private ``stateprovince (base)`` = stateprovince
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type stateprovince =
+            { [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Char")>]
+              stateprovincecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Boolean")>]
+              isonlystateprovinceflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``stateprovince (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``stateprovince (base)`` option =
+                match this.stateprovinceid with
+                | Some value ->
+                    let record: ``stateprovince (base)`` =
+                        { stateprovinceid = value
+                          stateprovincecode = this.stateprovincecode.Value
+                          countryregioncode = this.countryregioncode.Value
+                          isonlystateprovinceflag = this.isonlystateprovinceflag.Value
+                          name = this.name.Value
+                          territoryid = this.territoryid.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let stateprovince = leftTable<``stateprovince (base)``, stateprovince>
+
+        type private ``vadditionalcontactinfo (base)`` = vadditionalcontactinfo
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vadditionalcontactinfo =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Xml")>]
+              telephonenumber: Option<string>
+              [<ProviderDbType("Text")>]
+              telephonespecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              street: Option<string>
+              [<ProviderDbType("Xml")>]
+              city: Option<string>
+              [<ProviderDbType("Xml")>]
+              stateprovince: Option<string>
+              [<ProviderDbType("Xml")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Xml")>]
+              countryregion: Option<string>
+              [<ProviderDbType("Xml")>]
+              homeaddressspecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Text")>]
+              emailspecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              emailtelephonenumber: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vadditionalcontactinfo (base)``>
+
+        let vadditionalcontactinfo =
+            leftTable<``vadditionalcontactinfo (base)``, vadditionalcontactinfo>
+
+        type private ``vstateprovincecountryregion (base)`` = vstateprovincecountryregion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstateprovincecountryregion =
+            { [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Name")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Name")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vstateprovincecountryregion (base)``>
+
+        let vstateprovincecountryregion =
+            leftTable<``vstateprovincecountryregion (base)``, vstateprovincecountryregion>
+
 
 module pr =
 
@@ -2054,6 +3435,681 @@ module pr =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let wr = table<wr>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``bom (base)`` = bom
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bom =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              billofmaterialsid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productassemblyid: Option<int>
+              [<ProviderDbType("Integer")>]
+              componentid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bomlevel: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              perassemblyqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bom (base)``>
+
+        let bom = leftTable<``bom (base)``, bom>
+
+        type private ``c (base)`` = c
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type c =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``c (base)``>
+
+        let c = leftTable<``c (base)``, c>
+
+        type private ``d (base)`` = d
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type d =
+            { [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Integer")>]
+              owner: Option<int>
+              [<ProviderDbType("Boolean")>]
+              folderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              filename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              fileextension: Option<string>
+              [<ProviderDbType("Char")>]
+              revision: Option<string>
+              [<ProviderDbType("Integer")>]
+              changenumber: Option<int>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Text")>]
+              documentsummary: Option<string>
+              [<ProviderDbType("Bytea")>]
+              document: Option<byte[]>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``d (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``d (base)`` option =
+                match this.folderflag with
+                | Some value ->
+                    let record: ``d (base)`` =
+                        { title = this.title
+                          owner = this.owner
+                          folderflag = value
+                          filename = this.filename
+                          fileextension = this.fileextension
+                          revision = this.revision
+                          changenumber = this.changenumber
+                          status = this.status
+                          documentsummary = this.documentsummary
+                          document = this.document
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate
+                          documentnode = this.documentnode }
+
+                    Some record
+                | None -> None
+
+        let d = leftTable<``d (base)``, d>
+
+        type private ``i (base)`` = i
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type i =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Xml")>]
+              diagram: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``i (base)``>
+
+        let i = leftTable<``i (base)``, i>
+
+        type private ``l (base)`` = l
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type l =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              locationid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              costrate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              availability: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``l (base)``>
+
+        let l = leftTable<``l (base)``, l>
+
+        type private ``p (base)`` = p
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type p =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productnumber: Option<string>
+              [<ProviderDbType("Boolean")>]
+              makeflag: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              finishedgoodsflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Smallint")>]
+              safetystocklevel: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              reorderpoint: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              size: Option<string>
+              [<ProviderDbType("Char")>]
+              sizeunitmeasurecode: Option<string>
+              [<ProviderDbType("Char")>]
+              weightunitmeasurecode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              weight: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              daystomanufacture: Option<int>
+              [<ProviderDbType("Char")>]
+              productline: Option<string>
+              [<ProviderDbType("Char")>]
+              ``class``: Option<string>
+              [<ProviderDbType("Char")>]
+              style: Option<string>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              sellstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              sellenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              discontinueddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``p (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``p (base)`` option =
+                match this.makeflag with
+                | Some value ->
+                    let record: ``p (base)`` =
+                        { id = this.id
+                          productid = this.productid
+                          name = this.name
+                          productnumber = this.productnumber
+                          makeflag = value
+                          finishedgoodsflag = this.finishedgoodsflag.Value
+                          color = this.color
+                          safetystocklevel = this.safetystocklevel
+                          reorderpoint = this.reorderpoint
+                          standardcost = this.standardcost
+                          listprice = this.listprice
+                          size = this.size
+                          sizeunitmeasurecode = this.sizeunitmeasurecode
+                          weightunitmeasurecode = this.weightunitmeasurecode
+                          weight = this.weight
+                          daystomanufacture = this.daystomanufacture
+                          productline = this.productline
+                          ``class`` = this.``class``
+                          style = this.style
+                          productsubcategoryid = this.productsubcategoryid
+                          productmodelid = this.productmodelid
+                          sellstartdate = this.sellstartdate
+                          sellenddate = this.sellenddate
+                          discontinueddate = this.discontinueddate
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let p = leftTable<``p (base)``, p>
+
+        type private ``pc (base)`` = pc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pc (base)``>
+
+        let pc = leftTable<``pc (base)``, pc>
+
+        type private ``pch (base)`` = pch
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pch =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pch (base)``>
+
+        let pch = leftTable<``pch (base)``, pch>
+
+        type private ``pd (base)`` = pd
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pd =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pd (base)``>
+
+        let pd = leftTable<``pd (base)``, pd>
+
+        type private ``pdoc (base)`` = pdoc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pdoc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``pdoc (base)``>
+
+        let pdoc = leftTable<``pdoc (base)``, pdoc>
+
+        type private ``pi (base)`` = pi
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pi =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Varchar")>]
+              shelf: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bin: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              quantity: Option<int16>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pi (base)``>
+
+        let pi = leftTable<``pi (base)``, pi>
+
+        type private ``plph (base)`` = plph
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type plph =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``plph (base)``>
+
+        let plph = leftTable<``plph (base)``, plph>
+
+        type private ``pm (base)`` = pm
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pm =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Xml")>]
+              catalogdescription: Option<string>
+              [<ProviderDbType("Xml")>]
+              instructions: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pm (base)``>
+
+        let pm = leftTable<``pm (base)``, pm>
+
+        type private ``pmi (base)`` = pmi
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pmi =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pmi (base)``>
+
+        let pmi = leftTable<``pmi (base)``, pmi>
+
+        type private ``pmpdc (base)`` = pmpdc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pmpdc =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pmpdc (base)``>
+
+        let pmpdc = leftTable<``pmpdc (base)``, pmpdc>
+
+        type private ``pp (base)`` = pp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Bytea")>]
+              thumbnailphoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              thumbnailphotofilename: Option<string>
+              [<ProviderDbType("Bytea")>]
+              largephoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              largephotofilename: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pp (base)``>
+
+        let pp = leftTable<``pp (base)``, pp>
+
+        type private ``ppp (base)`` = ppp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ppp =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Boolean")>]
+              primary: Option<bool>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ppp (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ppp (base)`` option =
+                match this.primary with
+                | Some value ->
+                    let record: ``ppp (base)`` =
+                        { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let ppp = leftTable<``ppp (base)``, ppp>
+
+        type private ``pr (base)`` = pr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productreviewid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              reviewername: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              reviewdate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              rating: Option<int>
+              [<ProviderDbType("Varchar")>]
+              comments: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pr (base)``>
+
+        let pr = leftTable<``pr (base)``, pr>
+
+        type private ``psc (base)`` = psc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type psc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``psc (base)``>
+
+        let psc = leftTable<``psc (base)``, psc>
+
+        type private ``sr (base)`` = sr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              scrapreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sr (base)``>
+
+        let sr = leftTable<``sr (base)``, sr>
+
+        type private ``th (base)`` = th
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type th =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``th (base)``>
+
+        let th = leftTable<``th (base)``, th>
+
+        type private ``tha (base)`` = tha
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type tha =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``tha (base)``>
+
+        let tha = leftTable<``tha (base)``, tha>
+
+        type private ``um (base)`` = um
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type um =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``um (base)``>
+
+        let um = leftTable<``um (base)``, um>
+
+        type private ``w (base)`` = w
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type w =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              orderqty: Option<int>
+              [<ProviderDbType("Smallint")>]
+              scrappedqty: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              scrapreasonid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``w (base)``>
+
+        let w = leftTable<``w (base)``, w>
+
+        type private ``wr (base)`` = wr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type wr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              operationsequence: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              scheduledstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              scheduledenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualenddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              actualresourcehrs: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              plannedcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``wr (base)``>
+
+        let wr = leftTable<``wr (base)``, wr>
+
 
 module production =
 
@@ -2903,6 +4959,1065 @@ module production =
 
     let workorderrouting = table<workorderrouting>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``billofmaterials (base)`` = billofmaterials
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type billofmaterials =
+            { [<ProviderDbType("Integer")>]
+              billofmaterialsid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productassemblyid: Option<int>
+              [<ProviderDbType("Integer")>]
+              componentid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bomlevel: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              perassemblyqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``billofmaterials (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``billofmaterials (base)`` option =
+                match this.billofmaterialsid with
+                | Some value ->
+                    let record: ``billofmaterials (base)`` =
+                        { billofmaterialsid = value
+                          productassemblyid = this.productassemblyid
+                          componentid = this.componentid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          unitmeasurecode = this.unitmeasurecode.Value
+                          bomlevel = this.bomlevel.Value
+                          perassemblyqty = this.perassemblyqty.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let billofmaterials = leftTable<``billofmaterials (base)``, billofmaterials>
+
+        type private ``culture (base)`` = culture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type culture =
+            { [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``culture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``culture (base)`` option =
+                match this.cultureid with
+                | Some value ->
+                    let record: ``culture (base)`` =
+                        { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let culture = leftTable<``culture (base)``, culture>
+
+        type private ``document (base)`` = document
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type document =
+            { [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Integer")>]
+              owner: Option<int>
+              [<ProviderDbType("Boolean")>]
+              folderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              filename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              fileextension: Option<string>
+              [<ProviderDbType("Char")>]
+              revision: Option<string>
+              [<ProviderDbType("Integer")>]
+              changenumber: Option<int>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Text")>]
+              documentsummary: Option<string>
+              [<ProviderDbType("Bytea")>]
+              document: Option<byte[]>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``document (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``document (base)`` option =
+                match this.documentnode with
+                | Some value ->
+                    let record: ``document (base)`` =
+                        { title = this.title.Value
+                          owner = this.owner.Value
+                          folderflag = this.folderflag.Value
+                          filename = this.filename.Value
+                          fileextension = this.fileextension
+                          revision = this.revision.Value
+                          changenumber = this.changenumber.Value
+                          status = this.status.Value
+                          documentsummary = this.documentsummary
+                          document = this.document
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value
+                          documentnode = value }
+
+                    Some record
+                | None -> None
+
+        let document = leftTable<``document (base)``, document>
+
+        type private ``illustration (base)`` = illustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type illustration =
+            { [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Xml")>]
+              diagram: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``illustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``illustration (base)`` option =
+                match this.illustrationid with
+                | Some value ->
+                    let record: ``illustration (base)`` =
+                        { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let illustration = leftTable<``illustration (base)``, illustration>
+
+        type private ``location (base)`` = location
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type location =
+            { [<ProviderDbType("Integer")>]
+              locationid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              costrate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              availability: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``location (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``location (base)`` option =
+                match this.locationid with
+                | Some value ->
+                    let record: ``location (base)`` =
+                        { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let location = leftTable<``location (base)``, location>
+
+        type private ``product (base)`` = product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type product =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productnumber: Option<string>
+              [<ProviderDbType("Boolean")>]
+              makeflag: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              finishedgoodsflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Smallint")>]
+              safetystocklevel: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              reorderpoint: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              size: Option<string>
+              [<ProviderDbType("Char")>]
+              sizeunitmeasurecode: Option<string>
+              [<ProviderDbType("Char")>]
+              weightunitmeasurecode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              weight: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              daystomanufacture: Option<int>
+              [<ProviderDbType("Char")>]
+              productline: Option<string>
+              [<ProviderDbType("Char")>]
+              ``class``: Option<string>
+              [<ProviderDbType("Char")>]
+              style: Option<string>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              sellstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              sellenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              discontinueddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``product (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``product (base)`` =
+                        { productid = value
+                          name = this.name.Value
+                          productnumber = this.productnumber.Value
+                          makeflag = this.makeflag.Value
+                          finishedgoodsflag = this.finishedgoodsflag.Value
+                          color = this.color
+                          safetystocklevel = this.safetystocklevel.Value
+                          reorderpoint = this.reorderpoint.Value
+                          standardcost = this.standardcost.Value
+                          listprice = this.listprice.Value
+                          size = this.size
+                          sizeunitmeasurecode = this.sizeunitmeasurecode
+                          weightunitmeasurecode = this.weightunitmeasurecode
+                          weight = this.weight
+                          daystomanufacture = this.daystomanufacture.Value
+                          productline = this.productline
+                          ``class`` = this.``class``
+                          style = this.style
+                          productsubcategoryid = this.productsubcategoryid
+                          productmodelid = this.productmodelid
+                          sellstartdate = this.sellstartdate.Value
+                          sellenddate = this.sellenddate
+                          discontinueddate = this.discontinueddate
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let product = leftTable<``product (base)``, product>
+
+        type private ``productcategory (base)`` = productcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productcategory =
+            { [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productcategory (base)`` option =
+                match this.productcategoryid with
+                | Some value ->
+                    let record: ``productcategory (base)`` =
+                        { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productcategory = leftTable<``productcategory (base)``, productcategory>
+
+        type private ``productcosthistory (base)`` = productcosthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productcosthistory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productcosthistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productcosthistory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productcosthistory (base)`` =
+                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productcosthistory =
+            leftTable<``productcosthistory (base)``, productcosthistory>
+
+        type private ``productdescription (base)`` = productdescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productdescription =
+            { [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productdescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productdescription (base)`` option =
+                match this.productdescriptionid with
+                | Some value ->
+                    let record: ``productdescription (base)`` =
+                        { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productdescription =
+            leftTable<``productdescription (base)``, productdescription>
+
+        type private ``productdocument (base)`` = productdocument
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productdocument =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``productdocument (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productdocument (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productdocument (base)`` =
+                        { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
+
+                    Some record
+                | None -> None
+
+        let productdocument = leftTable<``productdocument (base)``, productdocument>
+
+        type private ``productinventory (base)`` = productinventory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productinventory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Varchar")>]
+              shelf: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bin: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              quantity: Option<int16>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productinventory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productinventory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productinventory (base)`` =
+                        { productid = value
+                          locationid = this.locationid.Value
+                          shelf = this.shelf.Value
+                          bin = this.bin.Value
+                          quantity = this.quantity.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productinventory = leftTable<``productinventory (base)``, productinventory>
+
+        type private ``productlistpricehistory (base)`` = productlistpricehistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productlistpricehistory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productlistpricehistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productlistpricehistory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productlistpricehistory (base)`` =
+                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productlistpricehistory =
+            leftTable<``productlistpricehistory (base)``, productlistpricehistory>
+
+        type private ``productmodel (base)`` = productmodel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodel =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Xml")>]
+              catalogdescription: Option<string>
+              [<ProviderDbType("Xml")>]
+              instructions: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodel (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodel (base)`` =
+                        { productmodelid = value
+                          name = this.name.Value
+                          catalogdescription = this.catalogdescription
+                          instructions = this.instructions
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodel = leftTable<``productmodel (base)``, productmodel>
+
+        type private ``productmodelillustration (base)`` = productmodelillustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodelillustration =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodelillustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodelillustration (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodelillustration (base)`` =
+                        { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodelillustration =
+            leftTable<``productmodelillustration (base)``, productmodelillustration>
+
+        type private ``productmodelproductdescriptionculture (base)`` = productmodelproductdescriptionculture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodelproductdescriptionculture =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodelproductdescriptionculture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodelproductdescriptionculture (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodelproductdescriptionculture (base)`` =
+                        { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodelproductdescriptionculture =
+            leftTable<``productmodelproductdescriptionculture (base)``, productmodelproductdescriptionculture>
+
+        type private ``productphoto (base)`` = productphoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productphoto =
+            { [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Bytea")>]
+              thumbnailphoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              thumbnailphotofilename: Option<string>
+              [<ProviderDbType("Bytea")>]
+              largephoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              largephotofilename: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productphoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productphoto (base)`` option =
+                match this.productphotoid with
+                | Some value ->
+                    let record: ``productphoto (base)`` =
+                        { productphotoid = value
+                          thumbnailphoto = this.thumbnailphoto
+                          thumbnailphotofilename = this.thumbnailphotofilename
+                          largephoto = this.largephoto
+                          largephotofilename = this.largephotofilename
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productphoto = leftTable<``productphoto (base)``, productphoto>
+
+        type private ``productproductphoto (base)`` = productproductphoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productproductphoto =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Boolean")>]
+              primary: Option<bool>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productproductphoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productproductphoto (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productproductphoto (base)`` =
+                        { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productproductphoto =
+            leftTable<``productproductphoto (base)``, productproductphoto>
+
+        type private ``productreview (base)`` = productreview
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productreview =
+            { [<ProviderDbType("Integer")>]
+              productreviewid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              reviewername: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              reviewdate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              rating: Option<int>
+              [<ProviderDbType("Varchar")>]
+              comments: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productreview (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productreview (base)`` option =
+                match this.productreviewid with
+                | Some value ->
+                    let record: ``productreview (base)`` =
+                        { productreviewid = value
+                          productid = this.productid.Value
+                          reviewername = this.reviewername.Value
+                          reviewdate = this.reviewdate.Value
+                          emailaddress = this.emailaddress.Value
+                          rating = this.rating.Value
+                          comments = this.comments
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productreview = leftTable<``productreview (base)``, productreview>
+
+        type private ``productsubcategory (base)`` = productsubcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productsubcategory =
+            { [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productsubcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productsubcategory (base)`` option =
+                match this.productsubcategoryid with
+                | Some value ->
+                    let record: ``productsubcategory (base)`` =
+                        { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productsubcategory =
+            leftTable<``productsubcategory (base)``, productsubcategory>
+
+        type private ``scrapreason (base)`` = scrapreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type scrapreason =
+            { [<ProviderDbType("Integer")>]
+              scrapreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``scrapreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``scrapreason (base)`` option =
+                match this.scrapreasonid with
+                | Some value ->
+                    let record: ``scrapreason (base)`` =
+                        { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let scrapreason = leftTable<``scrapreason (base)``, scrapreason>
+
+        type private ``transactionhistory (base)`` = transactionhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type transactionhistory =
+            { [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``transactionhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``transactionhistory (base)`` option =
+                match this.transactionid with
+                | Some value ->
+                    let record: ``transactionhistory (base)`` =
+                        { transactionid = value
+                          productid = this.productid.Value
+                          referenceorderid = this.referenceorderid.Value
+                          referenceorderlineid = this.referenceorderlineid.Value
+                          transactiondate = this.transactiondate.Value
+                          transactiontype = this.transactiontype.Value
+                          quantity = this.quantity.Value
+                          actualcost = this.actualcost.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let transactionhistory =
+            leftTable<``transactionhistory (base)``, transactionhistory>
+
+        type private ``transactionhistoryarchive (base)`` = transactionhistoryarchive
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type transactionhistoryarchive =
+            { [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``transactionhistoryarchive (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``transactionhistoryarchive (base)`` option =
+                match this.transactionid with
+                | Some value ->
+                    let record: ``transactionhistoryarchive (base)`` =
+                        { transactionid = value
+                          productid = this.productid.Value
+                          referenceorderid = this.referenceorderid.Value
+                          referenceorderlineid = this.referenceorderlineid.Value
+                          transactiondate = this.transactiondate.Value
+                          transactiontype = this.transactiontype.Value
+                          quantity = this.quantity.Value
+                          actualcost = this.actualcost.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let transactionhistoryarchive =
+            leftTable<``transactionhistoryarchive (base)``, transactionhistoryarchive>
+
+        type private ``unitmeasure (base)`` = unitmeasure
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type unitmeasure =
+            { [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``unitmeasure (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``unitmeasure (base)`` option =
+                match this.unitmeasurecode with
+                | Some value ->
+                    let record: ``unitmeasure (base)`` =
+                        { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let unitmeasure = leftTable<``unitmeasure (base)``, unitmeasure>
+
+        type private ``vproductanddescription (base)`` = vproductanddescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductanddescription =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Name")>]
+              name: Option<string>
+              [<ProviderDbType("Name")>]
+              productmodel: Option<string>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string> }
+
+            interface ILeftViewOf<``vproductanddescription (base)``>
+
+        let vproductanddescription =
+            leftTable<``vproductanddescription (base)``, vproductanddescription>
+
+        type private ``vproductmodelcatalogdescription (base)`` = vproductmodelcatalogdescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductmodelcatalogdescription =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Summary: Option<string>
+              [<ProviderDbType("Varchar")>]
+              manufacturer: Option<string>
+              [<ProviderDbType("Varchar")>]
+              copyright: Option<string>
+              [<ProviderDbType("Varchar")>]
+              producturl: Option<string>
+              [<ProviderDbType("Varchar")>]
+              warrantyperiod: Option<string>
+              [<ProviderDbType("Varchar")>]
+              warrantydescription: Option<string>
+              [<ProviderDbType("Varchar")>]
+              noofyears: Option<string>
+              [<ProviderDbType("Varchar")>]
+              maintenancedescription: Option<string>
+              [<ProviderDbType("Varchar")>]
+              wheel: Option<string>
+              [<ProviderDbType("Varchar")>]
+              saddle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              pedal: Option<string>
+              [<ProviderDbType("Varchar")>]
+              bikeframe: Option<string>
+              [<ProviderDbType("Varchar")>]
+              crankset: Option<string>
+              [<ProviderDbType("Varchar")>]
+              pictureangle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              picturesize: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productphotoid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              material: Option<string>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productline: Option<string>
+              [<ProviderDbType("Varchar")>]
+              style: Option<string>
+              [<ProviderDbType("Varchar")>]
+              riderexperience: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vproductmodelcatalogdescription (base)``>
+
+        let vproductmodelcatalogdescription =
+            leftTable<``vproductmodelcatalogdescription (base)``, vproductmodelcatalogdescription>
+
+        type private ``vproductmodelinstructions (base)`` = vproductmodelinstructions
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductmodelinstructions =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              instructions: Option<string>
+              [<ProviderDbType("Integer")>]
+              LocationID: Option<int>
+              [<ProviderDbType("Numeric")>]
+              SetupHours: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              MachineHours: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              LaborHours: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              LotSize: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Step: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vproductmodelinstructions (base)``>
+
+        let vproductmodelinstructions =
+            leftTable<``vproductmodelinstructions (base)``, vproductmodelinstructions>
+
+        type private ``workorder (base)`` = workorder
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type workorder =
+            { [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              orderqty: Option<int>
+              [<ProviderDbType("Smallint")>]
+              scrappedqty: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              scrapreasonid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``workorder (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``workorder (base)`` option =
+                match this.workorderid with
+                | Some value ->
+                    let record: ``workorder (base)`` =
+                        { workorderid = value
+                          productid = this.productid.Value
+                          orderqty = this.orderqty.Value
+                          scrappedqty = this.scrappedqty.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          duedate = this.duedate.Value
+                          scrapreasonid = this.scrapreasonid
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let workorder = leftTable<``workorder (base)``, workorder>
+
+        type private ``workorderrouting (base)`` = workorderrouting
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type workorderrouting =
+            { [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              operationsequence: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              scheduledstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              scheduledenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualenddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              actualresourcehrs: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              plannedcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``workorderrouting (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``workorderrouting (base)`` option =
+                match this.workorderid with
+                | Some value ->
+                    let record: ``workorderrouting (base)`` =
+                        { workorderid = value
+                          productid = this.productid.Value
+                          operationsequence = this.operationsequence.Value
+                          locationid = this.locationid.Value
+                          scheduledstartdate = this.scheduledstartdate.Value
+                          scheduledenddate = this.scheduledenddate.Value
+                          actualstartdate = this.actualstartdate
+                          actualenddate = this.actualenddate
+                          actualresourcehrs = this.actualresourcehrs
+                          plannedcost = this.plannedcost.Value
+                          actualcost = this.actualcost
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let workorderrouting = leftTable<``workorderrouting (base)``, workorderrouting>
+
+
 module pu =
 
     [<CLIMutable>]
@@ -3097,6 +6212,176 @@ module pu =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let v = table<v>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``pod (base)`` = pod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pod =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderdetailid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              receivedqty: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              rejectedqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pod (base)``>
+
+        let pod = leftTable<``pod (base)``, pod>
+
+        type private ``poh (base)`` = poh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type poh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Integer")>]
+              employeeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              vendorid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``poh (base)``>
+
+        let poh = leftTable<``poh (base)``, poh>
+
+        type private ``pv (base)`` = pv
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pv =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              averageleadtime: Option<int>
+              [<ProviderDbType("Numeric")>]
+              standardprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              lastreceiptcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              lastreceiptdate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              onorderqty: Option<int>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pv (base)``>
+
+        let pv = leftTable<``pv (base)``, pv>
+
+        type private ``sm (base)`` = sm
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sm =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              shipbase: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              shiprate: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sm (base)``>
+
+        let sm = leftTable<``sm (base)``, sm>
+
+        type private ``v (base)`` = v
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type v =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Smallint")>]
+              creditrating: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              preferredvendorstatus: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              activeflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchasingwebserviceurl: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``v (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``v (base)`` option =
+                match this.preferredvendorstatus with
+                | Some value ->
+                    let record: ``v (base)`` =
+                        { id = this.id
+                          businessentityid = this.businessentityid
+                          accountnumber = this.accountnumber
+                          name = this.name
+                          creditrating = this.creditrating
+                          preferredvendorstatus = value
+                          activeflag = this.activeflag.Value
+                          purchasingwebserviceurl = this.purchasingwebserviceurl
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let v = leftTable<``v (base)``, v>
+
 
 module purchasing =
 
@@ -3356,6 +6641,307 @@ module purchasing =
                   { WriteColumn.Name = "emailpromotion"; Value = box this.emailpromotion; ProviderDbType = Some "Integer" } ]
 
     let vvendorwithcontacts = table<vvendorwithcontacts>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``productvendor (base)`` = productvendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productvendor =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              averageleadtime: Option<int>
+              [<ProviderDbType("Numeric")>]
+              standardprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              lastreceiptcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              lastreceiptdate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              onorderqty: Option<int>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productvendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productvendor (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productvendor (base)`` =
+                        { productid = value
+                          businessentityid = this.businessentityid.Value
+                          averageleadtime = this.averageleadtime.Value
+                          standardprice = this.standardprice.Value
+                          lastreceiptcost = this.lastreceiptcost
+                          lastreceiptdate = this.lastreceiptdate
+                          minorderqty = this.minorderqty.Value
+                          maxorderqty = this.maxorderqty.Value
+                          onorderqty = this.onorderqty
+                          unitmeasurecode = this.unitmeasurecode.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productvendor = leftTable<``productvendor (base)``, productvendor>
+
+        type private ``purchaseorderdetail (base)`` = purchaseorderdetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type purchaseorderdetail =
+            { [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderdetailid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              receivedqty: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              rejectedqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``purchaseorderdetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``purchaseorderdetail (base)`` option =
+                match this.purchaseorderid with
+                | Some value ->
+                    let record: ``purchaseorderdetail (base)`` =
+                        { purchaseorderid = value
+                          purchaseorderdetailid = this.purchaseorderdetailid.Value
+                          duedate = this.duedate.Value
+                          orderqty = this.orderqty.Value
+                          productid = this.productid.Value
+                          unitprice = this.unitprice.Value
+                          receivedqty = this.receivedqty.Value
+                          rejectedqty = this.rejectedqty.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let purchaseorderdetail =
+            leftTable<``purchaseorderdetail (base)``, purchaseorderdetail>
+
+        type private ``purchaseorderheader (base)`` = purchaseorderheader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type purchaseorderheader =
+            { [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Integer")>]
+              employeeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              vendorid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``purchaseorderheader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``purchaseorderheader (base)`` option =
+                match this.purchaseorderid with
+                | Some value ->
+                    let record: ``purchaseorderheader (base)`` =
+                        { purchaseorderid = value
+                          revisionnumber = this.revisionnumber.Value
+                          status = this.status.Value
+                          employeeid = this.employeeid.Value
+                          vendorid = this.vendorid.Value
+                          shipmethodid = this.shipmethodid.Value
+                          orderdate = this.orderdate.Value
+                          shipdate = this.shipdate
+                          subtotal = this.subtotal.Value
+                          taxamt = this.taxamt.Value
+                          freight = this.freight.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let purchaseorderheader =
+            leftTable<``purchaseorderheader (base)``, purchaseorderheader>
+
+        type private ``shipmethod (base)`` = shipmethod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shipmethod =
+            { [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              shipbase: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              shiprate: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shipmethod (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shipmethod (base)`` option =
+                match this.shipmethodid with
+                | Some value ->
+                    let record: ``shipmethod (base)`` =
+                        { shipmethodid = value
+                          name = this.name.Value
+                          shipbase = this.shipbase.Value
+                          shiprate = this.shiprate.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shipmethod = leftTable<``shipmethod (base)``, shipmethod>
+
+        type private ``vendor (base)`` = vendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vendor =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Smallint")>]
+              creditrating: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              preferredvendorstatus: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              activeflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchasingwebserviceurl: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``vendor (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``vendor (base)`` =
+                        { businessentityid = value
+                          accountnumber = this.accountnumber.Value
+                          name = this.name.Value
+                          creditrating = this.creditrating.Value
+                          preferredvendorstatus = this.preferredvendorstatus.Value
+                          activeflag = this.activeflag.Value
+                          purchasingwebserviceurl = this.purchasingwebserviceurl
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let vendor = leftTable<``vendor (base)``, vendor>
+
+        type private ``vvendorwithaddresses (base)`` = vvendorwithaddresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vvendorwithaddresses =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vvendorwithaddresses (base)``>
+
+        let vvendorwithaddresses =
+            leftTable<``vvendorwithaddresses (base)``, vvendorwithaddresses>
+
+        type private ``vvendorwithcontacts (base)`` = vvendorwithcontacts
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vvendorwithcontacts =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              contacttype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int> }
+
+            interface ILeftViewOf<``vvendorwithcontacts (base)``>
+
+        let vvendorwithcontacts =
+            leftTable<``vvendorwithcontacts (base)``, vvendorwithcontacts>
+
 
 module sa =
 
@@ -3960,6 +7546,517 @@ module sa =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let tr = table<tr>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``c (base)`` = c
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type c =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              storeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``c (base)``>
+
+        let c = leftTable<``c (base)``, c>
+
+        type private ``cc (base)`` = cc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              cardtype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              cardnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              expmonth: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              expyear: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cc (base)``>
+
+        let cc = leftTable<``cc (base)``, cc>
+
+        type private ``cr (base)`` = cr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cr =
+            { [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              currencyratedate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              fromcurrencycode: Option<string>
+              [<ProviderDbType("Char")>]
+              tocurrencycode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              averagerate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              endofdayrate: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cr (base)``>
+
+        let cr = leftTable<``cr (base)``, cr>
+
+        type private ``crc (base)`` = crc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type crc =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``crc (base)``>
+
+        let crc = leftTable<``crc (base)``, crc>
+
+        type private ``cu (base)`` = cu
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cu =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cu (base)``>
+
+        let cu = leftTable<``cu (base)``, cu>
+
+        type private ``pcc (base)`` = pcc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pcc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pcc (base)``>
+
+        let pcc = leftTable<``pcc (base)``, pcc>
+
+        type private ``s (base)`` = s
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type s =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``s (base)``>
+
+        let s = leftTable<``s (base)``, s>
+
+        type private ``sci (base)`` = sci
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sci =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              shoppingcartitemid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              shoppingcartid: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              datecreated: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sci (base)``>
+
+        let sci = leftTable<``sci (base)``, sci>
+
+        type private ``so (base)`` = so
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type so =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Numeric")>]
+              discountpct: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              ``type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              category: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxqty: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``so (base)``>
+
+        let so = leftTable<``so (base)``, so>
+
+        type private ``sod (base)`` = sod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sod =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderdetailid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              carriertrackingnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              unitpricediscount: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sod (base)``>
+
+        let sod = leftTable<``sod (base)``, sod>
+
+        type private ``soh (base)`` = soh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type soh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              onlineorderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchaseordernumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              billtoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shiptoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              creditcardapprovalcode: Option<string>
+              [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              totaldue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              comment: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``soh (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``soh (base)`` option =
+                match this.onlineorderflag with
+                | Some value ->
+                    let record: ``soh (base)`` =
+                        { id = this.id
+                          salesorderid = this.salesorderid
+                          revisionnumber = this.revisionnumber
+                          orderdate = this.orderdate
+                          duedate = this.duedate
+                          shipdate = this.shipdate
+                          status = this.status
+                          onlineorderflag = value
+                          purchaseordernumber = this.purchaseordernumber
+                          accountnumber = this.accountnumber
+                          customerid = this.customerid
+                          salespersonid = this.salespersonid
+                          territoryid = this.territoryid
+                          billtoaddressid = this.billtoaddressid
+                          shiptoaddressid = this.shiptoaddressid
+                          shipmethodid = this.shipmethodid
+                          creditcardid = this.creditcardid
+                          creditcardapprovalcode = this.creditcardapprovalcode
+                          currencyrateid = this.currencyrateid
+                          subtotal = this.subtotal
+                          taxamt = this.taxamt
+                          freight = this.freight
+                          totaldue = this.totaldue
+                          comment = this.comment
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let soh = leftTable<``soh (base)``, soh>
+
+        type private ``sohsr (base)`` = sohsr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sohsr =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sohsr (base)``>
+
+        let sohsr = leftTable<``sohsr (base)``, sohsr>
+
+        type private ``sop (base)`` = sop
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sop =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sop (base)``>
+
+        let sop = leftTable<``sop (base)``, sop>
+
+        type private ``sp (base)`` = sp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              bonus: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              commissionpct: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sp (base)``>
+
+        let sp = leftTable<``sp (base)``, sp>
+
+        type private ``spqh (base)`` = spqh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type spqh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              quotadate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``spqh (base)``>
+
+        let spqh = leftTable<``spqh (base)``, spqh>
+
+        type private ``sr (base)`` = sr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              reasontype: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sr (base)``>
+
+        let sr = leftTable<``sr (base)``, sr>
+
+        type private ``st (base)`` = st
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type st =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              group: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costlastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``st (base)``>
+
+        let st = leftTable<``st (base)``, st>
+
+        type private ``sth (base)`` = sth
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sth =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sth (base)``>
+
+        let sth = leftTable<``sth (base)``, sth>
+
+        type private ``tr (base)`` = tr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type tr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salestaxrateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              taxtype: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              taxrate: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``tr (base)``>
+
+        let tr = leftTable<``tr (base)``, tr>
+
 
 module sales =
 
@@ -4877,6 +8974,1032 @@ module sales =
                   { WriteColumn.Name = "NumberEmployees"; Value = box this.NumberEmployees; ProviderDbType = Some "Integer" } ]
 
     let vstorewithdemographics = table<vstorewithdemographics>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``countryregioncurrency (base)`` = countryregioncurrency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type countryregioncurrency =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``countryregioncurrency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``countryregioncurrency (base)`` option =
+                match this.countryregioncode with
+                | Some value ->
+                    let record: ``countryregioncurrency (base)`` =
+                        { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let countryregioncurrency =
+            leftTable<``countryregioncurrency (base)``, countryregioncurrency>
+
+        type private ``creditcard (base)`` = creditcard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type creditcard =
+            { [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              cardtype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              cardnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              expmonth: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              expyear: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``creditcard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``creditcard (base)`` option =
+                match this.creditcardid with
+                | Some value ->
+                    let record: ``creditcard (base)`` =
+                        { creditcardid = value
+                          cardtype = this.cardtype.Value
+                          cardnumber = this.cardnumber.Value
+                          expmonth = this.expmonth.Value
+                          expyear = this.expyear.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let creditcard = leftTable<``creditcard (base)``, creditcard>
+
+        type private ``currency (base)`` = currency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type currency =
+            { [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``currency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``currency (base)`` option =
+                match this.currencycode with
+                | Some value ->
+                    let record: ``currency (base)`` =
+                        { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let currency = leftTable<``currency (base)``, currency>
+
+        type private ``currencyrate (base)`` = currencyrate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type currencyrate =
+            { [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              currencyratedate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              fromcurrencycode: Option<string>
+              [<ProviderDbType("Char")>]
+              tocurrencycode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              averagerate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              endofdayrate: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``currencyrate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``currencyrate (base)`` option =
+                match this.currencyrateid with
+                | Some value ->
+                    let record: ``currencyrate (base)`` =
+                        { currencyrateid = value
+                          currencyratedate = this.currencyratedate.Value
+                          fromcurrencycode = this.fromcurrencycode.Value
+                          tocurrencycode = this.tocurrencycode.Value
+                          averagerate = this.averagerate.Value
+                          endofdayrate = this.endofdayrate.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let currencyrate = leftTable<``currencyrate (base)``, currencyrate>
+
+        type private ``customer (base)`` = customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type customer =
+            { [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              storeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``customer (base)`` option =
+                match this.customerid with
+                | Some value ->
+                    let record: ``customer (base)`` =
+                        { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let customer = leftTable<``customer (base)``, customer>
+
+        type private ``personcreditcard (base)`` = personcreditcard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type personcreditcard =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``personcreditcard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``personcreditcard (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``personcreditcard (base)`` =
+                        { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let personcreditcard = leftTable<``personcreditcard (base)``, personcreditcard>
+
+        type private ``salesorderdetail (base)`` = salesorderdetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderdetail =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderdetailid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              carriertrackingnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              unitpricediscount: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderdetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderdetail (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderdetail (base)`` =
+                        { salesorderid = value
+                          salesorderdetailid = this.salesorderdetailid.Value
+                          carriertrackingnumber = this.carriertrackingnumber
+                          orderqty = this.orderqty.Value
+                          productid = this.productid.Value
+                          specialofferid = this.specialofferid.Value
+                          unitprice = this.unitprice.Value
+                          unitpricediscount = this.unitpricediscount.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderdetail = leftTable<``salesorderdetail (base)``, salesorderdetail>
+
+        type private ``salesorderheader (base)`` = salesorderheader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderheader =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              onlineorderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchaseordernumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              billtoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shiptoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              creditcardapprovalcode: Option<string>
+              [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              totaldue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              comment: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderheader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderheader (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderheader (base)`` =
+                        { salesorderid = value
+                          revisionnumber = this.revisionnumber.Value
+                          orderdate = this.orderdate.Value
+                          duedate = this.duedate.Value
+                          shipdate = this.shipdate
+                          status = this.status.Value
+                          onlineorderflag = this.onlineorderflag.Value
+                          purchaseordernumber = this.purchaseordernumber
+                          accountnumber = this.accountnumber
+                          customerid = this.customerid.Value
+                          salespersonid = this.salespersonid
+                          territoryid = this.territoryid
+                          billtoaddressid = this.billtoaddressid.Value
+                          shiptoaddressid = this.shiptoaddressid.Value
+                          shipmethodid = this.shipmethodid.Value
+                          creditcardid = this.creditcardid
+                          creditcardapprovalcode = this.creditcardapprovalcode
+                          currencyrateid = this.currencyrateid
+                          subtotal = this.subtotal.Value
+                          taxamt = this.taxamt.Value
+                          freight = this.freight.Value
+                          totaldue = this.totaldue
+                          comment = this.comment
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderheader = leftTable<``salesorderheader (base)``, salesorderheader>
+
+        type private ``salesorderheadersalesreason (base)`` = salesorderheadersalesreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderheadersalesreason =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderheadersalesreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderheadersalesreason (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderheadersalesreason (base)`` =
+                        { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderheadersalesreason =
+            leftTable<``salesorderheadersalesreason (base)``, salesorderheadersalesreason>
+
+        type private ``salesperson (base)`` = salesperson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesperson =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              bonus: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              commissionpct: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesperson (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesperson (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salesperson (base)`` =
+                        { businessentityid = value
+                          territoryid = this.territoryid
+                          salesquota = this.salesquota
+                          bonus = this.bonus.Value
+                          commissionpct = this.commissionpct.Value
+                          salesytd = this.salesytd.Value
+                          saleslastyear = this.saleslastyear.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesperson = leftTable<``salesperson (base)``, salesperson>
+
+        type private ``salespersonquotahistory (base)`` = salespersonquotahistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salespersonquotahistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              quotadate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salespersonquotahistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salespersonquotahistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salespersonquotahistory (base)`` =
+                        { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salespersonquotahistory =
+            leftTable<``salespersonquotahistory (base)``, salespersonquotahistory>
+
+        type private ``salesreason (base)`` = salesreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesreason =
+            { [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              reasontype: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesreason (base)`` option =
+                match this.salesreasonid with
+                | Some value ->
+                    let record: ``salesreason (base)`` =
+                        { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesreason = leftTable<``salesreason (base)``, salesreason>
+
+        type private ``salestaxrate (base)`` = salestaxrate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salestaxrate =
+            { [<ProviderDbType("Integer")>]
+              salestaxrateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              taxtype: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              taxrate: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salestaxrate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salestaxrate (base)`` option =
+                match this.salestaxrateid with
+                | Some value ->
+                    let record: ``salestaxrate (base)`` =
+                        { salestaxrateid = value
+                          stateprovinceid = this.stateprovinceid.Value
+                          taxtype = this.taxtype.Value
+                          taxrate = this.taxrate.Value
+                          name = this.name.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salestaxrate = leftTable<``salestaxrate (base)``, salestaxrate>
+
+        type private ``salesterritory (base)`` = salesterritory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesterritory =
+            { [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              group: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costlastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesterritory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesterritory (base)`` option =
+                match this.territoryid with
+                | Some value ->
+                    let record: ``salesterritory (base)`` =
+                        { territoryid = value
+                          name = this.name.Value
+                          countryregioncode = this.countryregioncode.Value
+                          group = this.group.Value
+                          salesytd = this.salesytd.Value
+                          saleslastyear = this.saleslastyear.Value
+                          costytd = this.costytd.Value
+                          costlastyear = this.costlastyear.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesterritory = leftTable<``salesterritory (base)``, salesterritory>
+
+        type private ``salesterritoryhistory (base)`` = salesterritoryhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesterritoryhistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesterritoryhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesterritoryhistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salesterritoryhistory (base)`` =
+                        { businessentityid = value
+                          territoryid = this.territoryid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesterritoryhistory =
+            leftTable<``salesterritoryhistory (base)``, salesterritoryhistory>
+
+        type private ``shoppingcartitem (base)`` = shoppingcartitem
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shoppingcartitem =
+            { [<ProviderDbType("Integer")>]
+              shoppingcartitemid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              shoppingcartid: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              datecreated: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shoppingcartitem (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shoppingcartitem (base)`` option =
+                match this.shoppingcartitemid with
+                | Some value ->
+                    let record: ``shoppingcartitem (base)`` =
+                        { shoppingcartitemid = value
+                          shoppingcartid = this.shoppingcartid.Value
+                          quantity = this.quantity.Value
+                          productid = this.productid.Value
+                          datecreated = this.datecreated.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shoppingcartitem = leftTable<``shoppingcartitem (base)``, shoppingcartitem>
+
+        type private ``specialoffer (base)`` = specialoffer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type specialoffer =
+            { [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Numeric")>]
+              discountpct: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              ``type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              category: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxqty: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``specialoffer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``specialoffer (base)`` option =
+                match this.specialofferid with
+                | Some value ->
+                    let record: ``specialoffer (base)`` =
+                        { specialofferid = value
+                          description = this.description.Value
+                          discountpct = this.discountpct.Value
+                          ``type`` = this.``type``.Value
+                          category = this.category.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate.Value
+                          minqty = this.minqty.Value
+                          maxqty = this.maxqty
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let specialoffer = leftTable<``specialoffer (base)``, specialoffer>
+
+        type private ``specialofferproduct (base)`` = specialofferproduct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type specialofferproduct =
+            { [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``specialofferproduct (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``specialofferproduct (base)`` option =
+                match this.specialofferid with
+                | Some value ->
+                    let record: ``specialofferproduct (base)`` =
+                        { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let specialofferproduct =
+            leftTable<``specialofferproduct (base)``, specialofferproduct>
+
+        type private ``store (base)`` = store
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type store =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``store (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``store (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``store (base)`` =
+                        { businessentityid = value
+                          name = this.name.Value
+                          salespersonid = this.salespersonid
+                          demographics = this.demographics
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let store = leftTable<``store (base)``, store>
+
+        type private ``vindividualcustomer (base)`` = vindividualcustomer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vindividualcustomer =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string> }
+
+            interface ILeftViewOf<``vindividualcustomer (base)``>
+
+        let vindividualcustomer =
+            leftTable<``vindividualcustomer (base)``, vindividualcustomer>
+
+        type private ``vpersondemographics (base)`` = vpersondemographics
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vpersondemographics =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Money")>]
+              totalpurchaseytd: Option<decimal>
+              [<ProviderDbType("Date")>]
+              datefirstpurchase: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              birthdate: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              maritalstatus: Option<string>
+              [<ProviderDbType("Varchar")>]
+              yearlyincome: Option<string>
+              [<ProviderDbType("Varchar")>]
+              gender: Option<string>
+              [<ProviderDbType("Integer")>]
+              totalchildren: Option<int>
+              [<ProviderDbType("Integer")>]
+              numberchildrenathome: Option<int>
+              [<ProviderDbType("Varchar")>]
+              education: Option<string>
+              [<ProviderDbType("Varchar")>]
+              occupation: Option<string>
+              [<ProviderDbType("Boolean")>]
+              homeownerflag: Option<bool>
+              [<ProviderDbType("Integer")>]
+              numbercarsowned: Option<int> }
+
+            interface ILeftViewOf<``vpersondemographics (base)``>
+
+        let vpersondemographics =
+            leftTable<``vpersondemographics (base)``, vpersondemographics>
+
+        type private ``vsalesperson (base)`` = vsalesperson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalesperson =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              territoryname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              territorygroup: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal> }
+
+            interface ILeftViewOf<``vsalesperson (base)``>
+
+        let vsalesperson = leftTable<``vsalesperson (base)``, vsalesperson>
+
+        type private ``vsalespersonsalesbyfiscalyears (base)`` = vsalespersonsalesbyfiscalyears
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalespersonsalesbyfiscalyears =
+            { [<ProviderDbType("Integer")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("Text")>]
+              FullName: Option<string>
+              [<ProviderDbType("Text")>]
+              JobTitle: Option<string>
+              [<ProviderDbType("Text")>]
+              SalesTerritory: Option<string>
+              [<ProviderDbType("Numeric")>]
+              ``2012``: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              ``2013``: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              ``2014``: Option<decimal> }
+
+            interface ILeftViewOf<``vsalespersonsalesbyfiscalyears (base)``>
+
+        let vsalespersonsalesbyfiscalyears =
+            leftTable<``vsalespersonsalesbyfiscalyears (base)``, vsalespersonsalesbyfiscalyears>
+
+        type private ``vsalespersonsalesbyfiscalyearsdata (base)`` = vsalespersonsalesbyfiscalyearsdata
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalespersonsalesbyfiscalyearsdata =
+            { [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Text")>]
+              fullname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              salesterritory: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salestotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              fiscalyear: Option<decimal> }
+
+            interface ILeftViewOf<``vsalespersonsalesbyfiscalyearsdata (base)``>
+
+        let vsalespersonsalesbyfiscalyearsdata =
+            leftTable<``vsalespersonsalesbyfiscalyearsdata (base)``, vsalespersonsalesbyfiscalyearsdata>
+
+        type private ``vstorewithaddresses (base)`` = vstorewithaddresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithaddresses =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vstorewithaddresses (base)``>
+
+        let vstorewithaddresses =
+            leftTable<``vstorewithaddresses (base)``, vstorewithaddresses>
+
+        type private ``vstorewithcontacts (base)`` = vstorewithcontacts
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithcontacts =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              contacttype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int> }
+
+            interface ILeftViewOf<``vstorewithcontacts (base)``>
+
+        let vstorewithcontacts =
+            leftTable<``vstorewithcontacts (base)``, vstorewithcontacts>
+
+        type private ``vstorewithdemographics (base)`` = vstorewithdemographics
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithdemographics =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Money")>]
+              AnnualSales: Option<decimal>
+              [<ProviderDbType("Money")>]
+              AnnualRevenue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              BankName: Option<string>
+              [<ProviderDbType("Varchar")>]
+              BusinessType: Option<string>
+              [<ProviderDbType("Integer")>]
+              YearOpened: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Specialty: Option<string>
+              [<ProviderDbType("Integer")>]
+              SquareFeet: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Brands: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Internet: Option<string>
+              [<ProviderDbType("Integer")>]
+              NumberEmployees: Option<int> }
+
+            interface ILeftViewOf<``vstorewithdemographics (base)``>
+
+        let vstorewithdemographics =
+            leftTable<``vstorewithdemographics (base)``, vstorewithdemographics>
+
 
 
 [<RequireQualifiedAccess>]

--- a/src/Tests/Npgsql/AdventureWorksNet10.fs
+++ b/src/Tests/Npgsql/AdventureWorksNet10.fs
@@ -78,17 +78,6 @@ module ext =
 
             interface ILeftViewOf<``arrays (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``arrays (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``arrays (base)`` =
-                        { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
-
-                    Some record
-                | None -> None
-
         let arrays = leftTable<``arrays (base)``, arrays>
 
         type private ``jsonsupport (base)`` = jsonsupport
@@ -104,17 +93,6 @@ module ext =
 
             interface ILeftViewOf<``jsonsupport (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``jsonsupport (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``jsonsupport (base)`` =
-                        { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
-
-                    Some record
-                | None -> None
-
         let jsonsupport = leftTable<``jsonsupport (base)``, jsonsupport>
 
         type private ``person (base)`` = person
@@ -126,17 +104,6 @@ module ext =
               currentmood: Option<mood> }
 
             interface ILeftViewOf<``person (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``person (base)`` option =
-                match this.name with
-                | Some value ->
-                    let record: ``person (base)`` =
-                        { name = value; currentmood = this.currentmood.Value }
-
-                    Some record
-                | None -> None
 
         let person = leftTable<``person (base)``, person>
 
@@ -611,17 +578,6 @@ module humanresources =
 
             interface ILeftViewOf<``department (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``department (base)`` option =
-                match this.departmentid with
-                | Some value ->
-                    let record: ``department (base)`` =
-                        { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let department = leftTable<``department (base)``, department>
 
         type private ``employee (base)`` = employee
@@ -661,31 +617,6 @@ module humanresources =
 
             interface ILeftViewOf<``employee (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employee (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employee (base)`` =
-                        { businessentityid = value
-                          nationalidnumber = this.nationalidnumber.Value
-                          loginid = this.loginid.Value
-                          jobtitle = this.jobtitle.Value
-                          birthdate = this.birthdate.Value
-                          maritalstatus = this.maritalstatus.Value
-                          gender = this.gender.Value
-                          hiredate = this.hiredate.Value
-                          salariedflag = this.salariedflag.Value
-                          vacationhours = this.vacationhours.Value
-                          sickleavehours = this.sickleavehours.Value
-                          currentflag = this.currentflag.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value
-                          organizationnode = this.organizationnode }
-
-                    Some record
-                | None -> None
-
         let employee = leftTable<``employee (base)``, employee>
 
         type private ``employeedepartmenthistory (base)`` = employeedepartmenthistory
@@ -707,22 +638,6 @@ module humanresources =
 
             interface ILeftViewOf<``employeedepartmenthistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employeedepartmenthistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employeedepartmenthistory (base)`` =
-                        { businessentityid = value
-                          departmentid = this.departmentid.Value
-                          shiftid = this.shiftid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let employeedepartmenthistory =
             leftTable<``employeedepartmenthistory (base)``, employeedepartmenthistory>
 
@@ -743,17 +658,6 @@ module humanresources =
 
             interface ILeftViewOf<``employeepayhistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employeepayhistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employeepayhistory (base)`` =
-                        { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let employeepayhistory =
             leftTable<``employeepayhistory (base)``, employeepayhistory>
 
@@ -771,17 +675,6 @@ module humanresources =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``jobcandidate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``jobcandidate (base)`` option =
-                match this.jobcandidateid with
-                | Some value ->
-                    let record: ``jobcandidate (base)`` =
-                        { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let jobcandidate = leftTable<``jobcandidate (base)``, jobcandidate>
 
@@ -801,17 +694,6 @@ module humanresources =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shift (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shift (base)`` option =
-                match this.shiftid with
-                | Some value ->
-                    let record: ``shift (base)`` =
-                        { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shift = leftTable<``shift (base)``, shift>
 
@@ -1076,17 +958,6 @@ module network_sample =
               net_macaddr8: Option<System.Net.NetworkInformation.PhysicalAddress> }
 
             interface ILeftViewOf<``network_addresses (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``network_addresses (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``network_addresses (base)`` =
-                        { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
-
-                    Some record
-                | None -> None
 
         let network_addresses = leftTable<``network_addresses (base)``, network_addresses>
 
@@ -1641,30 +1512,6 @@ module pe =
 
             interface ILeftViewOf<``p (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``p (base)`` option =
-                match this.namestyle with
-                | Some value ->
-                    let record: ``p (base)`` =
-                        { id = this.id
-                          businessentityid = this.businessentityid
-                          persontype = this.persontype
-                          namestyle = value
-                          title = this.title
-                          firstname = this.firstname
-                          middlename = this.middlename
-                          lastname = this.lastname
-                          suffix = this.suffix
-                          emailpromotion = this.emailpromotion
-                          additionalcontactinfo = this.additionalcontactinfo
-                          demographics = this.demographics
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
-
         let p = leftTable<``p (base)``, p>
 
         type private ``pa (base)`` = pa
@@ -1748,25 +1595,6 @@ module pe =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``sp (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``sp (base)`` option =
-                match this.isonlystateprovinceflag with
-                | Some value ->
-                    let record: ``sp (base)`` =
-                        { id = this.id
-                          stateprovinceid = this.stateprovinceid
-                          stateprovincecode = this.stateprovincecode
-                          countryregioncode = this.countryregioncode
-                          isonlystateprovinceflag = value
-                          name = this.name
-                          territoryid = this.territoryid
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let sp = leftTable<``sp (base)``, sp>
 
@@ -2197,25 +2025,6 @@ module person =
 
             interface ILeftViewOf<``address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``address (base)`` option =
-                match this.addressid with
-                | Some value ->
-                    let record: ``address (base)`` =
-                        { addressid = value
-                          addressline1 = this.addressline1.Value
-                          addressline2 = this.addressline2
-                          city = this.city.Value
-                          stateprovinceid = this.stateprovinceid.Value
-                          postalcode = this.postalcode.Value
-                          spatiallocation = this.spatiallocation
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let address = leftTable<``address (base)``, address>
 
         type private ``addresstype (base)`` = addresstype
@@ -2233,17 +2042,6 @@ module person =
 
             interface ILeftViewOf<``addresstype (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``addresstype (base)`` option =
-                match this.addresstypeid with
-                | Some value ->
-                    let record: ``addresstype (base)`` =
-                        { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let addresstype = leftTable<``addresstype (base)``, addresstype>
 
         type private ``businessentity (base)`` = businessentity
@@ -2258,17 +2056,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``businessentity (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentity (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentity (base)`` =
-                        { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let businessentity = leftTable<``businessentity (base)``, businessentity>
 
@@ -2288,17 +2075,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``businessentityaddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentityaddress (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentityaddress (base)`` =
-                        { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let businessentityaddress =
             leftTable<``businessentityaddress (base)``, businessentityaddress>
@@ -2320,17 +2096,6 @@ module person =
 
             interface ILeftViewOf<``businessentitycontact (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentitycontact (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentitycontact (base)`` =
-                        { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let businessentitycontact =
             leftTable<``businessentitycontact (base)``, businessentitycontact>
 
@@ -2347,17 +2112,6 @@ module person =
 
             interface ILeftViewOf<``contacttype (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``contacttype (base)`` option =
-                match this.contacttypeid with
-                | Some value ->
-                    let record: ``contacttype (base)`` =
-                        { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let contacttype = leftTable<``contacttype (base)``, contacttype>
 
         type private ``countryregion (base)`` = countryregion
@@ -2372,17 +2126,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``countryregion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``countryregion (base)`` option =
-                match this.countryregioncode with
-                | Some value ->
-                    let record: ``countryregion (base)`` =
-                        { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let countryregion = leftTable<``countryregion (base)``, countryregion>
 
@@ -2403,17 +2146,6 @@ module person =
 
             interface ILeftViewOf<``emailaddress (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``emailaddress (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``emailaddress (base)`` =
-                        { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let emailaddress = leftTable<``emailaddress (base)``, emailaddress>
 
         type private ``password (base)`` = password
@@ -2432,21 +2164,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``password (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``password (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``password (base)`` =
-                        { businessentityid = value
-                          passwordhash = this.passwordhash.Value
-                          passwordsalt = this.passwordsalt.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let password = leftTable<``password (base)``, password>
 
@@ -2483,29 +2200,6 @@ module person =
 
             interface ILeftViewOf<``person (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``person (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``person (base)`` =
-                        { businessentityid = value
-                          persontype = this.persontype.Value
-                          namestyle = this.namestyle.Value
-                          title = this.title
-                          firstname = this.firstname.Value
-                          middlename = this.middlename
-                          lastname = this.lastname.Value
-                          suffix = this.suffix
-                          emailpromotion = this.emailpromotion.Value
-                          additionalcontactinfo = this.additionalcontactinfo
-                          demographics = this.demographics
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let person = leftTable<``person (base)``, person>
 
         type private ``personphone (base)`` = personphone
@@ -2523,17 +2217,6 @@ module person =
 
             interface ILeftViewOf<``personphone (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``personphone (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``personphone (base)`` =
-                        { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let personphone = leftTable<``personphone (base)``, personphone>
 
         type private ``phonenumbertype (base)`` = phonenumbertype
@@ -2548,17 +2231,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``phonenumbertype (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``phonenumbertype (base)`` option =
-                match this.phonenumbertypeid with
-                | Some value ->
-                    let record: ``phonenumbertype (base)`` =
-                        { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let phonenumbertype = leftTable<``phonenumbertype (base)``, phonenumbertype>
 
@@ -2584,24 +2256,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``stateprovince (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``stateprovince (base)`` option =
-                match this.stateprovinceid with
-                | Some value ->
-                    let record: ``stateprovince (base)`` =
-                        { stateprovinceid = value
-                          stateprovincecode = this.stateprovincecode.Value
-                          countryregioncode = this.countryregioncode.Value
-                          isonlystateprovinceflag = this.isonlystateprovinceflag.Value
-                          name = this.name.Value
-                          territoryid = this.territoryid.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let stateprovince = leftTable<``stateprovince (base)``, stateprovince>
 
@@ -3518,29 +3172,6 @@ module pr =
 
             interface ILeftViewOf<``d (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``d (base)`` option =
-                match this.folderflag with
-                | Some value ->
-                    let record: ``d (base)`` =
-                        { title = this.title
-                          owner = this.owner
-                          folderflag = value
-                          filename = this.filename
-                          fileextension = this.fileextension
-                          revision = this.revision
-                          changenumber = this.changenumber
-                          status = this.status
-                          documentsummary = this.documentsummary
-                          document = this.document
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate
-                          documentnode = this.documentnode }
-
-                    Some record
-                | None -> None
-
         let d = leftTable<``d (base)``, d>
 
         type private ``i (base)`` = i
@@ -3639,42 +3270,6 @@ module pr =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``p (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``p (base)`` option =
-                match this.makeflag with
-                | Some value ->
-                    let record: ``p (base)`` =
-                        { id = this.id
-                          productid = this.productid
-                          name = this.name
-                          productnumber = this.productnumber
-                          makeflag = value
-                          finishedgoodsflag = this.finishedgoodsflag.Value
-                          color = this.color
-                          safetystocklevel = this.safetystocklevel
-                          reorderpoint = this.reorderpoint
-                          standardcost = this.standardcost
-                          listprice = this.listprice
-                          size = this.size
-                          sizeunitmeasurecode = this.sizeunitmeasurecode
-                          weightunitmeasurecode = this.weightunitmeasurecode
-                          weight = this.weight
-                          daystomanufacture = this.daystomanufacture
-                          productline = this.productline
-                          ``class`` = this.``class``
-                          style = this.style
-                          productsubcategoryid = this.productsubcategoryid
-                          productmodelid = this.productmodelid
-                          sellstartdate = this.sellstartdate
-                          sellenddate = this.sellenddate
-                          discontinueddate = this.discontinueddate
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let p = leftTable<``p (base)``, p>
 
@@ -3892,17 +3487,6 @@ module pr =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ppp (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ppp (base)`` option =
-                match this.primary with
-                | Some value ->
-                    let record: ``ppp (base)`` =
-                        { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let ppp = leftTable<``ppp (base)``, ppp>
 
@@ -4987,25 +4571,6 @@ module production =
 
             interface ILeftViewOf<``billofmaterials (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``billofmaterials (base)`` option =
-                match this.billofmaterialsid with
-                | Some value ->
-                    let record: ``billofmaterials (base)`` =
-                        { billofmaterialsid = value
-                          productassemblyid = this.productassemblyid
-                          componentid = this.componentid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          unitmeasurecode = this.unitmeasurecode.Value
-                          bomlevel = this.bomlevel.Value
-                          perassemblyqty = this.perassemblyqty.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let billofmaterials = leftTable<``billofmaterials (base)``, billofmaterials>
 
         type private ``culture (base)`` = culture
@@ -5020,17 +4585,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``culture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``culture (base)`` option =
-                match this.cultureid with
-                | Some value ->
-                    let record: ``culture (base)`` =
-                        { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let culture = leftTable<``culture (base)``, culture>
 
@@ -5067,29 +4621,6 @@ module production =
 
             interface ILeftViewOf<``document (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``document (base)`` option =
-                match this.documentnode with
-                | Some value ->
-                    let record: ``document (base)`` =
-                        { title = this.title.Value
-                          owner = this.owner.Value
-                          folderflag = this.folderflag.Value
-                          filename = this.filename.Value
-                          fileextension = this.fileextension
-                          revision = this.revision.Value
-                          changenumber = this.changenumber.Value
-                          status = this.status.Value
-                          documentsummary = this.documentsummary
-                          document = this.document
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value
-                          documentnode = value }
-
-                    Some record
-                | None -> None
-
         let document = leftTable<``document (base)``, document>
 
         type private ``illustration (base)`` = illustration
@@ -5104,17 +4635,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``illustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``illustration (base)`` option =
-                match this.illustrationid with
-                | Some value ->
-                    let record: ``illustration (base)`` =
-                        { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let illustration = leftTable<``illustration (base)``, illustration>
 
@@ -5134,17 +4654,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``location (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``location (base)`` option =
-                match this.locationid with
-                | Some value ->
-                    let record: ``location (base)`` =
-                        { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let location = leftTable<``location (base)``, location>
 
@@ -5205,41 +4714,6 @@ module production =
 
             interface ILeftViewOf<``product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``product (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``product (base)`` =
-                        { productid = value
-                          name = this.name.Value
-                          productnumber = this.productnumber.Value
-                          makeflag = this.makeflag.Value
-                          finishedgoodsflag = this.finishedgoodsflag.Value
-                          color = this.color
-                          safetystocklevel = this.safetystocklevel.Value
-                          reorderpoint = this.reorderpoint.Value
-                          standardcost = this.standardcost.Value
-                          listprice = this.listprice.Value
-                          size = this.size
-                          sizeunitmeasurecode = this.sizeunitmeasurecode
-                          weightunitmeasurecode = this.weightunitmeasurecode
-                          weight = this.weight
-                          daystomanufacture = this.daystomanufacture.Value
-                          productline = this.productline
-                          ``class`` = this.``class``
-                          style = this.style
-                          productsubcategoryid = this.productsubcategoryid
-                          productmodelid = this.productmodelid
-                          sellstartdate = this.sellstartdate.Value
-                          sellenddate = this.sellenddate
-                          discontinueddate = this.discontinueddate
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let product = leftTable<``product (base)``, product>
 
         type private ``productcategory (base)`` = productcategory
@@ -5256,17 +4730,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productcategory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productcategory (base)`` option =
-                match this.productcategoryid with
-                | Some value ->
-                    let record: ``productcategory (base)`` =
-                        { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productcategory = leftTable<``productcategory (base)``, productcategory>
 
@@ -5287,17 +4750,6 @@ module production =
 
             interface ILeftViewOf<``productcosthistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productcosthistory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productcosthistory (base)`` =
-                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productcosthistory =
             leftTable<``productcosthistory (base)``, productcosthistory>
 
@@ -5316,17 +4768,6 @@ module production =
 
             interface ILeftViewOf<``productdescription (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productdescription (base)`` option =
-                match this.productdescriptionid with
-                | Some value ->
-                    let record: ``productdescription (base)`` =
-                        { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productdescription =
             leftTable<``productdescription (base)``, productdescription>
 
@@ -5342,17 +4783,6 @@ module production =
               documentnode: Option<string> }
 
             interface ILeftViewOf<``productdocument (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productdocument (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productdocument (base)`` =
-                        { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
-
-                    Some record
-                | None -> None
 
         let productdocument = leftTable<``productdocument (base)``, productdocument>
 
@@ -5377,23 +4807,6 @@ module production =
 
             interface ILeftViewOf<``productinventory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productinventory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productinventory (base)`` =
-                        { productid = value
-                          locationid = this.locationid.Value
-                          shelf = this.shelf.Value
-                          bin = this.bin.Value
-                          quantity = this.quantity.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productinventory = leftTable<``productinventory (base)``, productinventory>
 
         type private ``productlistpricehistory (base)`` = productlistpricehistory
@@ -5412,17 +4825,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productlistpricehistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productlistpricehistory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productlistpricehistory (base)`` =
-                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productlistpricehistory =
             leftTable<``productlistpricehistory (base)``, productlistpricehistory>
@@ -5446,22 +4848,6 @@ module production =
 
             interface ILeftViewOf<``productmodel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodel (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodel (base)`` =
-                        { productmodelid = value
-                          name = this.name.Value
-                          catalogdescription = this.catalogdescription
-                          instructions = this.instructions
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productmodel = leftTable<``productmodel (base)``, productmodel>
 
         type private ``productmodelillustration (base)`` = productmodelillustration
@@ -5476,17 +4862,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productmodelillustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodelillustration (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodelillustration (base)`` =
-                        { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productmodelillustration =
             leftTable<``productmodelillustration (base)``, productmodelillustration>
@@ -5505,17 +4880,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productmodelproductdescriptionculture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodelproductdescriptionculture (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodelproductdescriptionculture (base)`` =
-                        { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productmodelproductdescriptionculture =
             leftTable<``productmodelproductdescriptionculture (base)``, productmodelproductdescriptionculture>
@@ -5539,22 +4903,6 @@ module production =
 
             interface ILeftViewOf<``productphoto (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productphoto (base)`` option =
-                match this.productphotoid with
-                | Some value ->
-                    let record: ``productphoto (base)`` =
-                        { productphotoid = value
-                          thumbnailphoto = this.thumbnailphoto
-                          thumbnailphotofilename = this.thumbnailphotofilename
-                          largephoto = this.largephoto
-                          largephotofilename = this.largephotofilename
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productphoto = leftTable<``productphoto (base)``, productphoto>
 
         type private ``productproductphoto (base)`` = productproductphoto
@@ -5571,17 +4919,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productproductphoto (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productproductphoto (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productproductphoto (base)`` =
-                        { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productproductphoto =
             leftTable<``productproductphoto (base)``, productproductphoto>
@@ -5609,24 +4946,6 @@ module production =
 
             interface ILeftViewOf<``productreview (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productreview (base)`` option =
-                match this.productreviewid with
-                | Some value ->
-                    let record: ``productreview (base)`` =
-                        { productreviewid = value
-                          productid = this.productid.Value
-                          reviewername = this.reviewername.Value
-                          reviewdate = this.reviewdate.Value
-                          emailaddress = this.emailaddress.Value
-                          rating = this.rating.Value
-                          comments = this.comments
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productreview = leftTable<``productreview (base)``, productreview>
 
         type private ``productsubcategory (base)`` = productsubcategory
@@ -5646,17 +4965,6 @@ module production =
 
             interface ILeftViewOf<``productsubcategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productsubcategory (base)`` option =
-                match this.productsubcategoryid with
-                | Some value ->
-                    let record: ``productsubcategory (base)`` =
-                        { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productsubcategory =
             leftTable<``productsubcategory (base)``, productsubcategory>
 
@@ -5672,17 +4980,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``scrapreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``scrapreason (base)`` option =
-                match this.scrapreasonid with
-                | Some value ->
-                    let record: ``scrapreason (base)`` =
-                        { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let scrapreason = leftTable<``scrapreason (base)``, scrapreason>
 
@@ -5710,25 +5007,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``transactionhistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``transactionhistory (base)`` option =
-                match this.transactionid with
-                | Some value ->
-                    let record: ``transactionhistory (base)`` =
-                        { transactionid = value
-                          productid = this.productid.Value
-                          referenceorderid = this.referenceorderid.Value
-                          referenceorderlineid = this.referenceorderlineid.Value
-                          transactiondate = this.transactiondate.Value
-                          transactiontype = this.transactiontype.Value
-                          quantity = this.quantity.Value
-                          actualcost = this.actualcost.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let transactionhistory =
             leftTable<``transactionhistory (base)``, transactionhistory>
@@ -5758,25 +5036,6 @@ module production =
 
             interface ILeftViewOf<``transactionhistoryarchive (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``transactionhistoryarchive (base)`` option =
-                match this.transactionid with
-                | Some value ->
-                    let record: ``transactionhistoryarchive (base)`` =
-                        { transactionid = value
-                          productid = this.productid.Value
-                          referenceorderid = this.referenceorderid.Value
-                          referenceorderlineid = this.referenceorderlineid.Value
-                          transactiondate = this.transactiondate.Value
-                          transactiontype = this.transactiontype.Value
-                          quantity = this.quantity.Value
-                          actualcost = this.actualcost.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let transactionhistoryarchive =
             leftTable<``transactionhistoryarchive (base)``, transactionhistoryarchive>
 
@@ -5792,17 +5051,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``unitmeasure (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``unitmeasure (base)`` option =
-                match this.unitmeasurecode with
-                | Some value ->
-                    let record: ``unitmeasure (base)`` =
-                        { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let unitmeasure = leftTable<``unitmeasure (base)``, unitmeasure>
 
@@ -5941,25 +5189,6 @@ module production =
 
             interface ILeftViewOf<``workorder (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``workorder (base)`` option =
-                match this.workorderid with
-                | Some value ->
-                    let record: ``workorder (base)`` =
-                        { workorderid = value
-                          productid = this.productid.Value
-                          orderqty = this.orderqty.Value
-                          scrappedqty = this.scrappedqty.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          duedate = this.duedate.Value
-                          scrapreasonid = this.scrapreasonid
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let workorder = leftTable<``workorder (base)``, workorder>
 
         type private ``workorderrouting (base)`` = workorderrouting
@@ -5992,28 +5221,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``workorderrouting (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``workorderrouting (base)`` option =
-                match this.workorderid with
-                | Some value ->
-                    let record: ``workorderrouting (base)`` =
-                        { workorderid = value
-                          productid = this.productid.Value
-                          operationsequence = this.operationsequence.Value
-                          locationid = this.locationid.Value
-                          scheduledstartdate = this.scheduledstartdate.Value
-                          scheduledenddate = this.scheduledenddate.Value
-                          actualstartdate = this.actualstartdate
-                          actualenddate = this.actualenddate
-                          actualresourcehrs = this.actualresourcehrs
-                          plannedcost = this.plannedcost.Value
-                          actualcost = this.actualcost
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let workorderrouting = leftTable<``workorderrouting (base)``, workorderrouting>
 
@@ -6361,25 +5568,6 @@ module pu =
 
             interface ILeftViewOf<``v (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``v (base)`` option =
-                match this.preferredvendorstatus with
-                | Some value ->
-                    let record: ``v (base)`` =
-                        { id = this.id
-                          businessentityid = this.businessentityid
-                          accountnumber = this.accountnumber
-                          name = this.name
-                          creditrating = this.creditrating
-                          preferredvendorstatus = value
-                          activeflag = this.activeflag.Value
-                          purchasingwebserviceurl = this.purchasingwebserviceurl
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
-
         let v = leftTable<``v (base)``, v>
 
 
@@ -6674,27 +5862,6 @@ module purchasing =
 
             interface ILeftViewOf<``productvendor (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productvendor (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productvendor (base)`` =
-                        { productid = value
-                          businessentityid = this.businessentityid.Value
-                          averageleadtime = this.averageleadtime.Value
-                          standardprice = this.standardprice.Value
-                          lastreceiptcost = this.lastreceiptcost
-                          lastreceiptdate = this.lastreceiptdate
-                          minorderqty = this.minorderqty.Value
-                          maxorderqty = this.maxorderqty.Value
-                          onorderqty = this.onorderqty
-                          unitmeasurecode = this.unitmeasurecode.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productvendor = leftTable<``productvendor (base)``, productvendor>
 
         type private ``purchaseorderdetail (base)`` = purchaseorderdetail
@@ -6721,25 +5888,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``purchaseorderdetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``purchaseorderdetail (base)`` option =
-                match this.purchaseorderid with
-                | Some value ->
-                    let record: ``purchaseorderdetail (base)`` =
-                        { purchaseorderid = value
-                          purchaseorderdetailid = this.purchaseorderdetailid.Value
-                          duedate = this.duedate.Value
-                          orderqty = this.orderqty.Value
-                          productid = this.productid.Value
-                          unitprice = this.unitprice.Value
-                          receivedqty = this.receivedqty.Value
-                          rejectedqty = this.rejectedqty.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let purchaseorderdetail =
             leftTable<``purchaseorderdetail (base)``, purchaseorderdetail>
@@ -6775,28 +5923,6 @@ module purchasing =
 
             interface ILeftViewOf<``purchaseorderheader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``purchaseorderheader (base)`` option =
-                match this.purchaseorderid with
-                | Some value ->
-                    let record: ``purchaseorderheader (base)`` =
-                        { purchaseorderid = value
-                          revisionnumber = this.revisionnumber.Value
-                          status = this.status.Value
-                          employeeid = this.employeeid.Value
-                          vendorid = this.vendorid.Value
-                          shipmethodid = this.shipmethodid.Value
-                          orderdate = this.orderdate.Value
-                          shipdate = this.shipdate
-                          subtotal = this.subtotal.Value
-                          taxamt = this.taxamt.Value
-                          freight = this.freight.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let purchaseorderheader =
             leftTable<``purchaseorderheader (base)``, purchaseorderheader>
 
@@ -6818,22 +5944,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shipmethod (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shipmethod (base)`` option =
-                match this.shipmethodid with
-                | Some value ->
-                    let record: ``shipmethod (base)`` =
-                        { shipmethodid = value
-                          name = this.name.Value
-                          shipbase = this.shipbase.Value
-                          shiprate = this.shiprate.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shipmethod = leftTable<``shipmethod (base)``, shipmethod>
 
@@ -6859,24 +5969,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``vendor (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``vendor (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``vendor (base)`` =
-                        { businessentityid = value
-                          accountnumber = this.accountnumber.Value
-                          name = this.name.Value
-                          creditrating = this.creditrating.Value
-                          preferredvendorstatus = this.preferredvendorstatus.Value
-                          activeflag = this.activeflag.Value
-                          purchasingwebserviceurl = this.purchasingwebserviceurl
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let vendor = leftTable<``vendor (base)``, vendor>
 
@@ -7836,42 +6928,6 @@ module sa =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``soh (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``soh (base)`` option =
-                match this.onlineorderflag with
-                | Some value ->
-                    let record: ``soh (base)`` =
-                        { id = this.id
-                          salesorderid = this.salesorderid
-                          revisionnumber = this.revisionnumber
-                          orderdate = this.orderdate
-                          duedate = this.duedate
-                          shipdate = this.shipdate
-                          status = this.status
-                          onlineorderflag = value
-                          purchaseordernumber = this.purchaseordernumber
-                          accountnumber = this.accountnumber
-                          customerid = this.customerid
-                          salespersonid = this.salespersonid
-                          territoryid = this.territoryid
-                          billtoaddressid = this.billtoaddressid
-                          shiptoaddressid = this.shiptoaddressid
-                          shipmethodid = this.shipmethodid
-                          creditcardid = this.creditcardid
-                          creditcardapprovalcode = this.creditcardapprovalcode
-                          currencyrateid = this.currencyrateid
-                          subtotal = this.subtotal
-                          taxamt = this.taxamt
-                          freight = this.freight
-                          totaldue = this.totaldue
-                          comment = this.comment
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let soh = leftTable<``soh (base)``, soh>
 
@@ -8991,17 +8047,6 @@ module sales =
 
             interface ILeftViewOf<``countryregioncurrency (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``countryregioncurrency (base)`` option =
-                match this.countryregioncode with
-                | Some value ->
-                    let record: ``countryregioncurrency (base)`` =
-                        { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let countryregioncurrency =
             leftTable<``countryregioncurrency (base)``, countryregioncurrency>
 
@@ -9024,22 +8069,6 @@ module sales =
 
             interface ILeftViewOf<``creditcard (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``creditcard (base)`` option =
-                match this.creditcardid with
-                | Some value ->
-                    let record: ``creditcard (base)`` =
-                        { creditcardid = value
-                          cardtype = this.cardtype.Value
-                          cardnumber = this.cardnumber.Value
-                          expmonth = this.expmonth.Value
-                          expyear = this.expyear.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let creditcard = leftTable<``creditcard (base)``, creditcard>
 
         type private ``currency (base)`` = currency
@@ -9054,17 +8083,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``currency (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``currency (base)`` option =
-                match this.currencycode with
-                | Some value ->
-                    let record: ``currency (base)`` =
-                        { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let currency = leftTable<``currency (base)``, currency>
 
@@ -9089,23 +8107,6 @@ module sales =
 
             interface ILeftViewOf<``currencyrate (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``currencyrate (base)`` option =
-                match this.currencyrateid with
-                | Some value ->
-                    let record: ``currencyrate (base)`` =
-                        { currencyrateid = value
-                          currencyratedate = this.currencyratedate.Value
-                          fromcurrencycode = this.fromcurrencycode.Value
-                          tocurrencycode = this.tocurrencycode.Value
-                          averagerate = this.averagerate.Value
-                          endofdayrate = this.endofdayrate.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let currencyrate = leftTable<``currencyrate (base)``, currencyrate>
 
         type private ``customer (base)`` = customer
@@ -9127,17 +8128,6 @@ module sales =
 
             interface ILeftViewOf<``customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``customer (base)`` option =
-                match this.customerid with
-                | Some value ->
-                    let record: ``customer (base)`` =
-                        { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let customer = leftTable<``customer (base)``, customer>
 
         type private ``personcreditcard (base)`` = personcreditcard
@@ -9152,17 +8142,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``personcreditcard (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``personcreditcard (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``personcreditcard (base)`` =
-                        { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let personcreditcard = leftTable<``personcreditcard (base)``, personcreditcard>
 
@@ -9192,26 +8171,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesorderdetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderdetail (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderdetail (base)`` =
-                        { salesorderid = value
-                          salesorderdetailid = this.salesorderdetailid.Value
-                          carriertrackingnumber = this.carriertrackingnumber
-                          orderqty = this.orderqty.Value
-                          productid = this.productid.Value
-                          specialofferid = this.specialofferid.Value
-                          unitprice = this.unitprice.Value
-                          unitpricediscount = this.unitpricediscount.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesorderdetail = leftTable<``salesorderdetail (base)``, salesorderdetail>
 
@@ -9272,41 +8231,6 @@ module sales =
 
             interface ILeftViewOf<``salesorderheader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderheader (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderheader (base)`` =
-                        { salesorderid = value
-                          revisionnumber = this.revisionnumber.Value
-                          orderdate = this.orderdate.Value
-                          duedate = this.duedate.Value
-                          shipdate = this.shipdate
-                          status = this.status.Value
-                          onlineorderflag = this.onlineorderflag.Value
-                          purchaseordernumber = this.purchaseordernumber
-                          accountnumber = this.accountnumber
-                          customerid = this.customerid.Value
-                          salespersonid = this.salespersonid
-                          territoryid = this.territoryid
-                          billtoaddressid = this.billtoaddressid.Value
-                          shiptoaddressid = this.shiptoaddressid.Value
-                          shipmethodid = this.shipmethodid.Value
-                          creditcardid = this.creditcardid
-                          creditcardapprovalcode = this.creditcardapprovalcode
-                          currencyrateid = this.currencyrateid
-                          subtotal = this.subtotal.Value
-                          taxamt = this.taxamt.Value
-                          freight = this.freight.Value
-                          totaldue = this.totaldue
-                          comment = this.comment
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesorderheader = leftTable<``salesorderheader (base)``, salesorderheader>
 
         type private ``salesorderheadersalesreason (base)`` = salesorderheadersalesreason
@@ -9321,17 +8245,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesorderheadersalesreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderheadersalesreason (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderheadersalesreason (base)`` =
-                        { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesorderheadersalesreason =
             leftTable<``salesorderheadersalesreason (base)``, salesorderheadersalesreason>
@@ -9361,25 +8274,6 @@ module sales =
 
             interface ILeftViewOf<``salesperson (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesperson (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salesperson (base)`` =
-                        { businessentityid = value
-                          territoryid = this.territoryid
-                          salesquota = this.salesquota
-                          bonus = this.bonus.Value
-                          commissionpct = this.commissionpct.Value
-                          salesytd = this.salesytd.Value
-                          saleslastyear = this.saleslastyear.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesperson = leftTable<``salesperson (base)``, salesperson>
 
         type private ``salespersonquotahistory (base)`` = salespersonquotahistory
@@ -9399,17 +8293,6 @@ module sales =
 
             interface ILeftViewOf<``salespersonquotahistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salespersonquotahistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salespersonquotahistory (base)`` =
-                        { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salespersonquotahistory =
             leftTable<``salespersonquotahistory (base)``, salespersonquotahistory>
 
@@ -9427,17 +8310,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesreason (base)`` option =
-                match this.salesreasonid with
-                | Some value ->
-                    let record: ``salesreason (base)`` =
-                        { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesreason = leftTable<``salesreason (base)``, salesreason>
 
@@ -9461,23 +8333,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salestaxrate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salestaxrate (base)`` option =
-                match this.salestaxrateid with
-                | Some value ->
-                    let record: ``salestaxrate (base)`` =
-                        { salestaxrateid = value
-                          stateprovinceid = this.stateprovinceid.Value
-                          taxtype = this.taxtype.Value
-                          taxrate = this.taxrate.Value
-                          name = this.name.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salestaxrate = leftTable<``salestaxrate (base)``, salestaxrate>
 
@@ -9508,26 +8363,6 @@ module sales =
 
             interface ILeftViewOf<``salesterritory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesterritory (base)`` option =
-                match this.territoryid with
-                | Some value ->
-                    let record: ``salesterritory (base)`` =
-                        { territoryid = value
-                          name = this.name.Value
-                          countryregioncode = this.countryregioncode.Value
-                          group = this.group.Value
-                          salesytd = this.salesytd.Value
-                          saleslastyear = this.saleslastyear.Value
-                          costytd = this.costytd.Value
-                          costlastyear = this.costlastyear.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesterritory = leftTable<``salesterritory (base)``, salesterritory>
 
         type private ``salesterritoryhistory (base)`` = salesterritoryhistory
@@ -9548,22 +8383,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesterritoryhistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesterritoryhistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salesterritoryhistory (base)`` =
-                        { businessentityid = value
-                          territoryid = this.territoryid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesterritoryhistory =
             leftTable<``salesterritoryhistory (base)``, salesterritoryhistory>
@@ -9586,22 +8405,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shoppingcartitem (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shoppingcartitem (base)`` option =
-                match this.shoppingcartitemid with
-                | Some value ->
-                    let record: ``shoppingcartitem (base)`` =
-                        { shoppingcartitemid = value
-                          shoppingcartid = this.shoppingcartid.Value
-                          quantity = this.quantity.Value
-                          productid = this.productid.Value
-                          datecreated = this.datecreated.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shoppingcartitem = leftTable<``shoppingcartitem (base)``, shoppingcartitem>
 
@@ -9634,27 +8437,6 @@ module sales =
 
             interface ILeftViewOf<``specialoffer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``specialoffer (base)`` option =
-                match this.specialofferid with
-                | Some value ->
-                    let record: ``specialoffer (base)`` =
-                        { specialofferid = value
-                          description = this.description.Value
-                          discountpct = this.discountpct.Value
-                          ``type`` = this.``type``.Value
-                          category = this.category.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate.Value
-                          minqty = this.minqty.Value
-                          maxqty = this.maxqty
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let specialoffer = leftTable<``specialoffer (base)``, specialoffer>
 
         type private ``specialofferproduct (base)`` = specialofferproduct
@@ -9671,17 +8453,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``specialofferproduct (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``specialofferproduct (base)`` option =
-                match this.specialofferid with
-                | Some value ->
-                    let record: ``specialofferproduct (base)`` =
-                        { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let specialofferproduct =
             leftTable<``specialofferproduct (base)``, specialofferproduct>
@@ -9704,22 +8475,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``store (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``store (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``store (base)`` =
-                        { businessentityid = value
-                          name = this.name.Value
-                          salespersonid = this.salespersonid
-                          demographics = this.demographics
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let store = leftTable<``store (base)``, store>
 
@@ -9999,6 +8754,1327 @@ module sales =
 
         let vstorewithdemographics =
             leftTable<``vstorewithdemographics (base)``, vstorewithdemographics>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type ext.LeftJoined.arrays with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.arrays option =
+            match this.id with
+            | Some value ->
+                let record: ext.arrays =
+                    { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.jsonsupport with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.jsonsupport option =
+            match this.id with
+            | Some value ->
+                let record: ext.jsonsupport =
+                    { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.person option =
+            match this.name with
+            | Some value ->
+                let record: ext.person = { name = value; currentmood = this.currentmood.Value }
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.department with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.department option =
+            match this.departmentid with
+            | Some value ->
+                let record: humanresources.department =
+                    { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employee with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employee option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employee =
+                    { businessentityid = value
+                      nationalidnumber = this.nationalidnumber.Value
+                      loginid = this.loginid.Value
+                      jobtitle = this.jobtitle.Value
+                      birthdate = this.birthdate.Value
+                      maritalstatus = this.maritalstatus.Value
+                      gender = this.gender.Value
+                      hiredate = this.hiredate.Value
+                      salariedflag = this.salariedflag.Value
+                      vacationhours = this.vacationhours.Value
+                      sickleavehours = this.sickleavehours.Value
+                      currentflag = this.currentflag.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value
+                      organizationnode = this.organizationnode }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employeedepartmenthistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employeedepartmenthistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employeedepartmenthistory =
+                    { businessentityid = value
+                      departmentid = this.departmentid.Value
+                      shiftid = this.shiftid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employeepayhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employeepayhistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employeepayhistory =
+                    { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.jobcandidate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.jobcandidate option =
+            match this.jobcandidateid with
+            | Some value ->
+                let record: humanresources.jobcandidate =
+                    { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.shift with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.shift option =
+            match this.shiftid with
+            | Some value ->
+                let record: humanresources.shift =
+                    { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type network_sample.LeftJoined.network_addresses with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : network_sample.network_addresses option =
+            match this.id with
+            | Some value ->
+                let record: network_sample.network_addresses =
+                    { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
+
+                Some record
+            | None -> None
+
+    type pe.LeftJoined.p with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pe.p option =
+            match this.namestyle with
+            | Some value ->
+                let record: pe.p =
+                    { id = this.id
+                      businessentityid = this.businessentityid
+                      persontype = this.persontype
+                      namestyle = value
+                      title = this.title
+                      firstname = this.firstname
+                      middlename = this.middlename
+                      lastname = this.lastname
+                      suffix = this.suffix
+                      emailpromotion = this.emailpromotion
+                      additionalcontactinfo = this.additionalcontactinfo
+                      demographics = this.demographics
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type pe.LeftJoined.sp with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pe.sp option =
+            match this.isonlystateprovinceflag with
+            | Some value ->
+                let record: pe.sp =
+                    { id = this.id
+                      stateprovinceid = this.stateprovinceid
+                      stateprovincecode = this.stateprovincecode
+                      countryregioncode = this.countryregioncode
+                      isonlystateprovinceflag = value
+                      name = this.name
+                      territoryid = this.territoryid
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.address option =
+            match this.addressid with
+            | Some value ->
+                let record: person.address =
+                    { addressid = value
+                      addressline1 = this.addressline1.Value
+                      addressline2 = this.addressline2
+                      city = this.city.Value
+                      stateprovinceid = this.stateprovinceid.Value
+                      postalcode = this.postalcode.Value
+                      spatiallocation = this.spatiallocation
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.addresstype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.addresstype option =
+            match this.addresstypeid with
+            | Some value ->
+                let record: person.addresstype =
+                    { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentity with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentity option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentity =
+                    { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentityaddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentityaddress option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentityaddress =
+                    { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentitycontact with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentitycontact option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentitycontact =
+                    { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.contacttype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.contacttype option =
+            match this.contacttypeid with
+            | Some value ->
+                let record: person.contacttype =
+                    { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.countryregion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.countryregion option =
+            match this.countryregioncode with
+            | Some value ->
+                let record: person.countryregion =
+                    { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.emailaddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.emailaddress option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.emailaddress =
+                    { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.password with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.password option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.password =
+                    { businessentityid = value; passwordhash = this.passwordhash.Value; passwordsalt = this.passwordsalt.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.person option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.person =
+                    { businessentityid = value
+                      persontype = this.persontype.Value
+                      namestyle = this.namestyle.Value
+                      title = this.title
+                      firstname = this.firstname.Value
+                      middlename = this.middlename
+                      lastname = this.lastname.Value
+                      suffix = this.suffix
+                      emailpromotion = this.emailpromotion.Value
+                      additionalcontactinfo = this.additionalcontactinfo
+                      demographics = this.demographics
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.personphone with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.personphone option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.personphone =
+                    { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.phonenumbertype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.phonenumbertype option =
+            match this.phonenumbertypeid with
+            | Some value ->
+                let record: person.phonenumbertype =
+                    { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.stateprovince with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.stateprovince option =
+            match this.stateprovinceid with
+            | Some value ->
+                let record: person.stateprovince =
+                    { stateprovinceid = value
+                      stateprovincecode = this.stateprovincecode.Value
+                      countryregioncode = this.countryregioncode.Value
+                      isonlystateprovinceflag = this.isonlystateprovinceflag.Value
+                      name = this.name.Value
+                      territoryid = this.territoryid.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.d with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.d option =
+            match this.folderflag with
+            | Some value ->
+                let record: pr.d =
+                    { title = this.title
+                      owner = this.owner
+                      folderflag = value
+                      filename = this.filename
+                      fileextension = this.fileextension
+                      revision = this.revision
+                      changenumber = this.changenumber
+                      status = this.status
+                      documentsummary = this.documentsummary
+                      document = this.document
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate
+                      documentnode = this.documentnode }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.p with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.p option =
+            match this.makeflag with
+            | Some value ->
+                let record: pr.p =
+                    { id = this.id
+                      productid = this.productid
+                      name = this.name
+                      productnumber = this.productnumber
+                      makeflag = value
+                      finishedgoodsflag = this.finishedgoodsflag.Value
+                      color = this.color
+                      safetystocklevel = this.safetystocklevel
+                      reorderpoint = this.reorderpoint
+                      standardcost = this.standardcost
+                      listprice = this.listprice
+                      size = this.size
+                      sizeunitmeasurecode = this.sizeunitmeasurecode
+                      weightunitmeasurecode = this.weightunitmeasurecode
+                      weight = this.weight
+                      daystomanufacture = this.daystomanufacture
+                      productline = this.productline
+                      ``class`` = this.``class``
+                      style = this.style
+                      productsubcategoryid = this.productsubcategoryid
+                      productmodelid = this.productmodelid
+                      sellstartdate = this.sellstartdate
+                      sellenddate = this.sellenddate
+                      discontinueddate = this.discontinueddate
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.ppp with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.ppp option =
+            match this.primary with
+            | Some value ->
+                let record: pr.ppp =
+                    { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.billofmaterials with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.billofmaterials option =
+            match this.billofmaterialsid with
+            | Some value ->
+                let record: production.billofmaterials =
+                    { billofmaterialsid = value
+                      productassemblyid = this.productassemblyid
+                      componentid = this.componentid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      unitmeasurecode = this.unitmeasurecode.Value
+                      bomlevel = this.bomlevel.Value
+                      perassemblyqty = this.perassemblyqty.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.culture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.culture option =
+            match this.cultureid with
+            | Some value ->
+                let record: production.culture =
+                    { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.document with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.document option =
+            match this.documentnode with
+            | Some value ->
+                let record: production.document =
+                    { title = this.title.Value
+                      owner = this.owner.Value
+                      folderflag = this.folderflag.Value
+                      filename = this.filename.Value
+                      fileextension = this.fileextension
+                      revision = this.revision.Value
+                      changenumber = this.changenumber.Value
+                      status = this.status.Value
+                      documentsummary = this.documentsummary
+                      document = this.document
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value
+                      documentnode = value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.illustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.illustration option =
+            match this.illustrationid with
+            | Some value ->
+                let record: production.illustration =
+                    { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.location with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.location option =
+            match this.locationid with
+            | Some value ->
+                let record: production.location =
+                    { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.product option =
+            match this.productid with
+            | Some value ->
+                let record: production.product =
+                    { productid = value
+                      name = this.name.Value
+                      productnumber = this.productnumber.Value
+                      makeflag = this.makeflag.Value
+                      finishedgoodsflag = this.finishedgoodsflag.Value
+                      color = this.color
+                      safetystocklevel = this.safetystocklevel.Value
+                      reorderpoint = this.reorderpoint.Value
+                      standardcost = this.standardcost.Value
+                      listprice = this.listprice.Value
+                      size = this.size
+                      sizeunitmeasurecode = this.sizeunitmeasurecode
+                      weightunitmeasurecode = this.weightunitmeasurecode
+                      weight = this.weight
+                      daystomanufacture = this.daystomanufacture.Value
+                      productline = this.productline
+                      ``class`` = this.``class``
+                      style = this.style
+                      productsubcategoryid = this.productsubcategoryid
+                      productmodelid = this.productmodelid
+                      sellstartdate = this.sellstartdate.Value
+                      sellenddate = this.sellenddate
+                      discontinueddate = this.discontinueddate
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productcategory option =
+            match this.productcategoryid with
+            | Some value ->
+                let record: production.productcategory =
+                    { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productcosthistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productcosthistory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productcosthistory =
+                    { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productdescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productdescription option =
+            match this.productdescriptionid with
+            | Some value ->
+                let record: production.productdescription =
+                    { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productdocument with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productdocument option =
+            match this.productid with
+            | Some value ->
+                let record: production.productdocument =
+                    { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productinventory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productinventory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productinventory =
+                    { productid = value
+                      locationid = this.locationid.Value
+                      shelf = this.shelf.Value
+                      bin = this.bin.Value
+                      quantity = this.quantity.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productlistpricehistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productlistpricehistory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productlistpricehistory =
+                    { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodel option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodel =
+                    { productmodelid = value
+                      name = this.name.Value
+                      catalogdescription = this.catalogdescription
+                      instructions = this.instructions
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodelillustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodelillustration option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodelillustration =
+                    { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodelproductdescriptionculture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodelproductdescriptionculture option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodelproductdescriptionculture =
+                    { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productphoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productphoto option =
+            match this.productphotoid with
+            | Some value ->
+                let record: production.productphoto =
+                    { productphotoid = value
+                      thumbnailphoto = this.thumbnailphoto
+                      thumbnailphotofilename = this.thumbnailphotofilename
+                      largephoto = this.largephoto
+                      largephotofilename = this.largephotofilename
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productproductphoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productproductphoto option =
+            match this.productid with
+            | Some value ->
+                let record: production.productproductphoto =
+                    { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productreview with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productreview option =
+            match this.productreviewid with
+            | Some value ->
+                let record: production.productreview =
+                    { productreviewid = value
+                      productid = this.productid.Value
+                      reviewername = this.reviewername.Value
+                      reviewdate = this.reviewdate.Value
+                      emailaddress = this.emailaddress.Value
+                      rating = this.rating.Value
+                      comments = this.comments
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productsubcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productsubcategory option =
+            match this.productsubcategoryid with
+            | Some value ->
+                let record: production.productsubcategory =
+                    { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.scrapreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.scrapreason option =
+            match this.scrapreasonid with
+            | Some value ->
+                let record: production.scrapreason =
+                    { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.transactionhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.transactionhistory option =
+            match this.transactionid with
+            | Some value ->
+                let record: production.transactionhistory =
+                    { transactionid = value
+                      productid = this.productid.Value
+                      referenceorderid = this.referenceorderid.Value
+                      referenceorderlineid = this.referenceorderlineid.Value
+                      transactiondate = this.transactiondate.Value
+                      transactiontype = this.transactiontype.Value
+                      quantity = this.quantity.Value
+                      actualcost = this.actualcost.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.transactionhistoryarchive with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.transactionhistoryarchive option =
+            match this.transactionid with
+            | Some value ->
+                let record: production.transactionhistoryarchive =
+                    { transactionid = value
+                      productid = this.productid.Value
+                      referenceorderid = this.referenceorderid.Value
+                      referenceorderlineid = this.referenceorderlineid.Value
+                      transactiondate = this.transactiondate.Value
+                      transactiontype = this.transactiontype.Value
+                      quantity = this.quantity.Value
+                      actualcost = this.actualcost.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.unitmeasure with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.unitmeasure option =
+            match this.unitmeasurecode with
+            | Some value ->
+                let record: production.unitmeasure =
+                    { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.workorder with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.workorder option =
+            match this.workorderid with
+            | Some value ->
+                let record: production.workorder =
+                    { workorderid = value
+                      productid = this.productid.Value
+                      orderqty = this.orderqty.Value
+                      scrappedqty = this.scrappedqty.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      duedate = this.duedate.Value
+                      scrapreasonid = this.scrapreasonid
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.workorderrouting with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.workorderrouting option =
+            match this.workorderid with
+            | Some value ->
+                let record: production.workorderrouting =
+                    { workorderid = value
+                      productid = this.productid.Value
+                      operationsequence = this.operationsequence.Value
+                      locationid = this.locationid.Value
+                      scheduledstartdate = this.scheduledstartdate.Value
+                      scheduledenddate = this.scheduledenddate.Value
+                      actualstartdate = this.actualstartdate
+                      actualenddate = this.actualenddate
+                      actualresourcehrs = this.actualresourcehrs
+                      plannedcost = this.plannedcost.Value
+                      actualcost = this.actualcost
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type pu.LeftJoined.v with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pu.v option =
+            match this.preferredvendorstatus with
+            | Some value ->
+                let record: pu.v =
+                    { id = this.id
+                      businessentityid = this.businessentityid
+                      accountnumber = this.accountnumber
+                      name = this.name
+                      creditrating = this.creditrating
+                      preferredvendorstatus = value
+                      activeflag = this.activeflag.Value
+                      purchasingwebserviceurl = this.purchasingwebserviceurl
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.productvendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.productvendor option =
+            match this.productid with
+            | Some value ->
+                let record: purchasing.productvendor =
+                    { productid = value
+                      businessentityid = this.businessentityid.Value
+                      averageleadtime = this.averageleadtime.Value
+                      standardprice = this.standardprice.Value
+                      lastreceiptcost = this.lastreceiptcost
+                      lastreceiptdate = this.lastreceiptdate
+                      minorderqty = this.minorderqty.Value
+                      maxorderqty = this.maxorderqty.Value
+                      onorderqty = this.onorderqty
+                      unitmeasurecode = this.unitmeasurecode.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.purchaseorderdetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.purchaseorderdetail option =
+            match this.purchaseorderid with
+            | Some value ->
+                let record: purchasing.purchaseorderdetail =
+                    { purchaseorderid = value
+                      purchaseorderdetailid = this.purchaseorderdetailid.Value
+                      duedate = this.duedate.Value
+                      orderqty = this.orderqty.Value
+                      productid = this.productid.Value
+                      unitprice = this.unitprice.Value
+                      receivedqty = this.receivedqty.Value
+                      rejectedqty = this.rejectedqty.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.purchaseorderheader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.purchaseorderheader option =
+            match this.purchaseorderid with
+            | Some value ->
+                let record: purchasing.purchaseorderheader =
+                    { purchaseorderid = value
+                      revisionnumber = this.revisionnumber.Value
+                      status = this.status.Value
+                      employeeid = this.employeeid.Value
+                      vendorid = this.vendorid.Value
+                      shipmethodid = this.shipmethodid.Value
+                      orderdate = this.orderdate.Value
+                      shipdate = this.shipdate
+                      subtotal = this.subtotal.Value
+                      taxamt = this.taxamt.Value
+                      freight = this.freight.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.shipmethod with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.shipmethod option =
+            match this.shipmethodid with
+            | Some value ->
+                let record: purchasing.shipmethod =
+                    { shipmethodid = value
+                      name = this.name.Value
+                      shipbase = this.shipbase.Value
+                      shiprate = this.shiprate.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.vendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.vendor option =
+            match this.businessentityid with
+            | Some value ->
+                let record: purchasing.vendor =
+                    { businessentityid = value
+                      accountnumber = this.accountnumber.Value
+                      name = this.name.Value
+                      creditrating = this.creditrating.Value
+                      preferredvendorstatus = this.preferredvendorstatus.Value
+                      activeflag = this.activeflag.Value
+                      purchasingwebserviceurl = this.purchasingwebserviceurl
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sa.LeftJoined.soh with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sa.soh option =
+            match this.onlineorderflag with
+            | Some value ->
+                let record: sa.soh =
+                    { id = this.id
+                      salesorderid = this.salesorderid
+                      revisionnumber = this.revisionnumber
+                      orderdate = this.orderdate
+                      duedate = this.duedate
+                      shipdate = this.shipdate
+                      status = this.status
+                      onlineorderflag = value
+                      purchaseordernumber = this.purchaseordernumber
+                      accountnumber = this.accountnumber
+                      customerid = this.customerid
+                      salespersonid = this.salespersonid
+                      territoryid = this.territoryid
+                      billtoaddressid = this.billtoaddressid
+                      shiptoaddressid = this.shiptoaddressid
+                      shipmethodid = this.shipmethodid
+                      creditcardid = this.creditcardid
+                      creditcardapprovalcode = this.creditcardapprovalcode
+                      currencyrateid = this.currencyrateid
+                      subtotal = this.subtotal
+                      taxamt = this.taxamt
+                      freight = this.freight
+                      totaldue = this.totaldue
+                      comment = this.comment
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.countryregioncurrency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.countryregioncurrency option =
+            match this.countryregioncode with
+            | Some value ->
+                let record: sales.countryregioncurrency =
+                    { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.creditcard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.creditcard option =
+            match this.creditcardid with
+            | Some value ->
+                let record: sales.creditcard =
+                    { creditcardid = value
+                      cardtype = this.cardtype.Value
+                      cardnumber = this.cardnumber.Value
+                      expmonth = this.expmonth.Value
+                      expyear = this.expyear.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.currency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.currency option =
+            match this.currencycode with
+            | Some value ->
+                let record: sales.currency =
+                    { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.currencyrate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.currencyrate option =
+            match this.currencyrateid with
+            | Some value ->
+                let record: sales.currencyrate =
+                    { currencyrateid = value
+                      currencyratedate = this.currencyratedate.Value
+                      fromcurrencycode = this.fromcurrencycode.Value
+                      tocurrencycode = this.tocurrencycode.Value
+                      averagerate = this.averagerate.Value
+                      endofdayrate = this.endofdayrate.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.customer option =
+            match this.customerid with
+            | Some value ->
+                let record: sales.customer =
+                    { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.personcreditcard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.personcreditcard option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.personcreditcard =
+                    { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderdetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderdetail option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderdetail =
+                    { salesorderid = value
+                      salesorderdetailid = this.salesorderdetailid.Value
+                      carriertrackingnumber = this.carriertrackingnumber
+                      orderqty = this.orderqty.Value
+                      productid = this.productid.Value
+                      specialofferid = this.specialofferid.Value
+                      unitprice = this.unitprice.Value
+                      unitpricediscount = this.unitpricediscount.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderheader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderheader option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderheader =
+                    { salesorderid = value
+                      revisionnumber = this.revisionnumber.Value
+                      orderdate = this.orderdate.Value
+                      duedate = this.duedate.Value
+                      shipdate = this.shipdate
+                      status = this.status.Value
+                      onlineorderflag = this.onlineorderflag.Value
+                      purchaseordernumber = this.purchaseordernumber
+                      accountnumber = this.accountnumber
+                      customerid = this.customerid.Value
+                      salespersonid = this.salespersonid
+                      territoryid = this.territoryid
+                      billtoaddressid = this.billtoaddressid.Value
+                      shiptoaddressid = this.shiptoaddressid.Value
+                      shipmethodid = this.shipmethodid.Value
+                      creditcardid = this.creditcardid
+                      creditcardapprovalcode = this.creditcardapprovalcode
+                      currencyrateid = this.currencyrateid
+                      subtotal = this.subtotal.Value
+                      taxamt = this.taxamt.Value
+                      freight = this.freight.Value
+                      totaldue = this.totaldue
+                      comment = this.comment
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderheadersalesreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderheadersalesreason option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderheadersalesreason =
+                    { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesperson with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesperson option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salesperson =
+                    { businessentityid = value
+                      territoryid = this.territoryid
+                      salesquota = this.salesquota
+                      bonus = this.bonus.Value
+                      commissionpct = this.commissionpct.Value
+                      salesytd = this.salesytd.Value
+                      saleslastyear = this.saleslastyear.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salespersonquotahistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salespersonquotahistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salespersonquotahistory =
+                    { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesreason option =
+            match this.salesreasonid with
+            | Some value ->
+                let record: sales.salesreason =
+                    { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salestaxrate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salestaxrate option =
+            match this.salestaxrateid with
+            | Some value ->
+                let record: sales.salestaxrate =
+                    { salestaxrateid = value
+                      stateprovinceid = this.stateprovinceid.Value
+                      taxtype = this.taxtype.Value
+                      taxrate = this.taxrate.Value
+                      name = this.name.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesterritory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesterritory option =
+            match this.territoryid with
+            | Some value ->
+                let record: sales.salesterritory =
+                    { territoryid = value
+                      name = this.name.Value
+                      countryregioncode = this.countryregioncode.Value
+                      group = this.group.Value
+                      salesytd = this.salesytd.Value
+                      saleslastyear = this.saleslastyear.Value
+                      costytd = this.costytd.Value
+                      costlastyear = this.costlastyear.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesterritoryhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesterritoryhistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salesterritoryhistory =
+                    { businessentityid = value
+                      territoryid = this.territoryid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.shoppingcartitem with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.shoppingcartitem option =
+            match this.shoppingcartitemid with
+            | Some value ->
+                let record: sales.shoppingcartitem =
+                    { shoppingcartitemid = value
+                      shoppingcartid = this.shoppingcartid.Value
+                      quantity = this.quantity.Value
+                      productid = this.productid.Value
+                      datecreated = this.datecreated.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.specialoffer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.specialoffer option =
+            match this.specialofferid with
+            | Some value ->
+                let record: sales.specialoffer =
+                    { specialofferid = value
+                      description = this.description.Value
+                      discountpct = this.discountpct.Value
+                      ``type`` = this.``type``.Value
+                      category = this.category.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate.Value
+                      minqty = this.minqty.Value
+                      maxqty = this.maxqty
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.specialofferproduct with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.specialofferproduct option =
+            match this.specialofferid with
+            | Some value ->
+                let record: sales.specialofferproduct =
+                    { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.store with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.store option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.store =
+                    { businessentityid = value
+                      name = this.name.Value
+                      salespersonid = this.salespersonid
+                      demographics = this.demographics
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Npgsql/AdventureWorksNet8.fs
+++ b/src/Tests/Npgsql/AdventureWorksNet8.fs
@@ -62,6 +62,85 @@ module ext =
 
     let person = table<person>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``arrays (base)`` = arrays
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type arrays =
+            { [<ProviderDbType("Text")>]
+              id: Option<string>
+              [<ProviderDbType("Text,Array")>]
+              text_array: Option<string[]>
+              [<ProviderDbType("Integer,Array")>]
+              integer_array: Option<int[]> }
+
+            interface ILeftViewOf<``arrays (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``arrays (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``arrays (base)`` =
+                        { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
+
+                    Some record
+                | None -> None
+
+        let arrays = leftTable<``arrays (base)``, arrays>
+
+        type private ``jsonsupport (base)`` = jsonsupport
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type jsonsupport =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Json")>]
+              json_field: Option<string>
+              [<ProviderDbType("Jsonb")>]
+              jsonb_field: Option<string> }
+
+            interface ILeftViewOf<``jsonsupport (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``jsonsupport (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``jsonsupport (base)`` =
+                        { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
+
+                    Some record
+                | None -> None
+
+        let jsonsupport = leftTable<``jsonsupport (base)``, jsonsupport>
+
+        type private ``person (base)`` = person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type person =
+            { [<ProviderDbType("Text")>]
+              name: Option<string>
+              currentmood: Option<mood> }
+
+            interface ILeftViewOf<``person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``person (base)`` option =
+                match this.name with
+                | Some value ->
+                    let record: ``person (base)`` =
+                        { name = value; currentmood = this.currentmood.Value }
+
+                    Some record
+                | None -> None
+
+        let person = leftTable<``person (base)``, person>
+
+
 module humanresources =
 
     [<CLIMutable>]
@@ -514,6 +593,445 @@ module humanresources =
 
     let vjobcandidateemployment = table<vjobcandidateemployment>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``department (base)`` = department
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type department =
+            { [<ProviderDbType("Integer")>]
+              departmentid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``department (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``department (base)`` option =
+                match this.departmentid with
+                | Some value ->
+                    let record: ``department (base)`` =
+                        { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let department = leftTable<``department (base)``, department>
+
+        type private ``employee (base)`` = employee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employee =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              nationalidnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              loginid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Date")>]
+              birthdate: Option<System.DateOnly>
+              [<ProviderDbType("Char")>]
+              maritalstatus: Option<string>
+              [<ProviderDbType("Char")>]
+              gender: Option<string>
+              [<ProviderDbType("Date")>]
+              hiredate: Option<System.DateOnly>
+              [<ProviderDbType("Boolean")>]
+              salariedflag: Option<bool>
+              [<ProviderDbType("Smallint")>]
+              vacationhours: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              sickleavehours: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              currentflag: Option<bool>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              organizationnode: Option<string> }
+
+            interface ILeftViewOf<``employee (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employee (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employee (base)`` =
+                        { businessentityid = value
+                          nationalidnumber = this.nationalidnumber.Value
+                          loginid = this.loginid.Value
+                          jobtitle = this.jobtitle.Value
+                          birthdate = this.birthdate.Value
+                          maritalstatus = this.maritalstatus.Value
+                          gender = this.gender.Value
+                          hiredate = this.hiredate.Value
+                          salariedflag = this.salariedflag.Value
+                          vacationhours = this.vacationhours.Value
+                          sickleavehours = this.sickleavehours.Value
+                          currentflag = this.currentflag.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value
+                          organizationnode = this.organizationnode }
+
+                    Some record
+                | None -> None
+
+        let employee = leftTable<``employee (base)``, employee>
+
+        type private ``employeedepartmenthistory (base)`` = employeedepartmenthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employeedepartmenthistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              departmentid: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              shiftid: Option<int16>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              enddate: Option<System.DateOnly>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``employeedepartmenthistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employeedepartmenthistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employeedepartmenthistory (base)`` =
+                        { businessentityid = value
+                          departmentid = this.departmentid.Value
+                          shiftid = this.shiftid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let employeedepartmenthistory =
+            leftTable<``employeedepartmenthistory (base)``, employeedepartmenthistory>
+
+        type private ``employeepayhistory (base)`` = employeepayhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employeepayhistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              ratechangedate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              rate: Option<decimal>
+              [<ProviderDbType("Smallint")>]
+              payfrequency: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``employeepayhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employeepayhistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employeepayhistory (base)`` =
+                        { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let employeepayhistory =
+            leftTable<``employeepayhistory (base)``, employeepayhistory>
+
+        type private ``jobcandidate (base)`` = jobcandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type jobcandidate =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Xml")>]
+              resume: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``jobcandidate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``jobcandidate (base)`` option =
+                match this.jobcandidateid with
+                | Some value ->
+                    let record: ``jobcandidate (base)`` =
+                        { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let jobcandidate = leftTable<``jobcandidate (base)``, jobcandidate>
+
+        type private ``shift (base)`` = shift
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shift =
+            { [<ProviderDbType("Integer")>]
+              shiftid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Time")>]
+              starttime: Option<System.TimeOnly>
+              [<ProviderDbType("Time")>]
+              endtime: Option<System.TimeOnly>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shift (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shift (base)`` option =
+                match this.shiftid with
+                | Some value ->
+                    let record: ``shift (base)`` =
+                        { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shift = leftTable<``shift (base)``, shift>
+
+        type private ``vemployee (base)`` = vemployee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployee =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string> }
+
+            interface ILeftViewOf<``vemployee (base)``>
+
+        let vemployee = leftTable<``vemployee (base)``, vemployee>
+
+        type private ``vemployeedepartment (base)`` = vemployeedepartment
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployeedepartment =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              department: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly> }
+
+            interface ILeftViewOf<``vemployeedepartment (base)``>
+
+        let vemployeedepartment =
+            leftTable<``vemployeedepartment (base)``, vemployeedepartment>
+
+        type private ``vemployeedepartmenthistory (base)`` = vemployeedepartmenthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployeedepartmenthistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              shift: Option<string>
+              [<ProviderDbType("Varchar")>]
+              department: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              enddate: Option<System.DateOnly> }
+
+            interface ILeftViewOf<``vemployeedepartmenthistory (base)``>
+
+        let vemployeedepartmenthistory =
+            leftTable<``vemployeedepartmenthistory (base)``, vemployeedepartmenthistory>
+
+        type private ``vjobcandidate (base)`` = vjobcandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidate =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Prefix``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.First``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Middle``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Last``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Suffix``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Skills: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.City``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.PostalCode``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              EMail: Option<string>
+              [<ProviderDbType("Varchar")>]
+              WebSite: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vjobcandidate (base)``>
+
+        let vjobcandidate = leftTable<``vjobcandidate (base)``, vjobcandidate>
+
+        type private ``vjobcandidateeducation (base)`` = vjobcandidateeducation
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidateeducation =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Level``: Option<string>
+              [<ProviderDbType("Date")>]
+              ``Edu.StartDate``: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              ``Edu.EndDate``: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Degree``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Major``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Minor``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.GPA``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.GPAScale``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.School``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.City``: Option<string> }
+
+            interface ILeftViewOf<``vjobcandidateeducation (base)``>
+
+        let vjobcandidateeducation =
+            leftTable<``vjobcandidateeducation (base)``, vjobcandidateeducation>
+
+        type private ``vjobcandidateemployment (base)`` = vjobcandidateemployment
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidateemployment =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Date")>]
+              ``Emp.StartDate``: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              ``Emp.EndDate``: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.OrgName``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.JobTitle``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Responsibility``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.FunctionCategory``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.IndustryCategory``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.City``: Option<string> }
+
+            interface ILeftViewOf<``vjobcandidateemployment (base)``>
+
+        let vjobcandidateemployment =
+            leftTable<``vjobcandidateemployment (base)``, vjobcandidateemployment>
+
+
 module network_sample =
 
     [<CLIMutable>]
@@ -538,6 +1056,40 @@ module network_sample =
                   { WriteColumn.Name = "net_macaddr8"; Value = box this.net_macaddr8; ProviderDbType = Some "MacAddr8" } ]
 
     let network_addresses = table<network_addresses>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``network_addresses (base)`` = network_addresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type network_addresses =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Cidr")>]
+              net_cidr: Option<System.Net.IPNetwork>
+              [<ProviderDbType("Inet")>]
+              net_inet: Option<System.Net.IPAddress>
+              [<ProviderDbType("MacAddr")>]
+              net_macaddr: Option<System.Net.NetworkInformation.PhysicalAddress>
+              [<ProviderDbType("MacAddr8")>]
+              net_macaddr8: Option<System.Net.NetworkInformation.PhysicalAddress> }
+
+            interface ILeftViewOf<``network_addresses (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``network_addresses (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``network_addresses (base)`` =
+                        { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
+
+                    Some record
+                | None -> None
+
+        let network_addresses = leftTable<``network_addresses (base)``, network_addresses>
+
 
 module pe =
 
@@ -890,6 +1442,334 @@ module pe =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let sp = table<sp>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``a (base)`` = a
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type a =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              spatiallocation: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``a (base)``>
+
+        let a = leftTable<``a (base)``, a>
+
+        type private ``at (base)`` = at
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type at =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``at (base)``>
+
+        let at = leftTable<``at (base)``, at>
+
+        type private ``be (base)`` = be
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type be =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``be (base)``>
+
+        let be = leftTable<``be (base)``, be>
+
+        type private ``bea (base)`` = bea
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bea =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bea (base)``>
+
+        let bea = leftTable<``bea (base)``, bea>
+
+        type private ``bec (base)`` = bec
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bec =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bec (base)``>
+
+        let bec = leftTable<``bec (base)``, bec>
+
+        type private ``cr (base)`` = cr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cr =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cr (base)``>
+
+        let cr = leftTable<``cr (base)``, cr>
+
+        type private ``ct (base)`` = ct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ct =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ct (base)``>
+
+        let ct = leftTable<``ct (base)``, ct>
+
+        type private ``e (base)`` = e
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type e =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              emailaddressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``e (base)``>
+
+        let e = leftTable<``e (base)``, e>
+
+        type private ``p (base)`` = p
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type p =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Char")>]
+              persontype: Option<string>
+              [<ProviderDbType("Boolean")>]
+              namestyle: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``p (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``p (base)`` option =
+                match this.namestyle with
+                | Some value ->
+                    let record: ``p (base)`` =
+                        { id = this.id
+                          businessentityid = this.businessentityid
+                          persontype = this.persontype
+                          namestyle = value
+                          title = this.title
+                          firstname = this.firstname
+                          middlename = this.middlename
+                          lastname = this.lastname
+                          suffix = this.suffix
+                          emailpromotion = this.emailpromotion
+                          additionalcontactinfo = this.additionalcontactinfo
+                          demographics = this.demographics
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let p = leftTable<``p (base)``, p>
+
+        type private ``pa (base)`` = pa
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pa =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              passwordhash: Option<string>
+              [<ProviderDbType("Varchar")>]
+              passwordsalt: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pa (base)``>
+
+        let pa = leftTable<``pa (base)``, pa>
+
+        type private ``pnt (base)`` = pnt
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pnt =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pnt (base)``>
+
+        let pnt = leftTable<``pnt (base)``, pnt>
+
+        type private ``pp (base)`` = pp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pp (base)``>
+
+        let pp = leftTable<``pp (base)``, pp>
+
+        type private ``sp (base)`` = sp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Char")>]
+              stateprovincecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Boolean")>]
+              isonlystateprovinceflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sp (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``sp (base)`` option =
+                match this.isonlystateprovinceflag with
+                | Some value ->
+                    let record: ``sp (base)`` =
+                        { id = this.id
+                          stateprovinceid = this.stateprovinceid
+                          stateprovincecode = this.stateprovincecode
+                          countryregioncode = this.countryregioncode
+                          isonlystateprovinceflag = value
+                          name = this.name
+                          territoryid = this.territoryid
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let sp = leftTable<``sp (base)``, sp>
+
 
 module person =
 
@@ -1288,6 +2168,507 @@ module person =
                   { WriteColumn.Name = "countryregionname"; Value = box this.countryregionname; ProviderDbType = Some "Name" } ]
 
     let vstateprovincecountryregion = table<vstateprovincecountryregion>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``address (base)`` = address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type address =
+            { [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              spatiallocation: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``address (base)`` option =
+                match this.addressid with
+                | Some value ->
+                    let record: ``address (base)`` =
+                        { addressid = value
+                          addressline1 = this.addressline1.Value
+                          addressline2 = this.addressline2
+                          city = this.city.Value
+                          stateprovinceid = this.stateprovinceid.Value
+                          postalcode = this.postalcode.Value
+                          spatiallocation = this.spatiallocation
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let address = leftTable<``address (base)``, address>
+
+        type private ``addresstype (base)`` = addresstype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type addresstype =
+            { [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``addresstype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``addresstype (base)`` option =
+                match this.addresstypeid with
+                | Some value ->
+                    let record: ``addresstype (base)`` =
+                        { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let addresstype = leftTable<``addresstype (base)``, addresstype>
+
+        type private ``businessentity (base)`` = businessentity
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentity =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentity (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentity (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentity (base)`` =
+                        { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentity = leftTable<``businessentity (base)``, businessentity>
+
+        type private ``businessentityaddress (base)`` = businessentityaddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentityaddress =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentityaddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentityaddress (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentityaddress (base)`` =
+                        { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentityaddress =
+            leftTable<``businessentityaddress (base)``, businessentityaddress>
+
+        type private ``businessentitycontact (base)`` = businessentitycontact
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentitycontact =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentitycontact (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentitycontact (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentitycontact (base)`` =
+                        { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentitycontact =
+            leftTable<``businessentitycontact (base)``, businessentitycontact>
+
+        type private ``contacttype (base)`` = contacttype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type contacttype =
+            { [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``contacttype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``contacttype (base)`` option =
+                match this.contacttypeid with
+                | Some value ->
+                    let record: ``contacttype (base)`` =
+                        { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let contacttype = leftTable<``contacttype (base)``, contacttype>
+
+        type private ``countryregion (base)`` = countryregion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type countryregion =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``countryregion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``countryregion (base)`` option =
+                match this.countryregioncode with
+                | Some value ->
+                    let record: ``countryregion (base)`` =
+                        { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let countryregion = leftTable<``countryregion (base)``, countryregion>
+
+        type private ``emailaddress (base)`` = emailaddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type emailaddress =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              emailaddressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``emailaddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``emailaddress (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``emailaddress (base)`` =
+                        { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let emailaddress = leftTable<``emailaddress (base)``, emailaddress>
+
+        type private ``password (base)`` = password
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type password =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              passwordhash: Option<string>
+              [<ProviderDbType("Varchar")>]
+              passwordsalt: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``password (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``password (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``password (base)`` =
+                        { businessentityid = value
+                          passwordhash = this.passwordhash.Value
+                          passwordsalt = this.passwordsalt.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let password = leftTable<``password (base)``, password>
+
+        type private ``person (base)`` = person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type person =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Char")>]
+              persontype: Option<string>
+              [<ProviderDbType("Boolean")>]
+              namestyle: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``person (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``person (base)`` =
+                        { businessentityid = value
+                          persontype = this.persontype.Value
+                          namestyle = this.namestyle.Value
+                          title = this.title
+                          firstname = this.firstname.Value
+                          middlename = this.middlename
+                          lastname = this.lastname.Value
+                          suffix = this.suffix
+                          emailpromotion = this.emailpromotion.Value
+                          additionalcontactinfo = this.additionalcontactinfo
+                          demographics = this.demographics
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let person = leftTable<``person (base)``, person>
+
+        type private ``personphone (base)`` = personphone
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type personphone =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``personphone (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``personphone (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``personphone (base)`` =
+                        { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let personphone = leftTable<``personphone (base)``, personphone>
+
+        type private ``phonenumbertype (base)`` = phonenumbertype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type phonenumbertype =
+            { [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``phonenumbertype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``phonenumbertype (base)`` option =
+                match this.phonenumbertypeid with
+                | Some value ->
+                    let record: ``phonenumbertype (base)`` =
+                        { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let phonenumbertype = leftTable<``phonenumbertype (base)``, phonenumbertype>
+
+        type private ``stateprovince (base)`` = stateprovince
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type stateprovince =
+            { [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Char")>]
+              stateprovincecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Boolean")>]
+              isonlystateprovinceflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``stateprovince (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``stateprovince (base)`` option =
+                match this.stateprovinceid with
+                | Some value ->
+                    let record: ``stateprovince (base)`` =
+                        { stateprovinceid = value
+                          stateprovincecode = this.stateprovincecode.Value
+                          countryregioncode = this.countryregioncode.Value
+                          isonlystateprovinceflag = this.isonlystateprovinceflag.Value
+                          name = this.name.Value
+                          territoryid = this.territoryid.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let stateprovince = leftTable<``stateprovince (base)``, stateprovince>
+
+        type private ``vadditionalcontactinfo (base)`` = vadditionalcontactinfo
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vadditionalcontactinfo =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Xml")>]
+              telephonenumber: Option<string>
+              [<ProviderDbType("Text")>]
+              telephonespecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              street: Option<string>
+              [<ProviderDbType("Xml")>]
+              city: Option<string>
+              [<ProviderDbType("Xml")>]
+              stateprovince: Option<string>
+              [<ProviderDbType("Xml")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Xml")>]
+              countryregion: Option<string>
+              [<ProviderDbType("Xml")>]
+              homeaddressspecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Text")>]
+              emailspecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              emailtelephonenumber: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vadditionalcontactinfo (base)``>
+
+        let vadditionalcontactinfo =
+            leftTable<``vadditionalcontactinfo (base)``, vadditionalcontactinfo>
+
+        type private ``vstateprovincecountryregion (base)`` = vstateprovincecountryregion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstateprovincecountryregion =
+            { [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Name")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Name")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vstateprovincecountryregion (base)``>
+
+        let vstateprovincecountryregion =
+            leftTable<``vstateprovincecountryregion (base)``, vstateprovincecountryregion>
+
 
 module pr =
 
@@ -2054,6 +3435,681 @@ module pr =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let wr = table<wr>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``bom (base)`` = bom
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bom =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              billofmaterialsid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productassemblyid: Option<int>
+              [<ProviderDbType("Integer")>]
+              componentid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bomlevel: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              perassemblyqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bom (base)``>
+
+        let bom = leftTable<``bom (base)``, bom>
+
+        type private ``c (base)`` = c
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type c =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``c (base)``>
+
+        let c = leftTable<``c (base)``, c>
+
+        type private ``d (base)`` = d
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type d =
+            { [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Integer")>]
+              owner: Option<int>
+              [<ProviderDbType("Boolean")>]
+              folderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              filename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              fileextension: Option<string>
+              [<ProviderDbType("Char")>]
+              revision: Option<string>
+              [<ProviderDbType("Integer")>]
+              changenumber: Option<int>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Text")>]
+              documentsummary: Option<string>
+              [<ProviderDbType("Bytea")>]
+              document: Option<byte[]>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``d (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``d (base)`` option =
+                match this.folderflag with
+                | Some value ->
+                    let record: ``d (base)`` =
+                        { title = this.title
+                          owner = this.owner
+                          folderflag = value
+                          filename = this.filename
+                          fileextension = this.fileextension
+                          revision = this.revision
+                          changenumber = this.changenumber
+                          status = this.status
+                          documentsummary = this.documentsummary
+                          document = this.document
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate
+                          documentnode = this.documentnode }
+
+                    Some record
+                | None -> None
+
+        let d = leftTable<``d (base)``, d>
+
+        type private ``i (base)`` = i
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type i =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Xml")>]
+              diagram: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``i (base)``>
+
+        let i = leftTable<``i (base)``, i>
+
+        type private ``l (base)`` = l
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type l =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              locationid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              costrate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              availability: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``l (base)``>
+
+        let l = leftTable<``l (base)``, l>
+
+        type private ``p (base)`` = p
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type p =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productnumber: Option<string>
+              [<ProviderDbType("Boolean")>]
+              makeflag: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              finishedgoodsflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Smallint")>]
+              safetystocklevel: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              reorderpoint: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              size: Option<string>
+              [<ProviderDbType("Char")>]
+              sizeunitmeasurecode: Option<string>
+              [<ProviderDbType("Char")>]
+              weightunitmeasurecode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              weight: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              daystomanufacture: Option<int>
+              [<ProviderDbType("Char")>]
+              productline: Option<string>
+              [<ProviderDbType("Char")>]
+              ``class``: Option<string>
+              [<ProviderDbType("Char")>]
+              style: Option<string>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              sellstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              sellenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              discontinueddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``p (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``p (base)`` option =
+                match this.makeflag with
+                | Some value ->
+                    let record: ``p (base)`` =
+                        { id = this.id
+                          productid = this.productid
+                          name = this.name
+                          productnumber = this.productnumber
+                          makeflag = value
+                          finishedgoodsflag = this.finishedgoodsflag.Value
+                          color = this.color
+                          safetystocklevel = this.safetystocklevel
+                          reorderpoint = this.reorderpoint
+                          standardcost = this.standardcost
+                          listprice = this.listprice
+                          size = this.size
+                          sizeunitmeasurecode = this.sizeunitmeasurecode
+                          weightunitmeasurecode = this.weightunitmeasurecode
+                          weight = this.weight
+                          daystomanufacture = this.daystomanufacture
+                          productline = this.productline
+                          ``class`` = this.``class``
+                          style = this.style
+                          productsubcategoryid = this.productsubcategoryid
+                          productmodelid = this.productmodelid
+                          sellstartdate = this.sellstartdate
+                          sellenddate = this.sellenddate
+                          discontinueddate = this.discontinueddate
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let p = leftTable<``p (base)``, p>
+
+        type private ``pc (base)`` = pc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pc (base)``>
+
+        let pc = leftTable<``pc (base)``, pc>
+
+        type private ``pch (base)`` = pch
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pch =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pch (base)``>
+
+        let pch = leftTable<``pch (base)``, pch>
+
+        type private ``pd (base)`` = pd
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pd =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pd (base)``>
+
+        let pd = leftTable<``pd (base)``, pd>
+
+        type private ``pdoc (base)`` = pdoc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pdoc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``pdoc (base)``>
+
+        let pdoc = leftTable<``pdoc (base)``, pdoc>
+
+        type private ``pi (base)`` = pi
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pi =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Varchar")>]
+              shelf: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bin: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              quantity: Option<int16>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pi (base)``>
+
+        let pi = leftTable<``pi (base)``, pi>
+
+        type private ``plph (base)`` = plph
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type plph =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``plph (base)``>
+
+        let plph = leftTable<``plph (base)``, plph>
+
+        type private ``pm (base)`` = pm
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pm =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Xml")>]
+              catalogdescription: Option<string>
+              [<ProviderDbType("Xml")>]
+              instructions: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pm (base)``>
+
+        let pm = leftTable<``pm (base)``, pm>
+
+        type private ``pmi (base)`` = pmi
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pmi =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pmi (base)``>
+
+        let pmi = leftTable<``pmi (base)``, pmi>
+
+        type private ``pmpdc (base)`` = pmpdc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pmpdc =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pmpdc (base)``>
+
+        let pmpdc = leftTable<``pmpdc (base)``, pmpdc>
+
+        type private ``pp (base)`` = pp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Bytea")>]
+              thumbnailphoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              thumbnailphotofilename: Option<string>
+              [<ProviderDbType("Bytea")>]
+              largephoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              largephotofilename: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pp (base)``>
+
+        let pp = leftTable<``pp (base)``, pp>
+
+        type private ``ppp (base)`` = ppp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ppp =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Boolean")>]
+              primary: Option<bool>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ppp (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ppp (base)`` option =
+                match this.primary with
+                | Some value ->
+                    let record: ``ppp (base)`` =
+                        { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let ppp = leftTable<``ppp (base)``, ppp>
+
+        type private ``pr (base)`` = pr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productreviewid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              reviewername: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              reviewdate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              rating: Option<int>
+              [<ProviderDbType("Varchar")>]
+              comments: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pr (base)``>
+
+        let pr = leftTable<``pr (base)``, pr>
+
+        type private ``psc (base)`` = psc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type psc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``psc (base)``>
+
+        let psc = leftTable<``psc (base)``, psc>
+
+        type private ``sr (base)`` = sr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              scrapreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sr (base)``>
+
+        let sr = leftTable<``sr (base)``, sr>
+
+        type private ``th (base)`` = th
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type th =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``th (base)``>
+
+        let th = leftTable<``th (base)``, th>
+
+        type private ``tha (base)`` = tha
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type tha =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``tha (base)``>
+
+        let tha = leftTable<``tha (base)``, tha>
+
+        type private ``um (base)`` = um
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type um =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``um (base)``>
+
+        let um = leftTable<``um (base)``, um>
+
+        type private ``w (base)`` = w
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type w =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              orderqty: Option<int>
+              [<ProviderDbType("Smallint")>]
+              scrappedqty: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              scrapreasonid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``w (base)``>
+
+        let w = leftTable<``w (base)``, w>
+
+        type private ``wr (base)`` = wr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type wr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              operationsequence: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              scheduledstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              scheduledenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualenddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              actualresourcehrs: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              plannedcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``wr (base)``>
+
+        let wr = leftTable<``wr (base)``, wr>
+
 
 module production =
 
@@ -2903,6 +4959,1065 @@ module production =
 
     let workorderrouting = table<workorderrouting>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``billofmaterials (base)`` = billofmaterials
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type billofmaterials =
+            { [<ProviderDbType("Integer")>]
+              billofmaterialsid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productassemblyid: Option<int>
+              [<ProviderDbType("Integer")>]
+              componentid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bomlevel: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              perassemblyqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``billofmaterials (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``billofmaterials (base)`` option =
+                match this.billofmaterialsid with
+                | Some value ->
+                    let record: ``billofmaterials (base)`` =
+                        { billofmaterialsid = value
+                          productassemblyid = this.productassemblyid
+                          componentid = this.componentid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          unitmeasurecode = this.unitmeasurecode.Value
+                          bomlevel = this.bomlevel.Value
+                          perassemblyqty = this.perassemblyqty.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let billofmaterials = leftTable<``billofmaterials (base)``, billofmaterials>
+
+        type private ``culture (base)`` = culture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type culture =
+            { [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``culture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``culture (base)`` option =
+                match this.cultureid with
+                | Some value ->
+                    let record: ``culture (base)`` =
+                        { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let culture = leftTable<``culture (base)``, culture>
+
+        type private ``document (base)`` = document
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type document =
+            { [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Integer")>]
+              owner: Option<int>
+              [<ProviderDbType("Boolean")>]
+              folderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              filename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              fileextension: Option<string>
+              [<ProviderDbType("Char")>]
+              revision: Option<string>
+              [<ProviderDbType("Integer")>]
+              changenumber: Option<int>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Text")>]
+              documentsummary: Option<string>
+              [<ProviderDbType("Bytea")>]
+              document: Option<byte[]>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``document (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``document (base)`` option =
+                match this.documentnode with
+                | Some value ->
+                    let record: ``document (base)`` =
+                        { title = this.title.Value
+                          owner = this.owner.Value
+                          folderflag = this.folderflag.Value
+                          filename = this.filename.Value
+                          fileextension = this.fileextension
+                          revision = this.revision.Value
+                          changenumber = this.changenumber.Value
+                          status = this.status.Value
+                          documentsummary = this.documentsummary
+                          document = this.document
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value
+                          documentnode = value }
+
+                    Some record
+                | None -> None
+
+        let document = leftTable<``document (base)``, document>
+
+        type private ``illustration (base)`` = illustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type illustration =
+            { [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Xml")>]
+              diagram: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``illustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``illustration (base)`` option =
+                match this.illustrationid with
+                | Some value ->
+                    let record: ``illustration (base)`` =
+                        { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let illustration = leftTable<``illustration (base)``, illustration>
+
+        type private ``location (base)`` = location
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type location =
+            { [<ProviderDbType("Integer")>]
+              locationid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              costrate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              availability: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``location (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``location (base)`` option =
+                match this.locationid with
+                | Some value ->
+                    let record: ``location (base)`` =
+                        { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let location = leftTable<``location (base)``, location>
+
+        type private ``product (base)`` = product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type product =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productnumber: Option<string>
+              [<ProviderDbType("Boolean")>]
+              makeflag: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              finishedgoodsflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Smallint")>]
+              safetystocklevel: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              reorderpoint: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              size: Option<string>
+              [<ProviderDbType("Char")>]
+              sizeunitmeasurecode: Option<string>
+              [<ProviderDbType("Char")>]
+              weightunitmeasurecode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              weight: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              daystomanufacture: Option<int>
+              [<ProviderDbType("Char")>]
+              productline: Option<string>
+              [<ProviderDbType("Char")>]
+              ``class``: Option<string>
+              [<ProviderDbType("Char")>]
+              style: Option<string>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              sellstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              sellenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              discontinueddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``product (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``product (base)`` =
+                        { productid = value
+                          name = this.name.Value
+                          productnumber = this.productnumber.Value
+                          makeflag = this.makeflag.Value
+                          finishedgoodsflag = this.finishedgoodsflag.Value
+                          color = this.color
+                          safetystocklevel = this.safetystocklevel.Value
+                          reorderpoint = this.reorderpoint.Value
+                          standardcost = this.standardcost.Value
+                          listprice = this.listprice.Value
+                          size = this.size
+                          sizeunitmeasurecode = this.sizeunitmeasurecode
+                          weightunitmeasurecode = this.weightunitmeasurecode
+                          weight = this.weight
+                          daystomanufacture = this.daystomanufacture.Value
+                          productline = this.productline
+                          ``class`` = this.``class``
+                          style = this.style
+                          productsubcategoryid = this.productsubcategoryid
+                          productmodelid = this.productmodelid
+                          sellstartdate = this.sellstartdate.Value
+                          sellenddate = this.sellenddate
+                          discontinueddate = this.discontinueddate
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let product = leftTable<``product (base)``, product>
+
+        type private ``productcategory (base)`` = productcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productcategory =
+            { [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productcategory (base)`` option =
+                match this.productcategoryid with
+                | Some value ->
+                    let record: ``productcategory (base)`` =
+                        { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productcategory = leftTable<``productcategory (base)``, productcategory>
+
+        type private ``productcosthistory (base)`` = productcosthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productcosthistory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productcosthistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productcosthistory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productcosthistory (base)`` =
+                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productcosthistory =
+            leftTable<``productcosthistory (base)``, productcosthistory>
+
+        type private ``productdescription (base)`` = productdescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productdescription =
+            { [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productdescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productdescription (base)`` option =
+                match this.productdescriptionid with
+                | Some value ->
+                    let record: ``productdescription (base)`` =
+                        { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productdescription =
+            leftTable<``productdescription (base)``, productdescription>
+
+        type private ``productdocument (base)`` = productdocument
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productdocument =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``productdocument (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productdocument (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productdocument (base)`` =
+                        { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
+
+                    Some record
+                | None -> None
+
+        let productdocument = leftTable<``productdocument (base)``, productdocument>
+
+        type private ``productinventory (base)`` = productinventory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productinventory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Varchar")>]
+              shelf: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bin: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              quantity: Option<int16>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productinventory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productinventory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productinventory (base)`` =
+                        { productid = value
+                          locationid = this.locationid.Value
+                          shelf = this.shelf.Value
+                          bin = this.bin.Value
+                          quantity = this.quantity.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productinventory = leftTable<``productinventory (base)``, productinventory>
+
+        type private ``productlistpricehistory (base)`` = productlistpricehistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productlistpricehistory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productlistpricehistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productlistpricehistory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productlistpricehistory (base)`` =
+                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productlistpricehistory =
+            leftTable<``productlistpricehistory (base)``, productlistpricehistory>
+
+        type private ``productmodel (base)`` = productmodel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodel =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Xml")>]
+              catalogdescription: Option<string>
+              [<ProviderDbType("Xml")>]
+              instructions: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodel (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodel (base)`` =
+                        { productmodelid = value
+                          name = this.name.Value
+                          catalogdescription = this.catalogdescription
+                          instructions = this.instructions
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodel = leftTable<``productmodel (base)``, productmodel>
+
+        type private ``productmodelillustration (base)`` = productmodelillustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodelillustration =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodelillustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodelillustration (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodelillustration (base)`` =
+                        { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodelillustration =
+            leftTable<``productmodelillustration (base)``, productmodelillustration>
+
+        type private ``productmodelproductdescriptionculture (base)`` = productmodelproductdescriptionculture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodelproductdescriptionculture =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodelproductdescriptionculture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodelproductdescriptionculture (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodelproductdescriptionculture (base)`` =
+                        { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodelproductdescriptionculture =
+            leftTable<``productmodelproductdescriptionculture (base)``, productmodelproductdescriptionculture>
+
+        type private ``productphoto (base)`` = productphoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productphoto =
+            { [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Bytea")>]
+              thumbnailphoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              thumbnailphotofilename: Option<string>
+              [<ProviderDbType("Bytea")>]
+              largephoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              largephotofilename: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productphoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productphoto (base)`` option =
+                match this.productphotoid with
+                | Some value ->
+                    let record: ``productphoto (base)`` =
+                        { productphotoid = value
+                          thumbnailphoto = this.thumbnailphoto
+                          thumbnailphotofilename = this.thumbnailphotofilename
+                          largephoto = this.largephoto
+                          largephotofilename = this.largephotofilename
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productphoto = leftTable<``productphoto (base)``, productphoto>
+
+        type private ``productproductphoto (base)`` = productproductphoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productproductphoto =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Boolean")>]
+              primary: Option<bool>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productproductphoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productproductphoto (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productproductphoto (base)`` =
+                        { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productproductphoto =
+            leftTable<``productproductphoto (base)``, productproductphoto>
+
+        type private ``productreview (base)`` = productreview
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productreview =
+            { [<ProviderDbType("Integer")>]
+              productreviewid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              reviewername: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              reviewdate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              rating: Option<int>
+              [<ProviderDbType("Varchar")>]
+              comments: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productreview (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productreview (base)`` option =
+                match this.productreviewid with
+                | Some value ->
+                    let record: ``productreview (base)`` =
+                        { productreviewid = value
+                          productid = this.productid.Value
+                          reviewername = this.reviewername.Value
+                          reviewdate = this.reviewdate.Value
+                          emailaddress = this.emailaddress.Value
+                          rating = this.rating.Value
+                          comments = this.comments
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productreview = leftTable<``productreview (base)``, productreview>
+
+        type private ``productsubcategory (base)`` = productsubcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productsubcategory =
+            { [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productsubcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productsubcategory (base)`` option =
+                match this.productsubcategoryid with
+                | Some value ->
+                    let record: ``productsubcategory (base)`` =
+                        { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productsubcategory =
+            leftTable<``productsubcategory (base)``, productsubcategory>
+
+        type private ``scrapreason (base)`` = scrapreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type scrapreason =
+            { [<ProviderDbType("Integer")>]
+              scrapreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``scrapreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``scrapreason (base)`` option =
+                match this.scrapreasonid with
+                | Some value ->
+                    let record: ``scrapreason (base)`` =
+                        { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let scrapreason = leftTable<``scrapreason (base)``, scrapreason>
+
+        type private ``transactionhistory (base)`` = transactionhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type transactionhistory =
+            { [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``transactionhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``transactionhistory (base)`` option =
+                match this.transactionid with
+                | Some value ->
+                    let record: ``transactionhistory (base)`` =
+                        { transactionid = value
+                          productid = this.productid.Value
+                          referenceorderid = this.referenceorderid.Value
+                          referenceorderlineid = this.referenceorderlineid.Value
+                          transactiondate = this.transactiondate.Value
+                          transactiontype = this.transactiontype.Value
+                          quantity = this.quantity.Value
+                          actualcost = this.actualcost.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let transactionhistory =
+            leftTable<``transactionhistory (base)``, transactionhistory>
+
+        type private ``transactionhistoryarchive (base)`` = transactionhistoryarchive
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type transactionhistoryarchive =
+            { [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``transactionhistoryarchive (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``transactionhistoryarchive (base)`` option =
+                match this.transactionid with
+                | Some value ->
+                    let record: ``transactionhistoryarchive (base)`` =
+                        { transactionid = value
+                          productid = this.productid.Value
+                          referenceorderid = this.referenceorderid.Value
+                          referenceorderlineid = this.referenceorderlineid.Value
+                          transactiondate = this.transactiondate.Value
+                          transactiontype = this.transactiontype.Value
+                          quantity = this.quantity.Value
+                          actualcost = this.actualcost.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let transactionhistoryarchive =
+            leftTable<``transactionhistoryarchive (base)``, transactionhistoryarchive>
+
+        type private ``unitmeasure (base)`` = unitmeasure
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type unitmeasure =
+            { [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``unitmeasure (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``unitmeasure (base)`` option =
+                match this.unitmeasurecode with
+                | Some value ->
+                    let record: ``unitmeasure (base)`` =
+                        { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let unitmeasure = leftTable<``unitmeasure (base)``, unitmeasure>
+
+        type private ``vproductanddescription (base)`` = vproductanddescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductanddescription =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Name")>]
+              name: Option<string>
+              [<ProviderDbType("Name")>]
+              productmodel: Option<string>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string> }
+
+            interface ILeftViewOf<``vproductanddescription (base)``>
+
+        let vproductanddescription =
+            leftTable<``vproductanddescription (base)``, vproductanddescription>
+
+        type private ``vproductmodelcatalogdescription (base)`` = vproductmodelcatalogdescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductmodelcatalogdescription =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Summary: Option<string>
+              [<ProviderDbType("Varchar")>]
+              manufacturer: Option<string>
+              [<ProviderDbType("Varchar")>]
+              copyright: Option<string>
+              [<ProviderDbType("Varchar")>]
+              producturl: Option<string>
+              [<ProviderDbType("Varchar")>]
+              warrantyperiod: Option<string>
+              [<ProviderDbType("Varchar")>]
+              warrantydescription: Option<string>
+              [<ProviderDbType("Varchar")>]
+              noofyears: Option<string>
+              [<ProviderDbType("Varchar")>]
+              maintenancedescription: Option<string>
+              [<ProviderDbType("Varchar")>]
+              wheel: Option<string>
+              [<ProviderDbType("Varchar")>]
+              saddle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              pedal: Option<string>
+              [<ProviderDbType("Varchar")>]
+              bikeframe: Option<string>
+              [<ProviderDbType("Varchar")>]
+              crankset: Option<string>
+              [<ProviderDbType("Varchar")>]
+              pictureangle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              picturesize: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productphotoid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              material: Option<string>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productline: Option<string>
+              [<ProviderDbType("Varchar")>]
+              style: Option<string>
+              [<ProviderDbType("Varchar")>]
+              riderexperience: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vproductmodelcatalogdescription (base)``>
+
+        let vproductmodelcatalogdescription =
+            leftTable<``vproductmodelcatalogdescription (base)``, vproductmodelcatalogdescription>
+
+        type private ``vproductmodelinstructions (base)`` = vproductmodelinstructions
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductmodelinstructions =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              instructions: Option<string>
+              [<ProviderDbType("Integer")>]
+              LocationID: Option<int>
+              [<ProviderDbType("Numeric")>]
+              SetupHours: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              MachineHours: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              LaborHours: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              LotSize: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Step: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vproductmodelinstructions (base)``>
+
+        let vproductmodelinstructions =
+            leftTable<``vproductmodelinstructions (base)``, vproductmodelinstructions>
+
+        type private ``workorder (base)`` = workorder
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type workorder =
+            { [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              orderqty: Option<int>
+              [<ProviderDbType("Smallint")>]
+              scrappedqty: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              scrapreasonid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``workorder (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``workorder (base)`` option =
+                match this.workorderid with
+                | Some value ->
+                    let record: ``workorder (base)`` =
+                        { workorderid = value
+                          productid = this.productid.Value
+                          orderqty = this.orderqty.Value
+                          scrappedqty = this.scrappedqty.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          duedate = this.duedate.Value
+                          scrapreasonid = this.scrapreasonid
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let workorder = leftTable<``workorder (base)``, workorder>
+
+        type private ``workorderrouting (base)`` = workorderrouting
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type workorderrouting =
+            { [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              operationsequence: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              scheduledstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              scheduledenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualenddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              actualresourcehrs: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              plannedcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``workorderrouting (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``workorderrouting (base)`` option =
+                match this.workorderid with
+                | Some value ->
+                    let record: ``workorderrouting (base)`` =
+                        { workorderid = value
+                          productid = this.productid.Value
+                          operationsequence = this.operationsequence.Value
+                          locationid = this.locationid.Value
+                          scheduledstartdate = this.scheduledstartdate.Value
+                          scheduledenddate = this.scheduledenddate.Value
+                          actualstartdate = this.actualstartdate
+                          actualenddate = this.actualenddate
+                          actualresourcehrs = this.actualresourcehrs
+                          plannedcost = this.plannedcost.Value
+                          actualcost = this.actualcost
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let workorderrouting = leftTable<``workorderrouting (base)``, workorderrouting>
+
+
 module pu =
 
     [<CLIMutable>]
@@ -3097,6 +6212,176 @@ module pu =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let v = table<v>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``pod (base)`` = pod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pod =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderdetailid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              receivedqty: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              rejectedqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pod (base)``>
+
+        let pod = leftTable<``pod (base)``, pod>
+
+        type private ``poh (base)`` = poh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type poh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Integer")>]
+              employeeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              vendorid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``poh (base)``>
+
+        let poh = leftTable<``poh (base)``, poh>
+
+        type private ``pv (base)`` = pv
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pv =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              averageleadtime: Option<int>
+              [<ProviderDbType("Numeric")>]
+              standardprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              lastreceiptcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              lastreceiptdate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              onorderqty: Option<int>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pv (base)``>
+
+        let pv = leftTable<``pv (base)``, pv>
+
+        type private ``sm (base)`` = sm
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sm =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              shipbase: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              shiprate: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sm (base)``>
+
+        let sm = leftTable<``sm (base)``, sm>
+
+        type private ``v (base)`` = v
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type v =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Smallint")>]
+              creditrating: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              preferredvendorstatus: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              activeflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchasingwebserviceurl: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``v (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``v (base)`` option =
+                match this.preferredvendorstatus with
+                | Some value ->
+                    let record: ``v (base)`` =
+                        { id = this.id
+                          businessentityid = this.businessentityid
+                          accountnumber = this.accountnumber
+                          name = this.name
+                          creditrating = this.creditrating
+                          preferredvendorstatus = value
+                          activeflag = this.activeflag.Value
+                          purchasingwebserviceurl = this.purchasingwebserviceurl
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let v = leftTable<``v (base)``, v>
+
 
 module purchasing =
 
@@ -3356,6 +6641,307 @@ module purchasing =
                   { WriteColumn.Name = "emailpromotion"; Value = box this.emailpromotion; ProviderDbType = Some "Integer" } ]
 
     let vvendorwithcontacts = table<vvendorwithcontacts>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``productvendor (base)`` = productvendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productvendor =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              averageleadtime: Option<int>
+              [<ProviderDbType("Numeric")>]
+              standardprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              lastreceiptcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              lastreceiptdate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              onorderqty: Option<int>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productvendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productvendor (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productvendor (base)`` =
+                        { productid = value
+                          businessentityid = this.businessentityid.Value
+                          averageleadtime = this.averageleadtime.Value
+                          standardprice = this.standardprice.Value
+                          lastreceiptcost = this.lastreceiptcost
+                          lastreceiptdate = this.lastreceiptdate
+                          minorderqty = this.minorderqty.Value
+                          maxorderqty = this.maxorderqty.Value
+                          onorderqty = this.onorderqty
+                          unitmeasurecode = this.unitmeasurecode.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productvendor = leftTable<``productvendor (base)``, productvendor>
+
+        type private ``purchaseorderdetail (base)`` = purchaseorderdetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type purchaseorderdetail =
+            { [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderdetailid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              receivedqty: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              rejectedqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``purchaseorderdetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``purchaseorderdetail (base)`` option =
+                match this.purchaseorderid with
+                | Some value ->
+                    let record: ``purchaseorderdetail (base)`` =
+                        { purchaseorderid = value
+                          purchaseorderdetailid = this.purchaseorderdetailid.Value
+                          duedate = this.duedate.Value
+                          orderqty = this.orderqty.Value
+                          productid = this.productid.Value
+                          unitprice = this.unitprice.Value
+                          receivedqty = this.receivedqty.Value
+                          rejectedqty = this.rejectedqty.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let purchaseorderdetail =
+            leftTable<``purchaseorderdetail (base)``, purchaseorderdetail>
+
+        type private ``purchaseorderheader (base)`` = purchaseorderheader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type purchaseorderheader =
+            { [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Integer")>]
+              employeeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              vendorid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``purchaseorderheader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``purchaseorderheader (base)`` option =
+                match this.purchaseorderid with
+                | Some value ->
+                    let record: ``purchaseorderheader (base)`` =
+                        { purchaseorderid = value
+                          revisionnumber = this.revisionnumber.Value
+                          status = this.status.Value
+                          employeeid = this.employeeid.Value
+                          vendorid = this.vendorid.Value
+                          shipmethodid = this.shipmethodid.Value
+                          orderdate = this.orderdate.Value
+                          shipdate = this.shipdate
+                          subtotal = this.subtotal.Value
+                          taxamt = this.taxamt.Value
+                          freight = this.freight.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let purchaseorderheader =
+            leftTable<``purchaseorderheader (base)``, purchaseorderheader>
+
+        type private ``shipmethod (base)`` = shipmethod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shipmethod =
+            { [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              shipbase: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              shiprate: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shipmethod (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shipmethod (base)`` option =
+                match this.shipmethodid with
+                | Some value ->
+                    let record: ``shipmethod (base)`` =
+                        { shipmethodid = value
+                          name = this.name.Value
+                          shipbase = this.shipbase.Value
+                          shiprate = this.shiprate.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shipmethod = leftTable<``shipmethod (base)``, shipmethod>
+
+        type private ``vendor (base)`` = vendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vendor =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Smallint")>]
+              creditrating: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              preferredvendorstatus: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              activeflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchasingwebserviceurl: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``vendor (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``vendor (base)`` =
+                        { businessentityid = value
+                          accountnumber = this.accountnumber.Value
+                          name = this.name.Value
+                          creditrating = this.creditrating.Value
+                          preferredvendorstatus = this.preferredvendorstatus.Value
+                          activeflag = this.activeflag.Value
+                          purchasingwebserviceurl = this.purchasingwebserviceurl
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let vendor = leftTable<``vendor (base)``, vendor>
+
+        type private ``vvendorwithaddresses (base)`` = vvendorwithaddresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vvendorwithaddresses =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vvendorwithaddresses (base)``>
+
+        let vvendorwithaddresses =
+            leftTable<``vvendorwithaddresses (base)``, vvendorwithaddresses>
+
+        type private ``vvendorwithcontacts (base)`` = vvendorwithcontacts
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vvendorwithcontacts =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              contacttype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int> }
+
+            interface ILeftViewOf<``vvendorwithcontacts (base)``>
+
+        let vvendorwithcontacts =
+            leftTable<``vvendorwithcontacts (base)``, vvendorwithcontacts>
+
 
 module sa =
 
@@ -3960,6 +7546,517 @@ module sa =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let tr = table<tr>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``c (base)`` = c
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type c =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              storeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``c (base)``>
+
+        let c = leftTable<``c (base)``, c>
+
+        type private ``cc (base)`` = cc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              cardtype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              cardnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              expmonth: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              expyear: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cc (base)``>
+
+        let cc = leftTable<``cc (base)``, cc>
+
+        type private ``cr (base)`` = cr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cr =
+            { [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              currencyratedate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              fromcurrencycode: Option<string>
+              [<ProviderDbType("Char")>]
+              tocurrencycode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              averagerate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              endofdayrate: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cr (base)``>
+
+        let cr = leftTable<``cr (base)``, cr>
+
+        type private ``crc (base)`` = crc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type crc =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``crc (base)``>
+
+        let crc = leftTable<``crc (base)``, crc>
+
+        type private ``cu (base)`` = cu
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cu =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cu (base)``>
+
+        let cu = leftTable<``cu (base)``, cu>
+
+        type private ``pcc (base)`` = pcc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pcc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pcc (base)``>
+
+        let pcc = leftTable<``pcc (base)``, pcc>
+
+        type private ``s (base)`` = s
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type s =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``s (base)``>
+
+        let s = leftTable<``s (base)``, s>
+
+        type private ``sci (base)`` = sci
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sci =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              shoppingcartitemid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              shoppingcartid: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              datecreated: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sci (base)``>
+
+        let sci = leftTable<``sci (base)``, sci>
+
+        type private ``so (base)`` = so
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type so =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Numeric")>]
+              discountpct: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              ``type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              category: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxqty: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``so (base)``>
+
+        let so = leftTable<``so (base)``, so>
+
+        type private ``sod (base)`` = sod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sod =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderdetailid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              carriertrackingnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              unitpricediscount: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sod (base)``>
+
+        let sod = leftTable<``sod (base)``, sod>
+
+        type private ``soh (base)`` = soh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type soh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              onlineorderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchaseordernumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              billtoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shiptoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              creditcardapprovalcode: Option<string>
+              [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              totaldue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              comment: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``soh (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``soh (base)`` option =
+                match this.onlineorderflag with
+                | Some value ->
+                    let record: ``soh (base)`` =
+                        { id = this.id
+                          salesorderid = this.salesorderid
+                          revisionnumber = this.revisionnumber
+                          orderdate = this.orderdate
+                          duedate = this.duedate
+                          shipdate = this.shipdate
+                          status = this.status
+                          onlineorderflag = value
+                          purchaseordernumber = this.purchaseordernumber
+                          accountnumber = this.accountnumber
+                          customerid = this.customerid
+                          salespersonid = this.salespersonid
+                          territoryid = this.territoryid
+                          billtoaddressid = this.billtoaddressid
+                          shiptoaddressid = this.shiptoaddressid
+                          shipmethodid = this.shipmethodid
+                          creditcardid = this.creditcardid
+                          creditcardapprovalcode = this.creditcardapprovalcode
+                          currencyrateid = this.currencyrateid
+                          subtotal = this.subtotal
+                          taxamt = this.taxamt
+                          freight = this.freight
+                          totaldue = this.totaldue
+                          comment = this.comment
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let soh = leftTable<``soh (base)``, soh>
+
+        type private ``sohsr (base)`` = sohsr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sohsr =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sohsr (base)``>
+
+        let sohsr = leftTable<``sohsr (base)``, sohsr>
+
+        type private ``sop (base)`` = sop
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sop =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sop (base)``>
+
+        let sop = leftTable<``sop (base)``, sop>
+
+        type private ``sp (base)`` = sp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              bonus: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              commissionpct: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sp (base)``>
+
+        let sp = leftTable<``sp (base)``, sp>
+
+        type private ``spqh (base)`` = spqh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type spqh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              quotadate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``spqh (base)``>
+
+        let spqh = leftTable<``spqh (base)``, spqh>
+
+        type private ``sr (base)`` = sr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              reasontype: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sr (base)``>
+
+        let sr = leftTable<``sr (base)``, sr>
+
+        type private ``st (base)`` = st
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type st =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              group: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costlastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``st (base)``>
+
+        let st = leftTable<``st (base)``, st>
+
+        type private ``sth (base)`` = sth
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sth =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sth (base)``>
+
+        let sth = leftTable<``sth (base)``, sth>
+
+        type private ``tr (base)`` = tr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type tr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salestaxrateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              taxtype: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              taxrate: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``tr (base)``>
+
+        let tr = leftTable<``tr (base)``, tr>
+
 
 module sales =
 
@@ -4877,6 +8974,1032 @@ module sales =
                   { WriteColumn.Name = "NumberEmployees"; Value = box this.NumberEmployees; ProviderDbType = Some "Integer" } ]
 
     let vstorewithdemographics = table<vstorewithdemographics>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``countryregioncurrency (base)`` = countryregioncurrency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type countryregioncurrency =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``countryregioncurrency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``countryregioncurrency (base)`` option =
+                match this.countryregioncode with
+                | Some value ->
+                    let record: ``countryregioncurrency (base)`` =
+                        { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let countryregioncurrency =
+            leftTable<``countryregioncurrency (base)``, countryregioncurrency>
+
+        type private ``creditcard (base)`` = creditcard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type creditcard =
+            { [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              cardtype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              cardnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              expmonth: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              expyear: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``creditcard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``creditcard (base)`` option =
+                match this.creditcardid with
+                | Some value ->
+                    let record: ``creditcard (base)`` =
+                        { creditcardid = value
+                          cardtype = this.cardtype.Value
+                          cardnumber = this.cardnumber.Value
+                          expmonth = this.expmonth.Value
+                          expyear = this.expyear.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let creditcard = leftTable<``creditcard (base)``, creditcard>
+
+        type private ``currency (base)`` = currency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type currency =
+            { [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``currency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``currency (base)`` option =
+                match this.currencycode with
+                | Some value ->
+                    let record: ``currency (base)`` =
+                        { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let currency = leftTable<``currency (base)``, currency>
+
+        type private ``currencyrate (base)`` = currencyrate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type currencyrate =
+            { [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              currencyratedate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              fromcurrencycode: Option<string>
+              [<ProviderDbType("Char")>]
+              tocurrencycode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              averagerate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              endofdayrate: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``currencyrate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``currencyrate (base)`` option =
+                match this.currencyrateid with
+                | Some value ->
+                    let record: ``currencyrate (base)`` =
+                        { currencyrateid = value
+                          currencyratedate = this.currencyratedate.Value
+                          fromcurrencycode = this.fromcurrencycode.Value
+                          tocurrencycode = this.tocurrencycode.Value
+                          averagerate = this.averagerate.Value
+                          endofdayrate = this.endofdayrate.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let currencyrate = leftTable<``currencyrate (base)``, currencyrate>
+
+        type private ``customer (base)`` = customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type customer =
+            { [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              storeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``customer (base)`` option =
+                match this.customerid with
+                | Some value ->
+                    let record: ``customer (base)`` =
+                        { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let customer = leftTable<``customer (base)``, customer>
+
+        type private ``personcreditcard (base)`` = personcreditcard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type personcreditcard =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``personcreditcard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``personcreditcard (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``personcreditcard (base)`` =
+                        { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let personcreditcard = leftTable<``personcreditcard (base)``, personcreditcard>
+
+        type private ``salesorderdetail (base)`` = salesorderdetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderdetail =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderdetailid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              carriertrackingnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              unitpricediscount: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderdetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderdetail (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderdetail (base)`` =
+                        { salesorderid = value
+                          salesorderdetailid = this.salesorderdetailid.Value
+                          carriertrackingnumber = this.carriertrackingnumber
+                          orderqty = this.orderqty.Value
+                          productid = this.productid.Value
+                          specialofferid = this.specialofferid.Value
+                          unitprice = this.unitprice.Value
+                          unitpricediscount = this.unitpricediscount.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderdetail = leftTable<``salesorderdetail (base)``, salesorderdetail>
+
+        type private ``salesorderheader (base)`` = salesorderheader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderheader =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              onlineorderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchaseordernumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              billtoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shiptoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              creditcardapprovalcode: Option<string>
+              [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              totaldue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              comment: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderheader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderheader (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderheader (base)`` =
+                        { salesorderid = value
+                          revisionnumber = this.revisionnumber.Value
+                          orderdate = this.orderdate.Value
+                          duedate = this.duedate.Value
+                          shipdate = this.shipdate
+                          status = this.status.Value
+                          onlineorderflag = this.onlineorderflag.Value
+                          purchaseordernumber = this.purchaseordernumber
+                          accountnumber = this.accountnumber
+                          customerid = this.customerid.Value
+                          salespersonid = this.salespersonid
+                          territoryid = this.territoryid
+                          billtoaddressid = this.billtoaddressid.Value
+                          shiptoaddressid = this.shiptoaddressid.Value
+                          shipmethodid = this.shipmethodid.Value
+                          creditcardid = this.creditcardid
+                          creditcardapprovalcode = this.creditcardapprovalcode
+                          currencyrateid = this.currencyrateid
+                          subtotal = this.subtotal.Value
+                          taxamt = this.taxamt.Value
+                          freight = this.freight.Value
+                          totaldue = this.totaldue
+                          comment = this.comment
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderheader = leftTable<``salesorderheader (base)``, salesorderheader>
+
+        type private ``salesorderheadersalesreason (base)`` = salesorderheadersalesreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderheadersalesreason =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderheadersalesreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderheadersalesreason (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderheadersalesreason (base)`` =
+                        { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderheadersalesreason =
+            leftTable<``salesorderheadersalesreason (base)``, salesorderheadersalesreason>
+
+        type private ``salesperson (base)`` = salesperson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesperson =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              bonus: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              commissionpct: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesperson (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesperson (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salesperson (base)`` =
+                        { businessentityid = value
+                          territoryid = this.territoryid
+                          salesquota = this.salesquota
+                          bonus = this.bonus.Value
+                          commissionpct = this.commissionpct.Value
+                          salesytd = this.salesytd.Value
+                          saleslastyear = this.saleslastyear.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesperson = leftTable<``salesperson (base)``, salesperson>
+
+        type private ``salespersonquotahistory (base)`` = salespersonquotahistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salespersonquotahistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              quotadate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salespersonquotahistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salespersonquotahistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salespersonquotahistory (base)`` =
+                        { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salespersonquotahistory =
+            leftTable<``salespersonquotahistory (base)``, salespersonquotahistory>
+
+        type private ``salesreason (base)`` = salesreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesreason =
+            { [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              reasontype: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesreason (base)`` option =
+                match this.salesreasonid with
+                | Some value ->
+                    let record: ``salesreason (base)`` =
+                        { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesreason = leftTable<``salesreason (base)``, salesreason>
+
+        type private ``salestaxrate (base)`` = salestaxrate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salestaxrate =
+            { [<ProviderDbType("Integer")>]
+              salestaxrateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              taxtype: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              taxrate: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salestaxrate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salestaxrate (base)`` option =
+                match this.salestaxrateid with
+                | Some value ->
+                    let record: ``salestaxrate (base)`` =
+                        { salestaxrateid = value
+                          stateprovinceid = this.stateprovinceid.Value
+                          taxtype = this.taxtype.Value
+                          taxrate = this.taxrate.Value
+                          name = this.name.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salestaxrate = leftTable<``salestaxrate (base)``, salestaxrate>
+
+        type private ``salesterritory (base)`` = salesterritory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesterritory =
+            { [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              group: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costlastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesterritory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesterritory (base)`` option =
+                match this.territoryid with
+                | Some value ->
+                    let record: ``salesterritory (base)`` =
+                        { territoryid = value
+                          name = this.name.Value
+                          countryregioncode = this.countryregioncode.Value
+                          group = this.group.Value
+                          salesytd = this.salesytd.Value
+                          saleslastyear = this.saleslastyear.Value
+                          costytd = this.costytd.Value
+                          costlastyear = this.costlastyear.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesterritory = leftTable<``salesterritory (base)``, salesterritory>
+
+        type private ``salesterritoryhistory (base)`` = salesterritoryhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesterritoryhistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesterritoryhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesterritoryhistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salesterritoryhistory (base)`` =
+                        { businessentityid = value
+                          territoryid = this.territoryid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesterritoryhistory =
+            leftTable<``salesterritoryhistory (base)``, salesterritoryhistory>
+
+        type private ``shoppingcartitem (base)`` = shoppingcartitem
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shoppingcartitem =
+            { [<ProviderDbType("Integer")>]
+              shoppingcartitemid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              shoppingcartid: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              datecreated: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shoppingcartitem (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shoppingcartitem (base)`` option =
+                match this.shoppingcartitemid with
+                | Some value ->
+                    let record: ``shoppingcartitem (base)`` =
+                        { shoppingcartitemid = value
+                          shoppingcartid = this.shoppingcartid.Value
+                          quantity = this.quantity.Value
+                          productid = this.productid.Value
+                          datecreated = this.datecreated.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shoppingcartitem = leftTable<``shoppingcartitem (base)``, shoppingcartitem>
+
+        type private ``specialoffer (base)`` = specialoffer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type specialoffer =
+            { [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Numeric")>]
+              discountpct: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              ``type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              category: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxqty: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``specialoffer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``specialoffer (base)`` option =
+                match this.specialofferid with
+                | Some value ->
+                    let record: ``specialoffer (base)`` =
+                        { specialofferid = value
+                          description = this.description.Value
+                          discountpct = this.discountpct.Value
+                          ``type`` = this.``type``.Value
+                          category = this.category.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate.Value
+                          minqty = this.minqty.Value
+                          maxqty = this.maxqty
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let specialoffer = leftTable<``specialoffer (base)``, specialoffer>
+
+        type private ``specialofferproduct (base)`` = specialofferproduct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type specialofferproduct =
+            { [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``specialofferproduct (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``specialofferproduct (base)`` option =
+                match this.specialofferid with
+                | Some value ->
+                    let record: ``specialofferproduct (base)`` =
+                        { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let specialofferproduct =
+            leftTable<``specialofferproduct (base)``, specialofferproduct>
+
+        type private ``store (base)`` = store
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type store =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``store (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``store (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``store (base)`` =
+                        { businessentityid = value
+                          name = this.name.Value
+                          salespersonid = this.salespersonid
+                          demographics = this.demographics
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let store = leftTable<``store (base)``, store>
+
+        type private ``vindividualcustomer (base)`` = vindividualcustomer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vindividualcustomer =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string> }
+
+            interface ILeftViewOf<``vindividualcustomer (base)``>
+
+        let vindividualcustomer =
+            leftTable<``vindividualcustomer (base)``, vindividualcustomer>
+
+        type private ``vpersondemographics (base)`` = vpersondemographics
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vpersondemographics =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Money")>]
+              totalpurchaseytd: Option<decimal>
+              [<ProviderDbType("Date")>]
+              datefirstpurchase: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              birthdate: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              maritalstatus: Option<string>
+              [<ProviderDbType("Varchar")>]
+              yearlyincome: Option<string>
+              [<ProviderDbType("Varchar")>]
+              gender: Option<string>
+              [<ProviderDbType("Integer")>]
+              totalchildren: Option<int>
+              [<ProviderDbType("Integer")>]
+              numberchildrenathome: Option<int>
+              [<ProviderDbType("Varchar")>]
+              education: Option<string>
+              [<ProviderDbType("Varchar")>]
+              occupation: Option<string>
+              [<ProviderDbType("Boolean")>]
+              homeownerflag: Option<bool>
+              [<ProviderDbType("Integer")>]
+              numbercarsowned: Option<int> }
+
+            interface ILeftViewOf<``vpersondemographics (base)``>
+
+        let vpersondemographics =
+            leftTable<``vpersondemographics (base)``, vpersondemographics>
+
+        type private ``vsalesperson (base)`` = vsalesperson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalesperson =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              territoryname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              territorygroup: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal> }
+
+            interface ILeftViewOf<``vsalesperson (base)``>
+
+        let vsalesperson = leftTable<``vsalesperson (base)``, vsalesperson>
+
+        type private ``vsalespersonsalesbyfiscalyears (base)`` = vsalespersonsalesbyfiscalyears
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalespersonsalesbyfiscalyears =
+            { [<ProviderDbType("Integer")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("Text")>]
+              FullName: Option<string>
+              [<ProviderDbType("Text")>]
+              JobTitle: Option<string>
+              [<ProviderDbType("Text")>]
+              SalesTerritory: Option<string>
+              [<ProviderDbType("Numeric")>]
+              ``2012``: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              ``2013``: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              ``2014``: Option<decimal> }
+
+            interface ILeftViewOf<``vsalespersonsalesbyfiscalyears (base)``>
+
+        let vsalespersonsalesbyfiscalyears =
+            leftTable<``vsalespersonsalesbyfiscalyears (base)``, vsalespersonsalesbyfiscalyears>
+
+        type private ``vsalespersonsalesbyfiscalyearsdata (base)`` = vsalespersonsalesbyfiscalyearsdata
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalespersonsalesbyfiscalyearsdata =
+            { [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Text")>]
+              fullname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              salesterritory: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salestotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              fiscalyear: Option<decimal> }
+
+            interface ILeftViewOf<``vsalespersonsalesbyfiscalyearsdata (base)``>
+
+        let vsalespersonsalesbyfiscalyearsdata =
+            leftTable<``vsalespersonsalesbyfiscalyearsdata (base)``, vsalespersonsalesbyfiscalyearsdata>
+
+        type private ``vstorewithaddresses (base)`` = vstorewithaddresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithaddresses =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vstorewithaddresses (base)``>
+
+        let vstorewithaddresses =
+            leftTable<``vstorewithaddresses (base)``, vstorewithaddresses>
+
+        type private ``vstorewithcontacts (base)`` = vstorewithcontacts
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithcontacts =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              contacttype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int> }
+
+            interface ILeftViewOf<``vstorewithcontacts (base)``>
+
+        let vstorewithcontacts =
+            leftTable<``vstorewithcontacts (base)``, vstorewithcontacts>
+
+        type private ``vstorewithdemographics (base)`` = vstorewithdemographics
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithdemographics =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Money")>]
+              AnnualSales: Option<decimal>
+              [<ProviderDbType("Money")>]
+              AnnualRevenue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              BankName: Option<string>
+              [<ProviderDbType("Varchar")>]
+              BusinessType: Option<string>
+              [<ProviderDbType("Integer")>]
+              YearOpened: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Specialty: Option<string>
+              [<ProviderDbType("Integer")>]
+              SquareFeet: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Brands: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Internet: Option<string>
+              [<ProviderDbType("Integer")>]
+              NumberEmployees: Option<int> }
+
+            interface ILeftViewOf<``vstorewithdemographics (base)``>
+
+        let vstorewithdemographics =
+            leftTable<``vstorewithdemographics (base)``, vstorewithdemographics>
+
 
 
 [<RequireQualifiedAccess>]

--- a/src/Tests/Npgsql/AdventureWorksNet8.fs
+++ b/src/Tests/Npgsql/AdventureWorksNet8.fs
@@ -78,17 +78,6 @@ module ext =
 
             interface ILeftViewOf<``arrays (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``arrays (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``arrays (base)`` =
-                        { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
-
-                    Some record
-                | None -> None
-
         let arrays = leftTable<``arrays (base)``, arrays>
 
         type private ``jsonsupport (base)`` = jsonsupport
@@ -104,17 +93,6 @@ module ext =
 
             interface ILeftViewOf<``jsonsupport (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``jsonsupport (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``jsonsupport (base)`` =
-                        { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
-
-                    Some record
-                | None -> None
-
         let jsonsupport = leftTable<``jsonsupport (base)``, jsonsupport>
 
         type private ``person (base)`` = person
@@ -126,17 +104,6 @@ module ext =
               currentmood: Option<mood> }
 
             interface ILeftViewOf<``person (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``person (base)`` option =
-                match this.name with
-                | Some value ->
-                    let record: ``person (base)`` =
-                        { name = value; currentmood = this.currentmood.Value }
-
-                    Some record
-                | None -> None
 
         let person = leftTable<``person (base)``, person>
 
@@ -611,17 +578,6 @@ module humanresources =
 
             interface ILeftViewOf<``department (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``department (base)`` option =
-                match this.departmentid with
-                | Some value ->
-                    let record: ``department (base)`` =
-                        { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let department = leftTable<``department (base)``, department>
 
         type private ``employee (base)`` = employee
@@ -661,31 +617,6 @@ module humanresources =
 
             interface ILeftViewOf<``employee (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employee (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employee (base)`` =
-                        { businessentityid = value
-                          nationalidnumber = this.nationalidnumber.Value
-                          loginid = this.loginid.Value
-                          jobtitle = this.jobtitle.Value
-                          birthdate = this.birthdate.Value
-                          maritalstatus = this.maritalstatus.Value
-                          gender = this.gender.Value
-                          hiredate = this.hiredate.Value
-                          salariedflag = this.salariedflag.Value
-                          vacationhours = this.vacationhours.Value
-                          sickleavehours = this.sickleavehours.Value
-                          currentflag = this.currentflag.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value
-                          organizationnode = this.organizationnode }
-
-                    Some record
-                | None -> None
-
         let employee = leftTable<``employee (base)``, employee>
 
         type private ``employeedepartmenthistory (base)`` = employeedepartmenthistory
@@ -707,22 +638,6 @@ module humanresources =
 
             interface ILeftViewOf<``employeedepartmenthistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employeedepartmenthistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employeedepartmenthistory (base)`` =
-                        { businessentityid = value
-                          departmentid = this.departmentid.Value
-                          shiftid = this.shiftid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let employeedepartmenthistory =
             leftTable<``employeedepartmenthistory (base)``, employeedepartmenthistory>
 
@@ -743,17 +658,6 @@ module humanresources =
 
             interface ILeftViewOf<``employeepayhistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employeepayhistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employeepayhistory (base)`` =
-                        { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let employeepayhistory =
             leftTable<``employeepayhistory (base)``, employeepayhistory>
 
@@ -771,17 +675,6 @@ module humanresources =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``jobcandidate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``jobcandidate (base)`` option =
-                match this.jobcandidateid with
-                | Some value ->
-                    let record: ``jobcandidate (base)`` =
-                        { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let jobcandidate = leftTable<``jobcandidate (base)``, jobcandidate>
 
@@ -801,17 +694,6 @@ module humanresources =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shift (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shift (base)`` option =
-                match this.shiftid with
-                | Some value ->
-                    let record: ``shift (base)`` =
-                        { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shift = leftTable<``shift (base)``, shift>
 
@@ -1076,17 +958,6 @@ module network_sample =
               net_macaddr8: Option<System.Net.NetworkInformation.PhysicalAddress> }
 
             interface ILeftViewOf<``network_addresses (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``network_addresses (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``network_addresses (base)`` =
-                        { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
-
-                    Some record
-                | None -> None
 
         let network_addresses = leftTable<``network_addresses (base)``, network_addresses>
 
@@ -1641,30 +1512,6 @@ module pe =
 
             interface ILeftViewOf<``p (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``p (base)`` option =
-                match this.namestyle with
-                | Some value ->
-                    let record: ``p (base)`` =
-                        { id = this.id
-                          businessentityid = this.businessentityid
-                          persontype = this.persontype
-                          namestyle = value
-                          title = this.title
-                          firstname = this.firstname
-                          middlename = this.middlename
-                          lastname = this.lastname
-                          suffix = this.suffix
-                          emailpromotion = this.emailpromotion
-                          additionalcontactinfo = this.additionalcontactinfo
-                          demographics = this.demographics
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
-
         let p = leftTable<``p (base)``, p>
 
         type private ``pa (base)`` = pa
@@ -1748,25 +1595,6 @@ module pe =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``sp (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``sp (base)`` option =
-                match this.isonlystateprovinceflag with
-                | Some value ->
-                    let record: ``sp (base)`` =
-                        { id = this.id
-                          stateprovinceid = this.stateprovinceid
-                          stateprovincecode = this.stateprovincecode
-                          countryregioncode = this.countryregioncode
-                          isonlystateprovinceflag = value
-                          name = this.name
-                          territoryid = this.territoryid
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let sp = leftTable<``sp (base)``, sp>
 
@@ -2197,25 +2025,6 @@ module person =
 
             interface ILeftViewOf<``address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``address (base)`` option =
-                match this.addressid with
-                | Some value ->
-                    let record: ``address (base)`` =
-                        { addressid = value
-                          addressline1 = this.addressline1.Value
-                          addressline2 = this.addressline2
-                          city = this.city.Value
-                          stateprovinceid = this.stateprovinceid.Value
-                          postalcode = this.postalcode.Value
-                          spatiallocation = this.spatiallocation
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let address = leftTable<``address (base)``, address>
 
         type private ``addresstype (base)`` = addresstype
@@ -2233,17 +2042,6 @@ module person =
 
             interface ILeftViewOf<``addresstype (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``addresstype (base)`` option =
-                match this.addresstypeid with
-                | Some value ->
-                    let record: ``addresstype (base)`` =
-                        { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let addresstype = leftTable<``addresstype (base)``, addresstype>
 
         type private ``businessentity (base)`` = businessentity
@@ -2258,17 +2056,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``businessentity (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentity (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentity (base)`` =
-                        { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let businessentity = leftTable<``businessentity (base)``, businessentity>
 
@@ -2288,17 +2075,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``businessentityaddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentityaddress (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentityaddress (base)`` =
-                        { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let businessentityaddress =
             leftTable<``businessentityaddress (base)``, businessentityaddress>
@@ -2320,17 +2096,6 @@ module person =
 
             interface ILeftViewOf<``businessentitycontact (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentitycontact (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentitycontact (base)`` =
-                        { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let businessentitycontact =
             leftTable<``businessentitycontact (base)``, businessentitycontact>
 
@@ -2347,17 +2112,6 @@ module person =
 
             interface ILeftViewOf<``contacttype (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``contacttype (base)`` option =
-                match this.contacttypeid with
-                | Some value ->
-                    let record: ``contacttype (base)`` =
-                        { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let contacttype = leftTable<``contacttype (base)``, contacttype>
 
         type private ``countryregion (base)`` = countryregion
@@ -2372,17 +2126,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``countryregion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``countryregion (base)`` option =
-                match this.countryregioncode with
-                | Some value ->
-                    let record: ``countryregion (base)`` =
-                        { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let countryregion = leftTable<``countryregion (base)``, countryregion>
 
@@ -2403,17 +2146,6 @@ module person =
 
             interface ILeftViewOf<``emailaddress (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``emailaddress (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``emailaddress (base)`` =
-                        { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let emailaddress = leftTable<``emailaddress (base)``, emailaddress>
 
         type private ``password (base)`` = password
@@ -2432,21 +2164,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``password (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``password (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``password (base)`` =
-                        { businessentityid = value
-                          passwordhash = this.passwordhash.Value
-                          passwordsalt = this.passwordsalt.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let password = leftTable<``password (base)``, password>
 
@@ -2483,29 +2200,6 @@ module person =
 
             interface ILeftViewOf<``person (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``person (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``person (base)`` =
-                        { businessentityid = value
-                          persontype = this.persontype.Value
-                          namestyle = this.namestyle.Value
-                          title = this.title
-                          firstname = this.firstname.Value
-                          middlename = this.middlename
-                          lastname = this.lastname.Value
-                          suffix = this.suffix
-                          emailpromotion = this.emailpromotion.Value
-                          additionalcontactinfo = this.additionalcontactinfo
-                          demographics = this.demographics
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let person = leftTable<``person (base)``, person>
 
         type private ``personphone (base)`` = personphone
@@ -2523,17 +2217,6 @@ module person =
 
             interface ILeftViewOf<``personphone (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``personphone (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``personphone (base)`` =
-                        { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let personphone = leftTable<``personphone (base)``, personphone>
 
         type private ``phonenumbertype (base)`` = phonenumbertype
@@ -2548,17 +2231,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``phonenumbertype (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``phonenumbertype (base)`` option =
-                match this.phonenumbertypeid with
-                | Some value ->
-                    let record: ``phonenumbertype (base)`` =
-                        { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let phonenumbertype = leftTable<``phonenumbertype (base)``, phonenumbertype>
 
@@ -2584,24 +2256,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``stateprovince (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``stateprovince (base)`` option =
-                match this.stateprovinceid with
-                | Some value ->
-                    let record: ``stateprovince (base)`` =
-                        { stateprovinceid = value
-                          stateprovincecode = this.stateprovincecode.Value
-                          countryregioncode = this.countryregioncode.Value
-                          isonlystateprovinceflag = this.isonlystateprovinceflag.Value
-                          name = this.name.Value
-                          territoryid = this.territoryid.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let stateprovince = leftTable<``stateprovince (base)``, stateprovince>
 
@@ -3518,29 +3172,6 @@ module pr =
 
             interface ILeftViewOf<``d (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``d (base)`` option =
-                match this.folderflag with
-                | Some value ->
-                    let record: ``d (base)`` =
-                        { title = this.title
-                          owner = this.owner
-                          folderflag = value
-                          filename = this.filename
-                          fileextension = this.fileextension
-                          revision = this.revision
-                          changenumber = this.changenumber
-                          status = this.status
-                          documentsummary = this.documentsummary
-                          document = this.document
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate
-                          documentnode = this.documentnode }
-
-                    Some record
-                | None -> None
-
         let d = leftTable<``d (base)``, d>
 
         type private ``i (base)`` = i
@@ -3639,42 +3270,6 @@ module pr =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``p (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``p (base)`` option =
-                match this.makeflag with
-                | Some value ->
-                    let record: ``p (base)`` =
-                        { id = this.id
-                          productid = this.productid
-                          name = this.name
-                          productnumber = this.productnumber
-                          makeflag = value
-                          finishedgoodsflag = this.finishedgoodsflag.Value
-                          color = this.color
-                          safetystocklevel = this.safetystocklevel
-                          reorderpoint = this.reorderpoint
-                          standardcost = this.standardcost
-                          listprice = this.listprice
-                          size = this.size
-                          sizeunitmeasurecode = this.sizeunitmeasurecode
-                          weightunitmeasurecode = this.weightunitmeasurecode
-                          weight = this.weight
-                          daystomanufacture = this.daystomanufacture
-                          productline = this.productline
-                          ``class`` = this.``class``
-                          style = this.style
-                          productsubcategoryid = this.productsubcategoryid
-                          productmodelid = this.productmodelid
-                          sellstartdate = this.sellstartdate
-                          sellenddate = this.sellenddate
-                          discontinueddate = this.discontinueddate
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let p = leftTable<``p (base)``, p>
 
@@ -3892,17 +3487,6 @@ module pr =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ppp (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ppp (base)`` option =
-                match this.primary with
-                | Some value ->
-                    let record: ``ppp (base)`` =
-                        { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let ppp = leftTable<``ppp (base)``, ppp>
 
@@ -4987,25 +4571,6 @@ module production =
 
             interface ILeftViewOf<``billofmaterials (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``billofmaterials (base)`` option =
-                match this.billofmaterialsid with
-                | Some value ->
-                    let record: ``billofmaterials (base)`` =
-                        { billofmaterialsid = value
-                          productassemblyid = this.productassemblyid
-                          componentid = this.componentid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          unitmeasurecode = this.unitmeasurecode.Value
-                          bomlevel = this.bomlevel.Value
-                          perassemblyqty = this.perassemblyqty.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let billofmaterials = leftTable<``billofmaterials (base)``, billofmaterials>
 
         type private ``culture (base)`` = culture
@@ -5020,17 +4585,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``culture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``culture (base)`` option =
-                match this.cultureid with
-                | Some value ->
-                    let record: ``culture (base)`` =
-                        { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let culture = leftTable<``culture (base)``, culture>
 
@@ -5067,29 +4621,6 @@ module production =
 
             interface ILeftViewOf<``document (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``document (base)`` option =
-                match this.documentnode with
-                | Some value ->
-                    let record: ``document (base)`` =
-                        { title = this.title.Value
-                          owner = this.owner.Value
-                          folderflag = this.folderflag.Value
-                          filename = this.filename.Value
-                          fileextension = this.fileextension
-                          revision = this.revision.Value
-                          changenumber = this.changenumber.Value
-                          status = this.status.Value
-                          documentsummary = this.documentsummary
-                          document = this.document
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value
-                          documentnode = value }
-
-                    Some record
-                | None -> None
-
         let document = leftTable<``document (base)``, document>
 
         type private ``illustration (base)`` = illustration
@@ -5104,17 +4635,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``illustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``illustration (base)`` option =
-                match this.illustrationid with
-                | Some value ->
-                    let record: ``illustration (base)`` =
-                        { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let illustration = leftTable<``illustration (base)``, illustration>
 
@@ -5134,17 +4654,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``location (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``location (base)`` option =
-                match this.locationid with
-                | Some value ->
-                    let record: ``location (base)`` =
-                        { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let location = leftTable<``location (base)``, location>
 
@@ -5205,41 +4714,6 @@ module production =
 
             interface ILeftViewOf<``product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``product (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``product (base)`` =
-                        { productid = value
-                          name = this.name.Value
-                          productnumber = this.productnumber.Value
-                          makeflag = this.makeflag.Value
-                          finishedgoodsflag = this.finishedgoodsflag.Value
-                          color = this.color
-                          safetystocklevel = this.safetystocklevel.Value
-                          reorderpoint = this.reorderpoint.Value
-                          standardcost = this.standardcost.Value
-                          listprice = this.listprice.Value
-                          size = this.size
-                          sizeunitmeasurecode = this.sizeunitmeasurecode
-                          weightunitmeasurecode = this.weightunitmeasurecode
-                          weight = this.weight
-                          daystomanufacture = this.daystomanufacture.Value
-                          productline = this.productline
-                          ``class`` = this.``class``
-                          style = this.style
-                          productsubcategoryid = this.productsubcategoryid
-                          productmodelid = this.productmodelid
-                          sellstartdate = this.sellstartdate.Value
-                          sellenddate = this.sellenddate
-                          discontinueddate = this.discontinueddate
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let product = leftTable<``product (base)``, product>
 
         type private ``productcategory (base)`` = productcategory
@@ -5256,17 +4730,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productcategory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productcategory (base)`` option =
-                match this.productcategoryid with
-                | Some value ->
-                    let record: ``productcategory (base)`` =
-                        { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productcategory = leftTable<``productcategory (base)``, productcategory>
 
@@ -5287,17 +4750,6 @@ module production =
 
             interface ILeftViewOf<``productcosthistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productcosthistory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productcosthistory (base)`` =
-                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productcosthistory =
             leftTable<``productcosthistory (base)``, productcosthistory>
 
@@ -5316,17 +4768,6 @@ module production =
 
             interface ILeftViewOf<``productdescription (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productdescription (base)`` option =
-                match this.productdescriptionid with
-                | Some value ->
-                    let record: ``productdescription (base)`` =
-                        { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productdescription =
             leftTable<``productdescription (base)``, productdescription>
 
@@ -5342,17 +4783,6 @@ module production =
               documentnode: Option<string> }
 
             interface ILeftViewOf<``productdocument (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productdocument (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productdocument (base)`` =
-                        { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
-
-                    Some record
-                | None -> None
 
         let productdocument = leftTable<``productdocument (base)``, productdocument>
 
@@ -5377,23 +4807,6 @@ module production =
 
             interface ILeftViewOf<``productinventory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productinventory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productinventory (base)`` =
-                        { productid = value
-                          locationid = this.locationid.Value
-                          shelf = this.shelf.Value
-                          bin = this.bin.Value
-                          quantity = this.quantity.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productinventory = leftTable<``productinventory (base)``, productinventory>
 
         type private ``productlistpricehistory (base)`` = productlistpricehistory
@@ -5412,17 +4825,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productlistpricehistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productlistpricehistory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productlistpricehistory (base)`` =
-                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productlistpricehistory =
             leftTable<``productlistpricehistory (base)``, productlistpricehistory>
@@ -5446,22 +4848,6 @@ module production =
 
             interface ILeftViewOf<``productmodel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodel (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodel (base)`` =
-                        { productmodelid = value
-                          name = this.name.Value
-                          catalogdescription = this.catalogdescription
-                          instructions = this.instructions
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productmodel = leftTable<``productmodel (base)``, productmodel>
 
         type private ``productmodelillustration (base)`` = productmodelillustration
@@ -5476,17 +4862,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productmodelillustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodelillustration (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodelillustration (base)`` =
-                        { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productmodelillustration =
             leftTable<``productmodelillustration (base)``, productmodelillustration>
@@ -5505,17 +4880,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productmodelproductdescriptionculture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodelproductdescriptionculture (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodelproductdescriptionculture (base)`` =
-                        { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productmodelproductdescriptionculture =
             leftTable<``productmodelproductdescriptionculture (base)``, productmodelproductdescriptionculture>
@@ -5539,22 +4903,6 @@ module production =
 
             interface ILeftViewOf<``productphoto (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productphoto (base)`` option =
-                match this.productphotoid with
-                | Some value ->
-                    let record: ``productphoto (base)`` =
-                        { productphotoid = value
-                          thumbnailphoto = this.thumbnailphoto
-                          thumbnailphotofilename = this.thumbnailphotofilename
-                          largephoto = this.largephoto
-                          largephotofilename = this.largephotofilename
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productphoto = leftTable<``productphoto (base)``, productphoto>
 
         type private ``productproductphoto (base)`` = productproductphoto
@@ -5571,17 +4919,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productproductphoto (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productproductphoto (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productproductphoto (base)`` =
-                        { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productproductphoto =
             leftTable<``productproductphoto (base)``, productproductphoto>
@@ -5609,24 +4946,6 @@ module production =
 
             interface ILeftViewOf<``productreview (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productreview (base)`` option =
-                match this.productreviewid with
-                | Some value ->
-                    let record: ``productreview (base)`` =
-                        { productreviewid = value
-                          productid = this.productid.Value
-                          reviewername = this.reviewername.Value
-                          reviewdate = this.reviewdate.Value
-                          emailaddress = this.emailaddress.Value
-                          rating = this.rating.Value
-                          comments = this.comments
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productreview = leftTable<``productreview (base)``, productreview>
 
         type private ``productsubcategory (base)`` = productsubcategory
@@ -5646,17 +4965,6 @@ module production =
 
             interface ILeftViewOf<``productsubcategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productsubcategory (base)`` option =
-                match this.productsubcategoryid with
-                | Some value ->
-                    let record: ``productsubcategory (base)`` =
-                        { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productsubcategory =
             leftTable<``productsubcategory (base)``, productsubcategory>
 
@@ -5672,17 +4980,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``scrapreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``scrapreason (base)`` option =
-                match this.scrapreasonid with
-                | Some value ->
-                    let record: ``scrapreason (base)`` =
-                        { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let scrapreason = leftTable<``scrapreason (base)``, scrapreason>
 
@@ -5710,25 +5007,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``transactionhistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``transactionhistory (base)`` option =
-                match this.transactionid with
-                | Some value ->
-                    let record: ``transactionhistory (base)`` =
-                        { transactionid = value
-                          productid = this.productid.Value
-                          referenceorderid = this.referenceorderid.Value
-                          referenceorderlineid = this.referenceorderlineid.Value
-                          transactiondate = this.transactiondate.Value
-                          transactiontype = this.transactiontype.Value
-                          quantity = this.quantity.Value
-                          actualcost = this.actualcost.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let transactionhistory =
             leftTable<``transactionhistory (base)``, transactionhistory>
@@ -5758,25 +5036,6 @@ module production =
 
             interface ILeftViewOf<``transactionhistoryarchive (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``transactionhistoryarchive (base)`` option =
-                match this.transactionid with
-                | Some value ->
-                    let record: ``transactionhistoryarchive (base)`` =
-                        { transactionid = value
-                          productid = this.productid.Value
-                          referenceorderid = this.referenceorderid.Value
-                          referenceorderlineid = this.referenceorderlineid.Value
-                          transactiondate = this.transactiondate.Value
-                          transactiontype = this.transactiontype.Value
-                          quantity = this.quantity.Value
-                          actualcost = this.actualcost.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let transactionhistoryarchive =
             leftTable<``transactionhistoryarchive (base)``, transactionhistoryarchive>
 
@@ -5792,17 +5051,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``unitmeasure (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``unitmeasure (base)`` option =
-                match this.unitmeasurecode with
-                | Some value ->
-                    let record: ``unitmeasure (base)`` =
-                        { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let unitmeasure = leftTable<``unitmeasure (base)``, unitmeasure>
 
@@ -5941,25 +5189,6 @@ module production =
 
             interface ILeftViewOf<``workorder (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``workorder (base)`` option =
-                match this.workorderid with
-                | Some value ->
-                    let record: ``workorder (base)`` =
-                        { workorderid = value
-                          productid = this.productid.Value
-                          orderqty = this.orderqty.Value
-                          scrappedqty = this.scrappedqty.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          duedate = this.duedate.Value
-                          scrapreasonid = this.scrapreasonid
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let workorder = leftTable<``workorder (base)``, workorder>
 
         type private ``workorderrouting (base)`` = workorderrouting
@@ -5992,28 +5221,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``workorderrouting (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``workorderrouting (base)`` option =
-                match this.workorderid with
-                | Some value ->
-                    let record: ``workorderrouting (base)`` =
-                        { workorderid = value
-                          productid = this.productid.Value
-                          operationsequence = this.operationsequence.Value
-                          locationid = this.locationid.Value
-                          scheduledstartdate = this.scheduledstartdate.Value
-                          scheduledenddate = this.scheduledenddate.Value
-                          actualstartdate = this.actualstartdate
-                          actualenddate = this.actualenddate
-                          actualresourcehrs = this.actualresourcehrs
-                          plannedcost = this.plannedcost.Value
-                          actualcost = this.actualcost
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let workorderrouting = leftTable<``workorderrouting (base)``, workorderrouting>
 
@@ -6361,25 +5568,6 @@ module pu =
 
             interface ILeftViewOf<``v (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``v (base)`` option =
-                match this.preferredvendorstatus with
-                | Some value ->
-                    let record: ``v (base)`` =
-                        { id = this.id
-                          businessentityid = this.businessentityid
-                          accountnumber = this.accountnumber
-                          name = this.name
-                          creditrating = this.creditrating
-                          preferredvendorstatus = value
-                          activeflag = this.activeflag.Value
-                          purchasingwebserviceurl = this.purchasingwebserviceurl
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
-
         let v = leftTable<``v (base)``, v>
 
 
@@ -6674,27 +5862,6 @@ module purchasing =
 
             interface ILeftViewOf<``productvendor (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productvendor (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productvendor (base)`` =
-                        { productid = value
-                          businessentityid = this.businessentityid.Value
-                          averageleadtime = this.averageleadtime.Value
-                          standardprice = this.standardprice.Value
-                          lastreceiptcost = this.lastreceiptcost
-                          lastreceiptdate = this.lastreceiptdate
-                          minorderqty = this.minorderqty.Value
-                          maxorderqty = this.maxorderqty.Value
-                          onorderqty = this.onorderqty
-                          unitmeasurecode = this.unitmeasurecode.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productvendor = leftTable<``productvendor (base)``, productvendor>
 
         type private ``purchaseorderdetail (base)`` = purchaseorderdetail
@@ -6721,25 +5888,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``purchaseorderdetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``purchaseorderdetail (base)`` option =
-                match this.purchaseorderid with
-                | Some value ->
-                    let record: ``purchaseorderdetail (base)`` =
-                        { purchaseorderid = value
-                          purchaseorderdetailid = this.purchaseorderdetailid.Value
-                          duedate = this.duedate.Value
-                          orderqty = this.orderqty.Value
-                          productid = this.productid.Value
-                          unitprice = this.unitprice.Value
-                          receivedqty = this.receivedqty.Value
-                          rejectedqty = this.rejectedqty.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let purchaseorderdetail =
             leftTable<``purchaseorderdetail (base)``, purchaseorderdetail>
@@ -6775,28 +5923,6 @@ module purchasing =
 
             interface ILeftViewOf<``purchaseorderheader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``purchaseorderheader (base)`` option =
-                match this.purchaseorderid with
-                | Some value ->
-                    let record: ``purchaseorderheader (base)`` =
-                        { purchaseorderid = value
-                          revisionnumber = this.revisionnumber.Value
-                          status = this.status.Value
-                          employeeid = this.employeeid.Value
-                          vendorid = this.vendorid.Value
-                          shipmethodid = this.shipmethodid.Value
-                          orderdate = this.orderdate.Value
-                          shipdate = this.shipdate
-                          subtotal = this.subtotal.Value
-                          taxamt = this.taxamt.Value
-                          freight = this.freight.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let purchaseorderheader =
             leftTable<``purchaseorderheader (base)``, purchaseorderheader>
 
@@ -6818,22 +5944,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shipmethod (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shipmethod (base)`` option =
-                match this.shipmethodid with
-                | Some value ->
-                    let record: ``shipmethod (base)`` =
-                        { shipmethodid = value
-                          name = this.name.Value
-                          shipbase = this.shipbase.Value
-                          shiprate = this.shiprate.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shipmethod = leftTable<``shipmethod (base)``, shipmethod>
 
@@ -6859,24 +5969,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``vendor (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``vendor (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``vendor (base)`` =
-                        { businessentityid = value
-                          accountnumber = this.accountnumber.Value
-                          name = this.name.Value
-                          creditrating = this.creditrating.Value
-                          preferredvendorstatus = this.preferredvendorstatus.Value
-                          activeflag = this.activeflag.Value
-                          purchasingwebserviceurl = this.purchasingwebserviceurl
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let vendor = leftTable<``vendor (base)``, vendor>
 
@@ -7836,42 +6928,6 @@ module sa =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``soh (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``soh (base)`` option =
-                match this.onlineorderflag with
-                | Some value ->
-                    let record: ``soh (base)`` =
-                        { id = this.id
-                          salesorderid = this.salesorderid
-                          revisionnumber = this.revisionnumber
-                          orderdate = this.orderdate
-                          duedate = this.duedate
-                          shipdate = this.shipdate
-                          status = this.status
-                          onlineorderflag = value
-                          purchaseordernumber = this.purchaseordernumber
-                          accountnumber = this.accountnumber
-                          customerid = this.customerid
-                          salespersonid = this.salespersonid
-                          territoryid = this.territoryid
-                          billtoaddressid = this.billtoaddressid
-                          shiptoaddressid = this.shiptoaddressid
-                          shipmethodid = this.shipmethodid
-                          creditcardid = this.creditcardid
-                          creditcardapprovalcode = this.creditcardapprovalcode
-                          currencyrateid = this.currencyrateid
-                          subtotal = this.subtotal
-                          taxamt = this.taxamt
-                          freight = this.freight
-                          totaldue = this.totaldue
-                          comment = this.comment
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let soh = leftTable<``soh (base)``, soh>
 
@@ -8991,17 +8047,6 @@ module sales =
 
             interface ILeftViewOf<``countryregioncurrency (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``countryregioncurrency (base)`` option =
-                match this.countryregioncode with
-                | Some value ->
-                    let record: ``countryregioncurrency (base)`` =
-                        { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let countryregioncurrency =
             leftTable<``countryregioncurrency (base)``, countryregioncurrency>
 
@@ -9024,22 +8069,6 @@ module sales =
 
             interface ILeftViewOf<``creditcard (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``creditcard (base)`` option =
-                match this.creditcardid with
-                | Some value ->
-                    let record: ``creditcard (base)`` =
-                        { creditcardid = value
-                          cardtype = this.cardtype.Value
-                          cardnumber = this.cardnumber.Value
-                          expmonth = this.expmonth.Value
-                          expyear = this.expyear.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let creditcard = leftTable<``creditcard (base)``, creditcard>
 
         type private ``currency (base)`` = currency
@@ -9054,17 +8083,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``currency (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``currency (base)`` option =
-                match this.currencycode with
-                | Some value ->
-                    let record: ``currency (base)`` =
-                        { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let currency = leftTable<``currency (base)``, currency>
 
@@ -9089,23 +8107,6 @@ module sales =
 
             interface ILeftViewOf<``currencyrate (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``currencyrate (base)`` option =
-                match this.currencyrateid with
-                | Some value ->
-                    let record: ``currencyrate (base)`` =
-                        { currencyrateid = value
-                          currencyratedate = this.currencyratedate.Value
-                          fromcurrencycode = this.fromcurrencycode.Value
-                          tocurrencycode = this.tocurrencycode.Value
-                          averagerate = this.averagerate.Value
-                          endofdayrate = this.endofdayrate.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let currencyrate = leftTable<``currencyrate (base)``, currencyrate>
 
         type private ``customer (base)`` = customer
@@ -9127,17 +8128,6 @@ module sales =
 
             interface ILeftViewOf<``customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``customer (base)`` option =
-                match this.customerid with
-                | Some value ->
-                    let record: ``customer (base)`` =
-                        { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let customer = leftTable<``customer (base)``, customer>
 
         type private ``personcreditcard (base)`` = personcreditcard
@@ -9152,17 +8142,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``personcreditcard (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``personcreditcard (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``personcreditcard (base)`` =
-                        { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let personcreditcard = leftTable<``personcreditcard (base)``, personcreditcard>
 
@@ -9192,26 +8171,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesorderdetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderdetail (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderdetail (base)`` =
-                        { salesorderid = value
-                          salesorderdetailid = this.salesorderdetailid.Value
-                          carriertrackingnumber = this.carriertrackingnumber
-                          orderqty = this.orderqty.Value
-                          productid = this.productid.Value
-                          specialofferid = this.specialofferid.Value
-                          unitprice = this.unitprice.Value
-                          unitpricediscount = this.unitpricediscount.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesorderdetail = leftTable<``salesorderdetail (base)``, salesorderdetail>
 
@@ -9272,41 +8231,6 @@ module sales =
 
             interface ILeftViewOf<``salesorderheader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderheader (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderheader (base)`` =
-                        { salesorderid = value
-                          revisionnumber = this.revisionnumber.Value
-                          orderdate = this.orderdate.Value
-                          duedate = this.duedate.Value
-                          shipdate = this.shipdate
-                          status = this.status.Value
-                          onlineorderflag = this.onlineorderflag.Value
-                          purchaseordernumber = this.purchaseordernumber
-                          accountnumber = this.accountnumber
-                          customerid = this.customerid.Value
-                          salespersonid = this.salespersonid
-                          territoryid = this.territoryid
-                          billtoaddressid = this.billtoaddressid.Value
-                          shiptoaddressid = this.shiptoaddressid.Value
-                          shipmethodid = this.shipmethodid.Value
-                          creditcardid = this.creditcardid
-                          creditcardapprovalcode = this.creditcardapprovalcode
-                          currencyrateid = this.currencyrateid
-                          subtotal = this.subtotal.Value
-                          taxamt = this.taxamt.Value
-                          freight = this.freight.Value
-                          totaldue = this.totaldue
-                          comment = this.comment
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesorderheader = leftTable<``salesorderheader (base)``, salesorderheader>
 
         type private ``salesorderheadersalesreason (base)`` = salesorderheadersalesreason
@@ -9321,17 +8245,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesorderheadersalesreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderheadersalesreason (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderheadersalesreason (base)`` =
-                        { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesorderheadersalesreason =
             leftTable<``salesorderheadersalesreason (base)``, salesorderheadersalesreason>
@@ -9361,25 +8274,6 @@ module sales =
 
             interface ILeftViewOf<``salesperson (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesperson (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salesperson (base)`` =
-                        { businessentityid = value
-                          territoryid = this.territoryid
-                          salesquota = this.salesquota
-                          bonus = this.bonus.Value
-                          commissionpct = this.commissionpct.Value
-                          salesytd = this.salesytd.Value
-                          saleslastyear = this.saleslastyear.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesperson = leftTable<``salesperson (base)``, salesperson>
 
         type private ``salespersonquotahistory (base)`` = salespersonquotahistory
@@ -9399,17 +8293,6 @@ module sales =
 
             interface ILeftViewOf<``salespersonquotahistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salespersonquotahistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salespersonquotahistory (base)`` =
-                        { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salespersonquotahistory =
             leftTable<``salespersonquotahistory (base)``, salespersonquotahistory>
 
@@ -9427,17 +8310,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesreason (base)`` option =
-                match this.salesreasonid with
-                | Some value ->
-                    let record: ``salesreason (base)`` =
-                        { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesreason = leftTable<``salesreason (base)``, salesreason>
 
@@ -9461,23 +8333,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salestaxrate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salestaxrate (base)`` option =
-                match this.salestaxrateid with
-                | Some value ->
-                    let record: ``salestaxrate (base)`` =
-                        { salestaxrateid = value
-                          stateprovinceid = this.stateprovinceid.Value
-                          taxtype = this.taxtype.Value
-                          taxrate = this.taxrate.Value
-                          name = this.name.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salestaxrate = leftTable<``salestaxrate (base)``, salestaxrate>
 
@@ -9508,26 +8363,6 @@ module sales =
 
             interface ILeftViewOf<``salesterritory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesterritory (base)`` option =
-                match this.territoryid with
-                | Some value ->
-                    let record: ``salesterritory (base)`` =
-                        { territoryid = value
-                          name = this.name.Value
-                          countryregioncode = this.countryregioncode.Value
-                          group = this.group.Value
-                          salesytd = this.salesytd.Value
-                          saleslastyear = this.saleslastyear.Value
-                          costytd = this.costytd.Value
-                          costlastyear = this.costlastyear.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesterritory = leftTable<``salesterritory (base)``, salesterritory>
 
         type private ``salesterritoryhistory (base)`` = salesterritoryhistory
@@ -9548,22 +8383,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesterritoryhistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesterritoryhistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salesterritoryhistory (base)`` =
-                        { businessentityid = value
-                          territoryid = this.territoryid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesterritoryhistory =
             leftTable<``salesterritoryhistory (base)``, salesterritoryhistory>
@@ -9586,22 +8405,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shoppingcartitem (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shoppingcartitem (base)`` option =
-                match this.shoppingcartitemid with
-                | Some value ->
-                    let record: ``shoppingcartitem (base)`` =
-                        { shoppingcartitemid = value
-                          shoppingcartid = this.shoppingcartid.Value
-                          quantity = this.quantity.Value
-                          productid = this.productid.Value
-                          datecreated = this.datecreated.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shoppingcartitem = leftTable<``shoppingcartitem (base)``, shoppingcartitem>
 
@@ -9634,27 +8437,6 @@ module sales =
 
             interface ILeftViewOf<``specialoffer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``specialoffer (base)`` option =
-                match this.specialofferid with
-                | Some value ->
-                    let record: ``specialoffer (base)`` =
-                        { specialofferid = value
-                          description = this.description.Value
-                          discountpct = this.discountpct.Value
-                          ``type`` = this.``type``.Value
-                          category = this.category.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate.Value
-                          minqty = this.minqty.Value
-                          maxqty = this.maxqty
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let specialoffer = leftTable<``specialoffer (base)``, specialoffer>
 
         type private ``specialofferproduct (base)`` = specialofferproduct
@@ -9671,17 +8453,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``specialofferproduct (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``specialofferproduct (base)`` option =
-                match this.specialofferid with
-                | Some value ->
-                    let record: ``specialofferproduct (base)`` =
-                        { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let specialofferproduct =
             leftTable<``specialofferproduct (base)``, specialofferproduct>
@@ -9704,22 +8475,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``store (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``store (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``store (base)`` =
-                        { businessentityid = value
-                          name = this.name.Value
-                          salespersonid = this.salespersonid
-                          demographics = this.demographics
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let store = leftTable<``store (base)``, store>
 
@@ -9999,6 +8754,1327 @@ module sales =
 
         let vstorewithdemographics =
             leftTable<``vstorewithdemographics (base)``, vstorewithdemographics>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type ext.LeftJoined.arrays with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.arrays option =
+            match this.id with
+            | Some value ->
+                let record: ext.arrays =
+                    { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.jsonsupport with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.jsonsupport option =
+            match this.id with
+            | Some value ->
+                let record: ext.jsonsupport =
+                    { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.person option =
+            match this.name with
+            | Some value ->
+                let record: ext.person = { name = value; currentmood = this.currentmood.Value }
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.department with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.department option =
+            match this.departmentid with
+            | Some value ->
+                let record: humanresources.department =
+                    { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employee with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employee option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employee =
+                    { businessentityid = value
+                      nationalidnumber = this.nationalidnumber.Value
+                      loginid = this.loginid.Value
+                      jobtitle = this.jobtitle.Value
+                      birthdate = this.birthdate.Value
+                      maritalstatus = this.maritalstatus.Value
+                      gender = this.gender.Value
+                      hiredate = this.hiredate.Value
+                      salariedflag = this.salariedflag.Value
+                      vacationhours = this.vacationhours.Value
+                      sickleavehours = this.sickleavehours.Value
+                      currentflag = this.currentflag.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value
+                      organizationnode = this.organizationnode }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employeedepartmenthistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employeedepartmenthistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employeedepartmenthistory =
+                    { businessentityid = value
+                      departmentid = this.departmentid.Value
+                      shiftid = this.shiftid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employeepayhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employeepayhistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employeepayhistory =
+                    { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.jobcandidate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.jobcandidate option =
+            match this.jobcandidateid with
+            | Some value ->
+                let record: humanresources.jobcandidate =
+                    { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.shift with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.shift option =
+            match this.shiftid with
+            | Some value ->
+                let record: humanresources.shift =
+                    { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type network_sample.LeftJoined.network_addresses with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : network_sample.network_addresses option =
+            match this.id with
+            | Some value ->
+                let record: network_sample.network_addresses =
+                    { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
+
+                Some record
+            | None -> None
+
+    type pe.LeftJoined.p with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pe.p option =
+            match this.namestyle with
+            | Some value ->
+                let record: pe.p =
+                    { id = this.id
+                      businessentityid = this.businessentityid
+                      persontype = this.persontype
+                      namestyle = value
+                      title = this.title
+                      firstname = this.firstname
+                      middlename = this.middlename
+                      lastname = this.lastname
+                      suffix = this.suffix
+                      emailpromotion = this.emailpromotion
+                      additionalcontactinfo = this.additionalcontactinfo
+                      demographics = this.demographics
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type pe.LeftJoined.sp with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pe.sp option =
+            match this.isonlystateprovinceflag with
+            | Some value ->
+                let record: pe.sp =
+                    { id = this.id
+                      stateprovinceid = this.stateprovinceid
+                      stateprovincecode = this.stateprovincecode
+                      countryregioncode = this.countryregioncode
+                      isonlystateprovinceflag = value
+                      name = this.name
+                      territoryid = this.territoryid
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.address option =
+            match this.addressid with
+            | Some value ->
+                let record: person.address =
+                    { addressid = value
+                      addressline1 = this.addressline1.Value
+                      addressline2 = this.addressline2
+                      city = this.city.Value
+                      stateprovinceid = this.stateprovinceid.Value
+                      postalcode = this.postalcode.Value
+                      spatiallocation = this.spatiallocation
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.addresstype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.addresstype option =
+            match this.addresstypeid with
+            | Some value ->
+                let record: person.addresstype =
+                    { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentity with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentity option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentity =
+                    { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentityaddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentityaddress option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentityaddress =
+                    { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentitycontact with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentitycontact option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentitycontact =
+                    { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.contacttype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.contacttype option =
+            match this.contacttypeid with
+            | Some value ->
+                let record: person.contacttype =
+                    { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.countryregion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.countryregion option =
+            match this.countryregioncode with
+            | Some value ->
+                let record: person.countryregion =
+                    { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.emailaddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.emailaddress option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.emailaddress =
+                    { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.password with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.password option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.password =
+                    { businessentityid = value; passwordhash = this.passwordhash.Value; passwordsalt = this.passwordsalt.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.person option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.person =
+                    { businessentityid = value
+                      persontype = this.persontype.Value
+                      namestyle = this.namestyle.Value
+                      title = this.title
+                      firstname = this.firstname.Value
+                      middlename = this.middlename
+                      lastname = this.lastname.Value
+                      suffix = this.suffix
+                      emailpromotion = this.emailpromotion.Value
+                      additionalcontactinfo = this.additionalcontactinfo
+                      demographics = this.demographics
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.personphone with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.personphone option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.personphone =
+                    { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.phonenumbertype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.phonenumbertype option =
+            match this.phonenumbertypeid with
+            | Some value ->
+                let record: person.phonenumbertype =
+                    { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.stateprovince with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.stateprovince option =
+            match this.stateprovinceid with
+            | Some value ->
+                let record: person.stateprovince =
+                    { stateprovinceid = value
+                      stateprovincecode = this.stateprovincecode.Value
+                      countryregioncode = this.countryregioncode.Value
+                      isonlystateprovinceflag = this.isonlystateprovinceflag.Value
+                      name = this.name.Value
+                      territoryid = this.territoryid.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.d with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.d option =
+            match this.folderflag with
+            | Some value ->
+                let record: pr.d =
+                    { title = this.title
+                      owner = this.owner
+                      folderflag = value
+                      filename = this.filename
+                      fileextension = this.fileextension
+                      revision = this.revision
+                      changenumber = this.changenumber
+                      status = this.status
+                      documentsummary = this.documentsummary
+                      document = this.document
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate
+                      documentnode = this.documentnode }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.p with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.p option =
+            match this.makeflag with
+            | Some value ->
+                let record: pr.p =
+                    { id = this.id
+                      productid = this.productid
+                      name = this.name
+                      productnumber = this.productnumber
+                      makeflag = value
+                      finishedgoodsflag = this.finishedgoodsflag.Value
+                      color = this.color
+                      safetystocklevel = this.safetystocklevel
+                      reorderpoint = this.reorderpoint
+                      standardcost = this.standardcost
+                      listprice = this.listprice
+                      size = this.size
+                      sizeunitmeasurecode = this.sizeunitmeasurecode
+                      weightunitmeasurecode = this.weightunitmeasurecode
+                      weight = this.weight
+                      daystomanufacture = this.daystomanufacture
+                      productline = this.productline
+                      ``class`` = this.``class``
+                      style = this.style
+                      productsubcategoryid = this.productsubcategoryid
+                      productmodelid = this.productmodelid
+                      sellstartdate = this.sellstartdate
+                      sellenddate = this.sellenddate
+                      discontinueddate = this.discontinueddate
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.ppp with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.ppp option =
+            match this.primary with
+            | Some value ->
+                let record: pr.ppp =
+                    { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.billofmaterials with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.billofmaterials option =
+            match this.billofmaterialsid with
+            | Some value ->
+                let record: production.billofmaterials =
+                    { billofmaterialsid = value
+                      productassemblyid = this.productassemblyid
+                      componentid = this.componentid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      unitmeasurecode = this.unitmeasurecode.Value
+                      bomlevel = this.bomlevel.Value
+                      perassemblyqty = this.perassemblyqty.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.culture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.culture option =
+            match this.cultureid with
+            | Some value ->
+                let record: production.culture =
+                    { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.document with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.document option =
+            match this.documentnode with
+            | Some value ->
+                let record: production.document =
+                    { title = this.title.Value
+                      owner = this.owner.Value
+                      folderflag = this.folderflag.Value
+                      filename = this.filename.Value
+                      fileextension = this.fileextension
+                      revision = this.revision.Value
+                      changenumber = this.changenumber.Value
+                      status = this.status.Value
+                      documentsummary = this.documentsummary
+                      document = this.document
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value
+                      documentnode = value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.illustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.illustration option =
+            match this.illustrationid with
+            | Some value ->
+                let record: production.illustration =
+                    { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.location with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.location option =
+            match this.locationid with
+            | Some value ->
+                let record: production.location =
+                    { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.product option =
+            match this.productid with
+            | Some value ->
+                let record: production.product =
+                    { productid = value
+                      name = this.name.Value
+                      productnumber = this.productnumber.Value
+                      makeflag = this.makeflag.Value
+                      finishedgoodsflag = this.finishedgoodsflag.Value
+                      color = this.color
+                      safetystocklevel = this.safetystocklevel.Value
+                      reorderpoint = this.reorderpoint.Value
+                      standardcost = this.standardcost.Value
+                      listprice = this.listprice.Value
+                      size = this.size
+                      sizeunitmeasurecode = this.sizeunitmeasurecode
+                      weightunitmeasurecode = this.weightunitmeasurecode
+                      weight = this.weight
+                      daystomanufacture = this.daystomanufacture.Value
+                      productline = this.productline
+                      ``class`` = this.``class``
+                      style = this.style
+                      productsubcategoryid = this.productsubcategoryid
+                      productmodelid = this.productmodelid
+                      sellstartdate = this.sellstartdate.Value
+                      sellenddate = this.sellenddate
+                      discontinueddate = this.discontinueddate
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productcategory option =
+            match this.productcategoryid with
+            | Some value ->
+                let record: production.productcategory =
+                    { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productcosthistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productcosthistory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productcosthistory =
+                    { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productdescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productdescription option =
+            match this.productdescriptionid with
+            | Some value ->
+                let record: production.productdescription =
+                    { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productdocument with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productdocument option =
+            match this.productid with
+            | Some value ->
+                let record: production.productdocument =
+                    { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productinventory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productinventory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productinventory =
+                    { productid = value
+                      locationid = this.locationid.Value
+                      shelf = this.shelf.Value
+                      bin = this.bin.Value
+                      quantity = this.quantity.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productlistpricehistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productlistpricehistory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productlistpricehistory =
+                    { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodel option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodel =
+                    { productmodelid = value
+                      name = this.name.Value
+                      catalogdescription = this.catalogdescription
+                      instructions = this.instructions
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodelillustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodelillustration option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodelillustration =
+                    { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodelproductdescriptionculture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodelproductdescriptionculture option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodelproductdescriptionculture =
+                    { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productphoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productphoto option =
+            match this.productphotoid with
+            | Some value ->
+                let record: production.productphoto =
+                    { productphotoid = value
+                      thumbnailphoto = this.thumbnailphoto
+                      thumbnailphotofilename = this.thumbnailphotofilename
+                      largephoto = this.largephoto
+                      largephotofilename = this.largephotofilename
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productproductphoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productproductphoto option =
+            match this.productid with
+            | Some value ->
+                let record: production.productproductphoto =
+                    { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productreview with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productreview option =
+            match this.productreviewid with
+            | Some value ->
+                let record: production.productreview =
+                    { productreviewid = value
+                      productid = this.productid.Value
+                      reviewername = this.reviewername.Value
+                      reviewdate = this.reviewdate.Value
+                      emailaddress = this.emailaddress.Value
+                      rating = this.rating.Value
+                      comments = this.comments
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productsubcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productsubcategory option =
+            match this.productsubcategoryid with
+            | Some value ->
+                let record: production.productsubcategory =
+                    { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.scrapreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.scrapreason option =
+            match this.scrapreasonid with
+            | Some value ->
+                let record: production.scrapreason =
+                    { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.transactionhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.transactionhistory option =
+            match this.transactionid with
+            | Some value ->
+                let record: production.transactionhistory =
+                    { transactionid = value
+                      productid = this.productid.Value
+                      referenceorderid = this.referenceorderid.Value
+                      referenceorderlineid = this.referenceorderlineid.Value
+                      transactiondate = this.transactiondate.Value
+                      transactiontype = this.transactiontype.Value
+                      quantity = this.quantity.Value
+                      actualcost = this.actualcost.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.transactionhistoryarchive with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.transactionhistoryarchive option =
+            match this.transactionid with
+            | Some value ->
+                let record: production.transactionhistoryarchive =
+                    { transactionid = value
+                      productid = this.productid.Value
+                      referenceorderid = this.referenceorderid.Value
+                      referenceorderlineid = this.referenceorderlineid.Value
+                      transactiondate = this.transactiondate.Value
+                      transactiontype = this.transactiontype.Value
+                      quantity = this.quantity.Value
+                      actualcost = this.actualcost.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.unitmeasure with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.unitmeasure option =
+            match this.unitmeasurecode with
+            | Some value ->
+                let record: production.unitmeasure =
+                    { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.workorder with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.workorder option =
+            match this.workorderid with
+            | Some value ->
+                let record: production.workorder =
+                    { workorderid = value
+                      productid = this.productid.Value
+                      orderqty = this.orderqty.Value
+                      scrappedqty = this.scrappedqty.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      duedate = this.duedate.Value
+                      scrapreasonid = this.scrapreasonid
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.workorderrouting with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.workorderrouting option =
+            match this.workorderid with
+            | Some value ->
+                let record: production.workorderrouting =
+                    { workorderid = value
+                      productid = this.productid.Value
+                      operationsequence = this.operationsequence.Value
+                      locationid = this.locationid.Value
+                      scheduledstartdate = this.scheduledstartdate.Value
+                      scheduledenddate = this.scheduledenddate.Value
+                      actualstartdate = this.actualstartdate
+                      actualenddate = this.actualenddate
+                      actualresourcehrs = this.actualresourcehrs
+                      plannedcost = this.plannedcost.Value
+                      actualcost = this.actualcost
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type pu.LeftJoined.v with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pu.v option =
+            match this.preferredvendorstatus with
+            | Some value ->
+                let record: pu.v =
+                    { id = this.id
+                      businessentityid = this.businessentityid
+                      accountnumber = this.accountnumber
+                      name = this.name
+                      creditrating = this.creditrating
+                      preferredvendorstatus = value
+                      activeflag = this.activeflag.Value
+                      purchasingwebserviceurl = this.purchasingwebserviceurl
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.productvendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.productvendor option =
+            match this.productid with
+            | Some value ->
+                let record: purchasing.productvendor =
+                    { productid = value
+                      businessentityid = this.businessentityid.Value
+                      averageleadtime = this.averageleadtime.Value
+                      standardprice = this.standardprice.Value
+                      lastreceiptcost = this.lastreceiptcost
+                      lastreceiptdate = this.lastreceiptdate
+                      minorderqty = this.minorderqty.Value
+                      maxorderqty = this.maxorderqty.Value
+                      onorderqty = this.onorderqty
+                      unitmeasurecode = this.unitmeasurecode.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.purchaseorderdetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.purchaseorderdetail option =
+            match this.purchaseorderid with
+            | Some value ->
+                let record: purchasing.purchaseorderdetail =
+                    { purchaseorderid = value
+                      purchaseorderdetailid = this.purchaseorderdetailid.Value
+                      duedate = this.duedate.Value
+                      orderqty = this.orderqty.Value
+                      productid = this.productid.Value
+                      unitprice = this.unitprice.Value
+                      receivedqty = this.receivedqty.Value
+                      rejectedqty = this.rejectedqty.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.purchaseorderheader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.purchaseorderheader option =
+            match this.purchaseorderid with
+            | Some value ->
+                let record: purchasing.purchaseorderheader =
+                    { purchaseorderid = value
+                      revisionnumber = this.revisionnumber.Value
+                      status = this.status.Value
+                      employeeid = this.employeeid.Value
+                      vendorid = this.vendorid.Value
+                      shipmethodid = this.shipmethodid.Value
+                      orderdate = this.orderdate.Value
+                      shipdate = this.shipdate
+                      subtotal = this.subtotal.Value
+                      taxamt = this.taxamt.Value
+                      freight = this.freight.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.shipmethod with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.shipmethod option =
+            match this.shipmethodid with
+            | Some value ->
+                let record: purchasing.shipmethod =
+                    { shipmethodid = value
+                      name = this.name.Value
+                      shipbase = this.shipbase.Value
+                      shiprate = this.shiprate.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.vendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.vendor option =
+            match this.businessentityid with
+            | Some value ->
+                let record: purchasing.vendor =
+                    { businessentityid = value
+                      accountnumber = this.accountnumber.Value
+                      name = this.name.Value
+                      creditrating = this.creditrating.Value
+                      preferredvendorstatus = this.preferredvendorstatus.Value
+                      activeflag = this.activeflag.Value
+                      purchasingwebserviceurl = this.purchasingwebserviceurl
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sa.LeftJoined.soh with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sa.soh option =
+            match this.onlineorderflag with
+            | Some value ->
+                let record: sa.soh =
+                    { id = this.id
+                      salesorderid = this.salesorderid
+                      revisionnumber = this.revisionnumber
+                      orderdate = this.orderdate
+                      duedate = this.duedate
+                      shipdate = this.shipdate
+                      status = this.status
+                      onlineorderflag = value
+                      purchaseordernumber = this.purchaseordernumber
+                      accountnumber = this.accountnumber
+                      customerid = this.customerid
+                      salespersonid = this.salespersonid
+                      territoryid = this.territoryid
+                      billtoaddressid = this.billtoaddressid
+                      shiptoaddressid = this.shiptoaddressid
+                      shipmethodid = this.shipmethodid
+                      creditcardid = this.creditcardid
+                      creditcardapprovalcode = this.creditcardapprovalcode
+                      currencyrateid = this.currencyrateid
+                      subtotal = this.subtotal
+                      taxamt = this.taxamt
+                      freight = this.freight
+                      totaldue = this.totaldue
+                      comment = this.comment
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.countryregioncurrency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.countryregioncurrency option =
+            match this.countryregioncode with
+            | Some value ->
+                let record: sales.countryregioncurrency =
+                    { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.creditcard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.creditcard option =
+            match this.creditcardid with
+            | Some value ->
+                let record: sales.creditcard =
+                    { creditcardid = value
+                      cardtype = this.cardtype.Value
+                      cardnumber = this.cardnumber.Value
+                      expmonth = this.expmonth.Value
+                      expyear = this.expyear.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.currency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.currency option =
+            match this.currencycode with
+            | Some value ->
+                let record: sales.currency =
+                    { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.currencyrate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.currencyrate option =
+            match this.currencyrateid with
+            | Some value ->
+                let record: sales.currencyrate =
+                    { currencyrateid = value
+                      currencyratedate = this.currencyratedate.Value
+                      fromcurrencycode = this.fromcurrencycode.Value
+                      tocurrencycode = this.tocurrencycode.Value
+                      averagerate = this.averagerate.Value
+                      endofdayrate = this.endofdayrate.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.customer option =
+            match this.customerid with
+            | Some value ->
+                let record: sales.customer =
+                    { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.personcreditcard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.personcreditcard option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.personcreditcard =
+                    { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderdetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderdetail option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderdetail =
+                    { salesorderid = value
+                      salesorderdetailid = this.salesorderdetailid.Value
+                      carriertrackingnumber = this.carriertrackingnumber
+                      orderqty = this.orderqty.Value
+                      productid = this.productid.Value
+                      specialofferid = this.specialofferid.Value
+                      unitprice = this.unitprice.Value
+                      unitpricediscount = this.unitpricediscount.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderheader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderheader option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderheader =
+                    { salesorderid = value
+                      revisionnumber = this.revisionnumber.Value
+                      orderdate = this.orderdate.Value
+                      duedate = this.duedate.Value
+                      shipdate = this.shipdate
+                      status = this.status.Value
+                      onlineorderflag = this.onlineorderflag.Value
+                      purchaseordernumber = this.purchaseordernumber
+                      accountnumber = this.accountnumber
+                      customerid = this.customerid.Value
+                      salespersonid = this.salespersonid
+                      territoryid = this.territoryid
+                      billtoaddressid = this.billtoaddressid.Value
+                      shiptoaddressid = this.shiptoaddressid.Value
+                      shipmethodid = this.shipmethodid.Value
+                      creditcardid = this.creditcardid
+                      creditcardapprovalcode = this.creditcardapprovalcode
+                      currencyrateid = this.currencyrateid
+                      subtotal = this.subtotal.Value
+                      taxamt = this.taxamt.Value
+                      freight = this.freight.Value
+                      totaldue = this.totaldue
+                      comment = this.comment
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderheadersalesreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderheadersalesreason option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderheadersalesreason =
+                    { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesperson with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesperson option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salesperson =
+                    { businessentityid = value
+                      territoryid = this.territoryid
+                      salesquota = this.salesquota
+                      bonus = this.bonus.Value
+                      commissionpct = this.commissionpct.Value
+                      salesytd = this.salesytd.Value
+                      saleslastyear = this.saleslastyear.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salespersonquotahistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salespersonquotahistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salespersonquotahistory =
+                    { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesreason option =
+            match this.salesreasonid with
+            | Some value ->
+                let record: sales.salesreason =
+                    { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salestaxrate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salestaxrate option =
+            match this.salestaxrateid with
+            | Some value ->
+                let record: sales.salestaxrate =
+                    { salestaxrateid = value
+                      stateprovinceid = this.stateprovinceid.Value
+                      taxtype = this.taxtype.Value
+                      taxrate = this.taxrate.Value
+                      name = this.name.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesterritory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesterritory option =
+            match this.territoryid with
+            | Some value ->
+                let record: sales.salesterritory =
+                    { territoryid = value
+                      name = this.name.Value
+                      countryregioncode = this.countryregioncode.Value
+                      group = this.group.Value
+                      salesytd = this.salesytd.Value
+                      saleslastyear = this.saleslastyear.Value
+                      costytd = this.costytd.Value
+                      costlastyear = this.costlastyear.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesterritoryhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesterritoryhistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salesterritoryhistory =
+                    { businessentityid = value
+                      territoryid = this.territoryid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.shoppingcartitem with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.shoppingcartitem option =
+            match this.shoppingcartitemid with
+            | Some value ->
+                let record: sales.shoppingcartitem =
+                    { shoppingcartitemid = value
+                      shoppingcartid = this.shoppingcartid.Value
+                      quantity = this.quantity.Value
+                      productid = this.productid.Value
+                      datecreated = this.datecreated.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.specialoffer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.specialoffer option =
+            match this.specialofferid with
+            | Some value ->
+                let record: sales.specialoffer =
+                    { specialofferid = value
+                      description = this.description.Value
+                      discountpct = this.discountpct.Value
+                      ``type`` = this.``type``.Value
+                      category = this.category.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate.Value
+                      minqty = this.minqty.Value
+                      maxqty = this.maxqty
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.specialofferproduct with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.specialofferproduct option =
+            match this.specialofferid with
+            | Some value ->
+                let record: sales.specialofferproduct =
+                    { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.store with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.store option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.store =
+                    { businessentityid = value
+                      name = this.name.Value
+                      salespersonid = this.salespersonid
+                      demographics = this.demographics
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Npgsql/AdventureWorksNet9.fs
+++ b/src/Tests/Npgsql/AdventureWorksNet9.fs
@@ -62,6 +62,85 @@ module ext =
 
     let person = table<person>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``arrays (base)`` = arrays
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type arrays =
+            { [<ProviderDbType("Text")>]
+              id: Option<string>
+              [<ProviderDbType("Text,Array")>]
+              text_array: Option<string[]>
+              [<ProviderDbType("Integer,Array")>]
+              integer_array: Option<int[]> }
+
+            interface ILeftViewOf<``arrays (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``arrays (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``arrays (base)`` =
+                        { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
+
+                    Some record
+                | None -> None
+
+        let arrays = leftTable<``arrays (base)``, arrays>
+
+        type private ``jsonsupport (base)`` = jsonsupport
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type jsonsupport =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Json")>]
+              json_field: Option<string>
+              [<ProviderDbType("Jsonb")>]
+              jsonb_field: Option<string> }
+
+            interface ILeftViewOf<``jsonsupport (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``jsonsupport (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``jsonsupport (base)`` =
+                        { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
+
+                    Some record
+                | None -> None
+
+        let jsonsupport = leftTable<``jsonsupport (base)``, jsonsupport>
+
+        type private ``person (base)`` = person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type person =
+            { [<ProviderDbType("Text")>]
+              name: Option<string>
+              currentmood: Option<mood> }
+
+            interface ILeftViewOf<``person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``person (base)`` option =
+                match this.name with
+                | Some value ->
+                    let record: ``person (base)`` =
+                        { name = value; currentmood = this.currentmood.Value }
+
+                    Some record
+                | None -> None
+
+        let person = leftTable<``person (base)``, person>
+
+
 module humanresources =
 
     [<CLIMutable>]
@@ -514,6 +593,445 @@ module humanresources =
 
     let vjobcandidateemployment = table<vjobcandidateemployment>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``department (base)`` = department
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type department =
+            { [<ProviderDbType("Integer")>]
+              departmentid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``department (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``department (base)`` option =
+                match this.departmentid with
+                | Some value ->
+                    let record: ``department (base)`` =
+                        { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let department = leftTable<``department (base)``, department>
+
+        type private ``employee (base)`` = employee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employee =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              nationalidnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              loginid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Date")>]
+              birthdate: Option<System.DateOnly>
+              [<ProviderDbType("Char")>]
+              maritalstatus: Option<string>
+              [<ProviderDbType("Char")>]
+              gender: Option<string>
+              [<ProviderDbType("Date")>]
+              hiredate: Option<System.DateOnly>
+              [<ProviderDbType("Boolean")>]
+              salariedflag: Option<bool>
+              [<ProviderDbType("Smallint")>]
+              vacationhours: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              sickleavehours: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              currentflag: Option<bool>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              organizationnode: Option<string> }
+
+            interface ILeftViewOf<``employee (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employee (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employee (base)`` =
+                        { businessentityid = value
+                          nationalidnumber = this.nationalidnumber.Value
+                          loginid = this.loginid.Value
+                          jobtitle = this.jobtitle.Value
+                          birthdate = this.birthdate.Value
+                          maritalstatus = this.maritalstatus.Value
+                          gender = this.gender.Value
+                          hiredate = this.hiredate.Value
+                          salariedflag = this.salariedflag.Value
+                          vacationhours = this.vacationhours.Value
+                          sickleavehours = this.sickleavehours.Value
+                          currentflag = this.currentflag.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value
+                          organizationnode = this.organizationnode }
+
+                    Some record
+                | None -> None
+
+        let employee = leftTable<``employee (base)``, employee>
+
+        type private ``employeedepartmenthistory (base)`` = employeedepartmenthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employeedepartmenthistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              departmentid: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              shiftid: Option<int16>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              enddate: Option<System.DateOnly>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``employeedepartmenthistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employeedepartmenthistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employeedepartmenthistory (base)`` =
+                        { businessentityid = value
+                          departmentid = this.departmentid.Value
+                          shiftid = this.shiftid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let employeedepartmenthistory =
+            leftTable<``employeedepartmenthistory (base)``, employeedepartmenthistory>
+
+        type private ``employeepayhistory (base)`` = employeepayhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type employeepayhistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              ratechangedate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              rate: Option<decimal>
+              [<ProviderDbType("Smallint")>]
+              payfrequency: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``employeepayhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``employeepayhistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``employeepayhistory (base)`` =
+                        { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let employeepayhistory =
+            leftTable<``employeepayhistory (base)``, employeepayhistory>
+
+        type private ``jobcandidate (base)`` = jobcandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type jobcandidate =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Xml")>]
+              resume: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``jobcandidate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``jobcandidate (base)`` option =
+                match this.jobcandidateid with
+                | Some value ->
+                    let record: ``jobcandidate (base)`` =
+                        { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let jobcandidate = leftTable<``jobcandidate (base)``, jobcandidate>
+
+        type private ``shift (base)`` = shift
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shift =
+            { [<ProviderDbType("Integer")>]
+              shiftid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Time")>]
+              starttime: Option<System.TimeOnly>
+              [<ProviderDbType("Time")>]
+              endtime: Option<System.TimeOnly>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shift (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shift (base)`` option =
+                match this.shiftid with
+                | Some value ->
+                    let record: ``shift (base)`` =
+                        { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shift = leftTable<``shift (base)``, shift>
+
+        type private ``vemployee (base)`` = vemployee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployee =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string> }
+
+            interface ILeftViewOf<``vemployee (base)``>
+
+        let vemployee = leftTable<``vemployee (base)``, vemployee>
+
+        type private ``vemployeedepartment (base)`` = vemployeedepartment
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployeedepartment =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              department: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly> }
+
+            interface ILeftViewOf<``vemployeedepartment (base)``>
+
+        let vemployeedepartment =
+            leftTable<``vemployeedepartment (base)``, vemployeedepartment>
+
+        type private ``vemployeedepartmenthistory (base)`` = vemployeedepartmenthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vemployeedepartmenthistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              shift: Option<string>
+              [<ProviderDbType("Varchar")>]
+              department: Option<string>
+              [<ProviderDbType("Varchar")>]
+              groupname: Option<string>
+              [<ProviderDbType("Date")>]
+              startdate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              enddate: Option<System.DateOnly> }
+
+            interface ILeftViewOf<``vemployeedepartmenthistory (base)``>
+
+        let vemployeedepartmenthistory =
+            leftTable<``vemployeedepartmenthistory (base)``, vemployeedepartmenthistory>
+
+        type private ``vjobcandidate (base)`` = vjobcandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidate =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Prefix``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.First``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Middle``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Last``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Name.Suffix``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Skills: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.Loc.City``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Addr.PostalCode``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              EMail: Option<string>
+              [<ProviderDbType("Varchar")>]
+              WebSite: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vjobcandidate (base)``>
+
+        let vjobcandidate = leftTable<``vjobcandidate (base)``, vjobcandidate>
+
+        type private ``vjobcandidateeducation (base)`` = vjobcandidateeducation
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidateeducation =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Level``: Option<string>
+              [<ProviderDbType("Date")>]
+              ``Edu.StartDate``: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              ``Edu.EndDate``: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Degree``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Major``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Minor``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.GPA``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.GPAScale``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.School``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Edu.Loc.City``: Option<string> }
+
+            interface ILeftViewOf<``vjobcandidateeducation (base)``>
+
+        let vjobcandidateeducation =
+            leftTable<``vjobcandidateeducation (base)``, vjobcandidateeducation>
+
+        type private ``vjobcandidateemployment (base)`` = vjobcandidateemployment
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vjobcandidateemployment =
+            { [<ProviderDbType("Integer")>]
+              jobcandidateid: Option<int>
+              [<ProviderDbType("Date")>]
+              ``Emp.StartDate``: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              ``Emp.EndDate``: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.OrgName``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.JobTitle``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Responsibility``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.FunctionCategory``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.IndustryCategory``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.CountryRegion``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.State``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              ``Emp.Loc.City``: Option<string> }
+
+            interface ILeftViewOf<``vjobcandidateemployment (base)``>
+
+        let vjobcandidateemployment =
+            leftTable<``vjobcandidateemployment (base)``, vjobcandidateemployment>
+
+
 module network_sample =
 
     [<CLIMutable>]
@@ -538,6 +1056,40 @@ module network_sample =
                   { WriteColumn.Name = "net_macaddr8"; Value = box this.net_macaddr8; ProviderDbType = Some "MacAddr8" } ]
 
     let network_addresses = table<network_addresses>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``network_addresses (base)`` = network_addresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type network_addresses =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Cidr")>]
+              net_cidr: Option<System.Net.IPNetwork>
+              [<ProviderDbType("Inet")>]
+              net_inet: Option<System.Net.IPAddress>
+              [<ProviderDbType("MacAddr")>]
+              net_macaddr: Option<System.Net.NetworkInformation.PhysicalAddress>
+              [<ProviderDbType("MacAddr8")>]
+              net_macaddr8: Option<System.Net.NetworkInformation.PhysicalAddress> }
+
+            interface ILeftViewOf<``network_addresses (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``network_addresses (base)`` option =
+                match this.id with
+                | Some value ->
+                    let record: ``network_addresses (base)`` =
+                        { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
+
+                    Some record
+                | None -> None
+
+        let network_addresses = leftTable<``network_addresses (base)``, network_addresses>
+
 
 module pe =
 
@@ -890,6 +1442,334 @@ module pe =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let sp = table<sp>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``a (base)`` = a
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type a =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              spatiallocation: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``a (base)``>
+
+        let a = leftTable<``a (base)``, a>
+
+        type private ``at (base)`` = at
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type at =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``at (base)``>
+
+        let at = leftTable<``at (base)``, at>
+
+        type private ``be (base)`` = be
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type be =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``be (base)``>
+
+        let be = leftTable<``be (base)``, be>
+
+        type private ``bea (base)`` = bea
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bea =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bea (base)``>
+
+        let bea = leftTable<``bea (base)``, bea>
+
+        type private ``bec (base)`` = bec
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bec =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bec (base)``>
+
+        let bec = leftTable<``bec (base)``, bec>
+
+        type private ``cr (base)`` = cr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cr =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cr (base)``>
+
+        let cr = leftTable<``cr (base)``, cr>
+
+        type private ``ct (base)`` = ct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ct =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ct (base)``>
+
+        let ct = leftTable<``ct (base)``, ct>
+
+        type private ``e (base)`` = e
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type e =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              emailaddressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``e (base)``>
+
+        let e = leftTable<``e (base)``, e>
+
+        type private ``p (base)`` = p
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type p =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Char")>]
+              persontype: Option<string>
+              [<ProviderDbType("Boolean")>]
+              namestyle: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``p (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``p (base)`` option =
+                match this.namestyle with
+                | Some value ->
+                    let record: ``p (base)`` =
+                        { id = this.id
+                          businessentityid = this.businessentityid
+                          persontype = this.persontype
+                          namestyle = value
+                          title = this.title
+                          firstname = this.firstname
+                          middlename = this.middlename
+                          lastname = this.lastname
+                          suffix = this.suffix
+                          emailpromotion = this.emailpromotion
+                          additionalcontactinfo = this.additionalcontactinfo
+                          demographics = this.demographics
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let p = leftTable<``p (base)``, p>
+
+        type private ``pa (base)`` = pa
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pa =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              passwordhash: Option<string>
+              [<ProviderDbType("Varchar")>]
+              passwordsalt: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pa (base)``>
+
+        let pa = leftTable<``pa (base)``, pa>
+
+        type private ``pnt (base)`` = pnt
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pnt =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pnt (base)``>
+
+        let pnt = leftTable<``pnt (base)``, pnt>
+
+        type private ``pp (base)`` = pp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pp (base)``>
+
+        let pp = leftTable<``pp (base)``, pp>
+
+        type private ``sp (base)`` = sp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Char")>]
+              stateprovincecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Boolean")>]
+              isonlystateprovinceflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sp (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``sp (base)`` option =
+                match this.isonlystateprovinceflag with
+                | Some value ->
+                    let record: ``sp (base)`` =
+                        { id = this.id
+                          stateprovinceid = this.stateprovinceid
+                          stateprovincecode = this.stateprovincecode
+                          countryregioncode = this.countryregioncode
+                          isonlystateprovinceflag = value
+                          name = this.name
+                          territoryid = this.territoryid
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let sp = leftTable<``sp (base)``, sp>
+
 
 module person =
 
@@ -1288,6 +2168,507 @@ module person =
                   { WriteColumn.Name = "countryregionname"; Value = box this.countryregionname; ProviderDbType = Some "Name" } ]
 
     let vstateprovincecountryregion = table<vstateprovincecountryregion>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``address (base)`` = address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type address =
+            { [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              spatiallocation: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``address (base)`` option =
+                match this.addressid with
+                | Some value ->
+                    let record: ``address (base)`` =
+                        { addressid = value
+                          addressline1 = this.addressline1.Value
+                          addressline2 = this.addressline2
+                          city = this.city.Value
+                          stateprovinceid = this.stateprovinceid.Value
+                          postalcode = this.postalcode.Value
+                          spatiallocation = this.spatiallocation
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let address = leftTable<``address (base)``, address>
+
+        type private ``addresstype (base)`` = addresstype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type addresstype =
+            { [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``addresstype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``addresstype (base)`` option =
+                match this.addresstypeid with
+                | Some value ->
+                    let record: ``addresstype (base)`` =
+                        { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let addresstype = leftTable<``addresstype (base)``, addresstype>
+
+        type private ``businessentity (base)`` = businessentity
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentity =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentity (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentity (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentity (base)`` =
+                        { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentity = leftTable<``businessentity (base)``, businessentity>
+
+        type private ``businessentityaddress (base)`` = businessentityaddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentityaddress =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              addresstypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentityaddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentityaddress (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentityaddress (base)`` =
+                        { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentityaddress =
+            leftTable<``businessentityaddress (base)``, businessentityaddress>
+
+        type private ``businessentitycontact (base)`` = businessentitycontact
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type businessentitycontact =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``businessentitycontact (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``businessentitycontact (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``businessentitycontact (base)`` =
+                        { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let businessentitycontact =
+            leftTable<``businessentitycontact (base)``, businessentitycontact>
+
+        type private ``contacttype (base)`` = contacttype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type contacttype =
+            { [<ProviderDbType("Integer")>]
+              contacttypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``contacttype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``contacttype (base)`` option =
+                match this.contacttypeid with
+                | Some value ->
+                    let record: ``contacttype (base)`` =
+                        { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let contacttype = leftTable<``contacttype (base)``, contacttype>
+
+        type private ``countryregion (base)`` = countryregion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type countryregion =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``countryregion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``countryregion (base)`` option =
+                match this.countryregioncode with
+                | Some value ->
+                    let record: ``countryregion (base)`` =
+                        { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let countryregion = leftTable<``countryregion (base)``, countryregion>
+
+        type private ``emailaddress (base)`` = emailaddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type emailaddress =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              emailaddressid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``emailaddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``emailaddress (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``emailaddress (base)`` =
+                        { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let emailaddress = leftTable<``emailaddress (base)``, emailaddress>
+
+        type private ``password (base)`` = password
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type password =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              passwordhash: Option<string>
+              [<ProviderDbType("Varchar")>]
+              passwordsalt: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``password (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``password (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``password (base)`` =
+                        { businessentityid = value
+                          passwordhash = this.passwordhash.Value
+                          passwordsalt = this.passwordsalt.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let password = leftTable<``password (base)``, password>
+
+        type private ``person (base)`` = person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type person =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Char")>]
+              persontype: Option<string>
+              [<ProviderDbType("Boolean")>]
+              namestyle: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Xml")>]
+              additionalcontactinfo: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``person (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``person (base)`` =
+                        { businessentityid = value
+                          persontype = this.persontype.Value
+                          namestyle = this.namestyle.Value
+                          title = this.title
+                          firstname = this.firstname.Value
+                          middlename = this.middlename
+                          lastname = this.lastname.Value
+                          suffix = this.suffix
+                          emailpromotion = this.emailpromotion.Value
+                          additionalcontactinfo = this.additionalcontactinfo
+                          demographics = this.demographics
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let person = leftTable<``person (base)``, person>
+
+        type private ``personphone (base)`` = personphone
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type personphone =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``personphone (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``personphone (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``personphone (base)`` =
+                        { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let personphone = leftTable<``personphone (base)``, personphone>
+
+        type private ``phonenumbertype (base)`` = phonenumbertype
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type phonenumbertype =
+            { [<ProviderDbType("Integer")>]
+              phonenumbertypeid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``phonenumbertype (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``phonenumbertype (base)`` option =
+                match this.phonenumbertypeid with
+                | Some value ->
+                    let record: ``phonenumbertype (base)`` =
+                        { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let phonenumbertype = leftTable<``phonenumbertype (base)``, phonenumbertype>
+
+        type private ``stateprovince (base)`` = stateprovince
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type stateprovince =
+            { [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Char")>]
+              stateprovincecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Boolean")>]
+              isonlystateprovinceflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``stateprovince (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``stateprovince (base)`` option =
+                match this.stateprovinceid with
+                | Some value ->
+                    let record: ``stateprovince (base)`` =
+                        { stateprovinceid = value
+                          stateprovincecode = this.stateprovincecode.Value
+                          countryregioncode = this.countryregioncode.Value
+                          isonlystateprovinceflag = this.isonlystateprovinceflag.Value
+                          name = this.name.Value
+                          territoryid = this.territoryid.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let stateprovince = leftTable<``stateprovince (base)``, stateprovince>
+
+        type private ``vadditionalcontactinfo (base)`` = vadditionalcontactinfo
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vadditionalcontactinfo =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Xml")>]
+              telephonenumber: Option<string>
+              [<ProviderDbType("Text")>]
+              telephonespecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              street: Option<string>
+              [<ProviderDbType("Xml")>]
+              city: Option<string>
+              [<ProviderDbType("Xml")>]
+              stateprovince: Option<string>
+              [<ProviderDbType("Xml")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Xml")>]
+              countryregion: Option<string>
+              [<ProviderDbType("Xml")>]
+              homeaddressspecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Text")>]
+              emailspecialinstructions: Option<string>
+              [<ProviderDbType("Xml")>]
+              emailtelephonenumber: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vadditionalcontactinfo (base)``>
+
+        let vadditionalcontactinfo =
+            leftTable<``vadditionalcontactinfo (base)``, vadditionalcontactinfo>
+
+        type private ``vstateprovincecountryregion (base)`` = vstateprovincecountryregion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstateprovincecountryregion =
+            { [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Name")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Name")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vstateprovincecountryregion (base)``>
+
+        let vstateprovincecountryregion =
+            leftTable<``vstateprovincecountryregion (base)``, vstateprovincecountryregion>
+
 
 module pr =
 
@@ -2054,6 +3435,681 @@ module pr =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let wr = table<wr>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``bom (base)`` = bom
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type bom =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              billofmaterialsid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productassemblyid: Option<int>
+              [<ProviderDbType("Integer")>]
+              componentid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bomlevel: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              perassemblyqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``bom (base)``>
+
+        let bom = leftTable<``bom (base)``, bom>
+
+        type private ``c (base)`` = c
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type c =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``c (base)``>
+
+        let c = leftTable<``c (base)``, c>
+
+        type private ``d (base)`` = d
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type d =
+            { [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Integer")>]
+              owner: Option<int>
+              [<ProviderDbType("Boolean")>]
+              folderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              filename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              fileextension: Option<string>
+              [<ProviderDbType("Char")>]
+              revision: Option<string>
+              [<ProviderDbType("Integer")>]
+              changenumber: Option<int>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Text")>]
+              documentsummary: Option<string>
+              [<ProviderDbType("Bytea")>]
+              document: Option<byte[]>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``d (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``d (base)`` option =
+                match this.folderflag with
+                | Some value ->
+                    let record: ``d (base)`` =
+                        { title = this.title
+                          owner = this.owner
+                          folderflag = value
+                          filename = this.filename
+                          fileextension = this.fileextension
+                          revision = this.revision
+                          changenumber = this.changenumber
+                          status = this.status
+                          documentsummary = this.documentsummary
+                          document = this.document
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate
+                          documentnode = this.documentnode }
+
+                    Some record
+                | None -> None
+
+        let d = leftTable<``d (base)``, d>
+
+        type private ``i (base)`` = i
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type i =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Xml")>]
+              diagram: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``i (base)``>
+
+        let i = leftTable<``i (base)``, i>
+
+        type private ``l (base)`` = l
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type l =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              locationid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              costrate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              availability: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``l (base)``>
+
+        let l = leftTable<``l (base)``, l>
+
+        type private ``p (base)`` = p
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type p =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productnumber: Option<string>
+              [<ProviderDbType("Boolean")>]
+              makeflag: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              finishedgoodsflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Smallint")>]
+              safetystocklevel: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              reorderpoint: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              size: Option<string>
+              [<ProviderDbType("Char")>]
+              sizeunitmeasurecode: Option<string>
+              [<ProviderDbType("Char")>]
+              weightunitmeasurecode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              weight: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              daystomanufacture: Option<int>
+              [<ProviderDbType("Char")>]
+              productline: Option<string>
+              [<ProviderDbType("Char")>]
+              ``class``: Option<string>
+              [<ProviderDbType("Char")>]
+              style: Option<string>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              sellstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              sellenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              discontinueddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``p (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``p (base)`` option =
+                match this.makeflag with
+                | Some value ->
+                    let record: ``p (base)`` =
+                        { id = this.id
+                          productid = this.productid
+                          name = this.name
+                          productnumber = this.productnumber
+                          makeflag = value
+                          finishedgoodsflag = this.finishedgoodsflag.Value
+                          color = this.color
+                          safetystocklevel = this.safetystocklevel
+                          reorderpoint = this.reorderpoint
+                          standardcost = this.standardcost
+                          listprice = this.listprice
+                          size = this.size
+                          sizeunitmeasurecode = this.sizeunitmeasurecode
+                          weightunitmeasurecode = this.weightunitmeasurecode
+                          weight = this.weight
+                          daystomanufacture = this.daystomanufacture
+                          productline = this.productline
+                          ``class`` = this.``class``
+                          style = this.style
+                          productsubcategoryid = this.productsubcategoryid
+                          productmodelid = this.productmodelid
+                          sellstartdate = this.sellstartdate
+                          sellenddate = this.sellenddate
+                          discontinueddate = this.discontinueddate
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let p = leftTable<``p (base)``, p>
+
+        type private ``pc (base)`` = pc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pc (base)``>
+
+        let pc = leftTable<``pc (base)``, pc>
+
+        type private ``pch (base)`` = pch
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pch =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pch (base)``>
+
+        let pch = leftTable<``pch (base)``, pch>
+
+        type private ``pd (base)`` = pd
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pd =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pd (base)``>
+
+        let pd = leftTable<``pd (base)``, pd>
+
+        type private ``pdoc (base)`` = pdoc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pdoc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``pdoc (base)``>
+
+        let pdoc = leftTable<``pdoc (base)``, pdoc>
+
+        type private ``pi (base)`` = pi
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pi =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Varchar")>]
+              shelf: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bin: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              quantity: Option<int16>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pi (base)``>
+
+        let pi = leftTable<``pi (base)``, pi>
+
+        type private ``plph (base)`` = plph
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type plph =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``plph (base)``>
+
+        let plph = leftTable<``plph (base)``, plph>
+
+        type private ``pm (base)`` = pm
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pm =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Xml")>]
+              catalogdescription: Option<string>
+              [<ProviderDbType("Xml")>]
+              instructions: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pm (base)``>
+
+        let pm = leftTable<``pm (base)``, pm>
+
+        type private ``pmi (base)`` = pmi
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pmi =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pmi (base)``>
+
+        let pmi = leftTable<``pmi (base)``, pmi>
+
+        type private ``pmpdc (base)`` = pmpdc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pmpdc =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pmpdc (base)``>
+
+        let pmpdc = leftTable<``pmpdc (base)``, pmpdc>
+
+        type private ``pp (base)`` = pp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Bytea")>]
+              thumbnailphoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              thumbnailphotofilename: Option<string>
+              [<ProviderDbType("Bytea")>]
+              largephoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              largephotofilename: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pp (base)``>
+
+        let pp = leftTable<``pp (base)``, pp>
+
+        type private ``ppp (base)`` = ppp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ppp =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Boolean")>]
+              primary: Option<bool>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ppp (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ppp (base)`` option =
+                match this.primary with
+                | Some value ->
+                    let record: ``ppp (base)`` =
+                        { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let ppp = leftTable<``ppp (base)``, ppp>
+
+        type private ``pr (base)`` = pr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productreviewid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              reviewername: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              reviewdate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              rating: Option<int>
+              [<ProviderDbType("Varchar")>]
+              comments: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pr (base)``>
+
+        let pr = leftTable<``pr (base)``, pr>
+
+        type private ``psc (base)`` = psc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type psc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``psc (base)``>
+
+        let psc = leftTable<``psc (base)``, psc>
+
+        type private ``sr (base)`` = sr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              scrapreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sr (base)``>
+
+        let sr = leftTable<``sr (base)``, sr>
+
+        type private ``th (base)`` = th
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type th =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``th (base)``>
+
+        let th = leftTable<``th (base)``, th>
+
+        type private ``tha (base)`` = tha
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type tha =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``tha (base)``>
+
+        let tha = leftTable<``tha (base)``, tha>
+
+        type private ``um (base)`` = um
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type um =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``um (base)``>
+
+        let um = leftTable<``um (base)``, um>
+
+        type private ``w (base)`` = w
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type w =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              orderqty: Option<int>
+              [<ProviderDbType("Smallint")>]
+              scrappedqty: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              scrapreasonid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``w (base)``>
+
+        let w = leftTable<``w (base)``, w>
+
+        type private ``wr (base)`` = wr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type wr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              operationsequence: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              scheduledstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              scheduledenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualenddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              actualresourcehrs: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              plannedcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``wr (base)``>
+
+        let wr = leftTable<``wr (base)``, wr>
+
 
 module production =
 
@@ -2903,6 +4959,1065 @@ module production =
 
     let workorderrouting = table<workorderrouting>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``billofmaterials (base)`` = billofmaterials
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type billofmaterials =
+            { [<ProviderDbType("Integer")>]
+              billofmaterialsid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productassemblyid: Option<int>
+              [<ProviderDbType("Integer")>]
+              componentid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bomlevel: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              perassemblyqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``billofmaterials (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``billofmaterials (base)`` option =
+                match this.billofmaterialsid with
+                | Some value ->
+                    let record: ``billofmaterials (base)`` =
+                        { billofmaterialsid = value
+                          productassemblyid = this.productassemblyid
+                          componentid = this.componentid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          unitmeasurecode = this.unitmeasurecode.Value
+                          bomlevel = this.bomlevel.Value
+                          perassemblyqty = this.perassemblyqty.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let billofmaterials = leftTable<``billofmaterials (base)``, billofmaterials>
+
+        type private ``culture (base)`` = culture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type culture =
+            { [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``culture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``culture (base)`` option =
+                match this.cultureid with
+                | Some value ->
+                    let record: ``culture (base)`` =
+                        { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let culture = leftTable<``culture (base)``, culture>
+
+        type private ``document (base)`` = document
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type document =
+            { [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Integer")>]
+              owner: Option<int>
+              [<ProviderDbType("Boolean")>]
+              folderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              filename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              fileextension: Option<string>
+              [<ProviderDbType("Char")>]
+              revision: Option<string>
+              [<ProviderDbType("Integer")>]
+              changenumber: Option<int>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Text")>]
+              documentsummary: Option<string>
+              [<ProviderDbType("Bytea")>]
+              document: Option<byte[]>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``document (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``document (base)`` option =
+                match this.documentnode with
+                | Some value ->
+                    let record: ``document (base)`` =
+                        { title = this.title.Value
+                          owner = this.owner.Value
+                          folderflag = this.folderflag.Value
+                          filename = this.filename.Value
+                          fileextension = this.fileextension
+                          revision = this.revision.Value
+                          changenumber = this.changenumber.Value
+                          status = this.status.Value
+                          documentsummary = this.documentsummary
+                          document = this.document
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value
+                          documentnode = value }
+
+                    Some record
+                | None -> None
+
+        let document = leftTable<``document (base)``, document>
+
+        type private ``illustration (base)`` = illustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type illustration =
+            { [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Xml")>]
+              diagram: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``illustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``illustration (base)`` option =
+                match this.illustrationid with
+                | Some value ->
+                    let record: ``illustration (base)`` =
+                        { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let illustration = leftTable<``illustration (base)``, illustration>
+
+        type private ``location (base)`` = location
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type location =
+            { [<ProviderDbType("Integer")>]
+              locationid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              costrate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              availability: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``location (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``location (base)`` option =
+                match this.locationid with
+                | Some value ->
+                    let record: ``location (base)`` =
+                        { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let location = leftTable<``location (base)``, location>
+
+        type private ``product (base)`` = product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type product =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productnumber: Option<string>
+              [<ProviderDbType("Boolean")>]
+              makeflag: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              finishedgoodsflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Smallint")>]
+              safetystocklevel: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              reorderpoint: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              size: Option<string>
+              [<ProviderDbType("Char")>]
+              sizeunitmeasurecode: Option<string>
+              [<ProviderDbType("Char")>]
+              weightunitmeasurecode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              weight: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              daystomanufacture: Option<int>
+              [<ProviderDbType("Char")>]
+              productline: Option<string>
+              [<ProviderDbType("Char")>]
+              ``class``: Option<string>
+              [<ProviderDbType("Char")>]
+              style: Option<string>
+              [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              sellstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              sellenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              discontinueddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``product (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``product (base)`` =
+                        { productid = value
+                          name = this.name.Value
+                          productnumber = this.productnumber.Value
+                          makeflag = this.makeflag.Value
+                          finishedgoodsflag = this.finishedgoodsflag.Value
+                          color = this.color
+                          safetystocklevel = this.safetystocklevel.Value
+                          reorderpoint = this.reorderpoint.Value
+                          standardcost = this.standardcost.Value
+                          listprice = this.listprice.Value
+                          size = this.size
+                          sizeunitmeasurecode = this.sizeunitmeasurecode
+                          weightunitmeasurecode = this.weightunitmeasurecode
+                          weight = this.weight
+                          daystomanufacture = this.daystomanufacture.Value
+                          productline = this.productline
+                          ``class`` = this.``class``
+                          style = this.style
+                          productsubcategoryid = this.productsubcategoryid
+                          productmodelid = this.productmodelid
+                          sellstartdate = this.sellstartdate.Value
+                          sellenddate = this.sellenddate
+                          discontinueddate = this.discontinueddate
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let product = leftTable<``product (base)``, product>
+
+        type private ``productcategory (base)`` = productcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productcategory =
+            { [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productcategory (base)`` option =
+                match this.productcategoryid with
+                | Some value ->
+                    let record: ``productcategory (base)`` =
+                        { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productcategory = leftTable<``productcategory (base)``, productcategory>
+
+        type private ``productcosthistory (base)`` = productcosthistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productcosthistory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              standardcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productcosthistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productcosthistory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productcosthistory (base)`` =
+                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productcosthistory =
+            leftTable<``productcosthistory (base)``, productcosthistory>
+
+        type private ``productdescription (base)`` = productdescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productdescription =
+            { [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productdescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productdescription (base)`` option =
+                match this.productdescriptionid with
+                | Some value ->
+                    let record: ``productdescription (base)`` =
+                        { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productdescription =
+            leftTable<``productdescription (base)``, productdescription>
+
+        type private ``productdocument (base)`` = productdocument
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productdocument =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              documentnode: Option<string> }
+
+            interface ILeftViewOf<``productdocument (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productdocument (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productdocument (base)`` =
+                        { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
+
+                    Some record
+                | None -> None
+
+        let productdocument = leftTable<``productdocument (base)``, productdocument>
+
+        type private ``productinventory (base)`` = productinventory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productinventory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Varchar")>]
+              shelf: Option<string>
+              [<ProviderDbType("Smallint")>]
+              bin: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              quantity: Option<int16>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productinventory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productinventory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productinventory (base)`` =
+                        { productid = value
+                          locationid = this.locationid.Value
+                          shelf = this.shelf.Value
+                          bin = this.bin.Value
+                          quantity = this.quantity.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productinventory = leftTable<``productinventory (base)``, productinventory>
+
+        type private ``productlistpricehistory (base)`` = productlistpricehistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productlistpricehistory =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              listprice: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productlistpricehistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productlistpricehistory (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productlistpricehistory (base)`` =
+                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productlistpricehistory =
+            leftTable<``productlistpricehistory (base)``, productlistpricehistory>
+
+        type private ``productmodel (base)`` = productmodel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodel =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Xml")>]
+              catalogdescription: Option<string>
+              [<ProviderDbType("Xml")>]
+              instructions: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodel (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodel (base)`` =
+                        { productmodelid = value
+                          name = this.name.Value
+                          catalogdescription = this.catalogdescription
+                          instructions = this.instructions
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodel = leftTable<``productmodel (base)``, productmodel>
+
+        type private ``productmodelillustration (base)`` = productmodelillustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodelillustration =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              illustrationid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodelillustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodelillustration (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodelillustration (base)`` =
+                        { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodelillustration =
+            leftTable<``productmodelillustration (base)``, productmodelillustration>
+
+        type private ``productmodelproductdescriptionculture (base)`` = productmodelproductdescriptionculture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productmodelproductdescriptionculture =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productdescriptionid: Option<int>
+              [<ProviderDbType("Char")>]
+              cultureid: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productmodelproductdescriptionculture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productmodelproductdescriptionculture (base)`` option =
+                match this.productmodelid with
+                | Some value ->
+                    let record: ``productmodelproductdescriptionculture (base)`` =
+                        { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productmodelproductdescriptionculture =
+            leftTable<``productmodelproductdescriptionculture (base)``, productmodelproductdescriptionculture>
+
+        type private ``productphoto (base)`` = productphoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productphoto =
+            { [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Bytea")>]
+              thumbnailphoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              thumbnailphotofilename: Option<string>
+              [<ProviderDbType("Bytea")>]
+              largephoto: Option<byte[]>
+              [<ProviderDbType("Varchar")>]
+              largephotofilename: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productphoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productphoto (base)`` option =
+                match this.productphotoid with
+                | Some value ->
+                    let record: ``productphoto (base)`` =
+                        { productphotoid = value
+                          thumbnailphoto = this.thumbnailphoto
+                          thumbnailphotofilename = this.thumbnailphotofilename
+                          largephoto = this.largephoto
+                          largephotofilename = this.largephotofilename
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productphoto = leftTable<``productphoto (base)``, productphoto>
+
+        type private ``productproductphoto (base)`` = productproductphoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productproductphoto =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productphotoid: Option<int>
+              [<ProviderDbType("Boolean")>]
+              primary: Option<bool>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productproductphoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productproductphoto (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productproductphoto (base)`` =
+                        { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productproductphoto =
+            leftTable<``productproductphoto (base)``, productproductphoto>
+
+        type private ``productreview (base)`` = productreview
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productreview =
+            { [<ProviderDbType("Integer")>]
+              productreviewid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              reviewername: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              reviewdate: Option<System.DateTime>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              rating: Option<int>
+              [<ProviderDbType("Varchar")>]
+              comments: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productreview (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productreview (base)`` option =
+                match this.productreviewid with
+                | Some value ->
+                    let record: ``productreview (base)`` =
+                        { productreviewid = value
+                          productid = this.productid.Value
+                          reviewername = this.reviewername.Value
+                          reviewdate = this.reviewdate.Value
+                          emailaddress = this.emailaddress.Value
+                          rating = this.rating.Value
+                          comments = this.comments
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productreview = leftTable<``productreview (base)``, productreview>
+
+        type private ``productsubcategory (base)`` = productsubcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productsubcategory =
+            { [<ProviderDbType("Integer")>]
+              productsubcategoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productcategoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productsubcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productsubcategory (base)`` option =
+                match this.productsubcategoryid with
+                | Some value ->
+                    let record: ``productsubcategory (base)`` =
+                        { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productsubcategory =
+            leftTable<``productsubcategory (base)``, productsubcategory>
+
+        type private ``scrapreason (base)`` = scrapreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type scrapreason =
+            { [<ProviderDbType("Integer")>]
+              scrapreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``scrapreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``scrapreason (base)`` option =
+                match this.scrapreasonid with
+                | Some value ->
+                    let record: ``scrapreason (base)`` =
+                        { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let scrapreason = leftTable<``scrapreason (base)``, scrapreason>
+
+        type private ``transactionhistory (base)`` = transactionhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type transactionhistory =
+            { [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``transactionhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``transactionhistory (base)`` option =
+                match this.transactionid with
+                | Some value ->
+                    let record: ``transactionhistory (base)`` =
+                        { transactionid = value
+                          productid = this.productid.Value
+                          referenceorderid = this.referenceorderid.Value
+                          referenceorderlineid = this.referenceorderlineid.Value
+                          transactiondate = this.transactiondate.Value
+                          transactiontype = this.transactiontype.Value
+                          quantity = this.quantity.Value
+                          actualcost = this.actualcost.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let transactionhistory =
+            leftTable<``transactionhistory (base)``, transactionhistory>
+
+        type private ``transactionhistoryarchive (base)`` = transactionhistoryarchive
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type transactionhistoryarchive =
+            { [<ProviderDbType("Integer")>]
+              transactionid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              referenceorderlineid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              transactiondate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              transactiontype: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``transactionhistoryarchive (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``transactionhistoryarchive (base)`` option =
+                match this.transactionid with
+                | Some value ->
+                    let record: ``transactionhistoryarchive (base)`` =
+                        { transactionid = value
+                          productid = this.productid.Value
+                          referenceorderid = this.referenceorderid.Value
+                          referenceorderlineid = this.referenceorderlineid.Value
+                          transactiondate = this.transactiondate.Value
+                          transactiontype = this.transactiontype.Value
+                          quantity = this.quantity.Value
+                          actualcost = this.actualcost.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let transactionhistoryarchive =
+            leftTable<``transactionhistoryarchive (base)``, transactionhistoryarchive>
+
+        type private ``unitmeasure (base)`` = unitmeasure
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type unitmeasure =
+            { [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``unitmeasure (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``unitmeasure (base)`` option =
+                match this.unitmeasurecode with
+                | Some value ->
+                    let record: ``unitmeasure (base)`` =
+                        { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let unitmeasure = leftTable<``unitmeasure (base)``, unitmeasure>
+
+        type private ``vproductanddescription (base)`` = vproductanddescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductanddescription =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Name")>]
+              name: Option<string>
+              [<ProviderDbType("Name")>]
+              productmodel: Option<string>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string> }
+
+            interface ILeftViewOf<``vproductanddescription (base)``>
+
+        let vproductanddescription =
+            leftTable<``vproductanddescription (base)``, vproductanddescription>
+
+        type private ``vproductmodelcatalogdescription (base)`` = vproductmodelcatalogdescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductmodelcatalogdescription =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Summary: Option<string>
+              [<ProviderDbType("Varchar")>]
+              manufacturer: Option<string>
+              [<ProviderDbType("Varchar")>]
+              copyright: Option<string>
+              [<ProviderDbType("Varchar")>]
+              producturl: Option<string>
+              [<ProviderDbType("Varchar")>]
+              warrantyperiod: Option<string>
+              [<ProviderDbType("Varchar")>]
+              warrantydescription: Option<string>
+              [<ProviderDbType("Varchar")>]
+              noofyears: Option<string>
+              [<ProviderDbType("Varchar")>]
+              maintenancedescription: Option<string>
+              [<ProviderDbType("Varchar")>]
+              wheel: Option<string>
+              [<ProviderDbType("Varchar")>]
+              saddle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              pedal: Option<string>
+              [<ProviderDbType("Varchar")>]
+              bikeframe: Option<string>
+              [<ProviderDbType("Varchar")>]
+              crankset: Option<string>
+              [<ProviderDbType("Varchar")>]
+              pictureangle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              picturesize: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productphotoid: Option<string>
+              [<ProviderDbType("Varchar")>]
+              material: Option<string>
+              [<ProviderDbType("Varchar")>]
+              color: Option<string>
+              [<ProviderDbType("Varchar")>]
+              productline: Option<string>
+              [<ProviderDbType("Varchar")>]
+              style: Option<string>
+              [<ProviderDbType("Varchar")>]
+              riderexperience: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vproductmodelcatalogdescription (base)``>
+
+        let vproductmodelcatalogdescription =
+            leftTable<``vproductmodelcatalogdescription (base)``, vproductmodelcatalogdescription>
+
+        type private ``vproductmodelinstructions (base)`` = vproductmodelinstructions
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vproductmodelinstructions =
+            { [<ProviderDbType("Integer")>]
+              productmodelid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              instructions: Option<string>
+              [<ProviderDbType("Integer")>]
+              LocationID: Option<int>
+              [<ProviderDbType("Numeric")>]
+              SetupHours: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              MachineHours: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              LaborHours: Option<decimal>
+              [<ProviderDbType("Integer")>]
+              LotSize: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Step: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vproductmodelinstructions (base)``>
+
+        let vproductmodelinstructions =
+            leftTable<``vproductmodelinstructions (base)``, vproductmodelinstructions>
+
+        type private ``workorder (base)`` = workorder
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type workorder =
+            { [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              orderqty: Option<int>
+              [<ProviderDbType("Smallint")>]
+              scrappedqty: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              scrapreasonid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``workorder (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``workorder (base)`` option =
+                match this.workorderid with
+                | Some value ->
+                    let record: ``workorder (base)`` =
+                        { workorderid = value
+                          productid = this.productid.Value
+                          orderqty = this.orderqty.Value
+                          scrappedqty = this.scrappedqty.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          duedate = this.duedate.Value
+                          scrapreasonid = this.scrapreasonid
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let workorder = leftTable<``workorder (base)``, workorder>
+
+        type private ``workorderrouting (base)`` = workorderrouting
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type workorderrouting =
+            { [<ProviderDbType("Integer")>]
+              workorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              operationsequence: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              locationid: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              scheduledstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              scheduledenddate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualstartdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              actualenddate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              actualresourcehrs: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              plannedcost: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              actualcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``workorderrouting (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``workorderrouting (base)`` option =
+                match this.workorderid with
+                | Some value ->
+                    let record: ``workorderrouting (base)`` =
+                        { workorderid = value
+                          productid = this.productid.Value
+                          operationsequence = this.operationsequence.Value
+                          locationid = this.locationid.Value
+                          scheduledstartdate = this.scheduledstartdate.Value
+                          scheduledenddate = this.scheduledenddate.Value
+                          actualstartdate = this.actualstartdate
+                          actualenddate = this.actualenddate
+                          actualresourcehrs = this.actualresourcehrs
+                          plannedcost = this.plannedcost.Value
+                          actualcost = this.actualcost
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let workorderrouting = leftTable<``workorderrouting (base)``, workorderrouting>
+
+
 module pu =
 
     [<CLIMutable>]
@@ -3097,6 +6212,176 @@ module pu =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let v = table<v>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``pod (base)`` = pod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pod =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderdetailid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              receivedqty: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              rejectedqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pod (base)``>
+
+        let pod = leftTable<``pod (base)``, pod>
+
+        type private ``poh (base)`` = poh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type poh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Integer")>]
+              employeeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              vendorid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``poh (base)``>
+
+        let poh = leftTable<``poh (base)``, poh>
+
+        type private ``pv (base)`` = pv
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pv =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              averageleadtime: Option<int>
+              [<ProviderDbType("Numeric")>]
+              standardprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              lastreceiptcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              lastreceiptdate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              onorderqty: Option<int>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pv (base)``>
+
+        let pv = leftTable<``pv (base)``, pv>
+
+        type private ``sm (base)`` = sm
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sm =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              shipbase: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              shiprate: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sm (base)``>
+
+        let sm = leftTable<``sm (base)``, sm>
+
+        type private ``v (base)`` = v
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type v =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Smallint")>]
+              creditrating: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              preferredvendorstatus: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              activeflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchasingwebserviceurl: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``v (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``v (base)`` option =
+                match this.preferredvendorstatus with
+                | Some value ->
+                    let record: ``v (base)`` =
+                        { id = this.id
+                          businessentityid = this.businessentityid
+                          accountnumber = this.accountnumber
+                          name = this.name
+                          creditrating = this.creditrating
+                          preferredvendorstatus = value
+                          activeflag = this.activeflag.Value
+                          purchasingwebserviceurl = this.purchasingwebserviceurl
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let v = leftTable<``v (base)``, v>
+
 
 module purchasing =
 
@@ -3356,6 +6641,307 @@ module purchasing =
                   { WriteColumn.Name = "emailpromotion"; Value = box this.emailpromotion; ProviderDbType = Some "Integer" } ]
 
     let vvendorwithcontacts = table<vvendorwithcontacts>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``productvendor (base)`` = productvendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type productvendor =
+            { [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              averageleadtime: Option<int>
+              [<ProviderDbType("Numeric")>]
+              standardprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              lastreceiptcost: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              lastreceiptdate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxorderqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              onorderqty: Option<int>
+              [<ProviderDbType("Char")>]
+              unitmeasurecode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``productvendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``productvendor (base)`` option =
+                match this.productid with
+                | Some value ->
+                    let record: ``productvendor (base)`` =
+                        { productid = value
+                          businessentityid = this.businessentityid.Value
+                          averageleadtime = this.averageleadtime.Value
+                          standardprice = this.standardprice.Value
+                          lastreceiptcost = this.lastreceiptcost
+                          lastreceiptdate = this.lastreceiptdate
+                          minorderqty = this.minorderqty.Value
+                          maxorderqty = this.maxorderqty.Value
+                          onorderqty = this.onorderqty
+                          unitmeasurecode = this.unitmeasurecode.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let productvendor = leftTable<``productvendor (base)``, productvendor>
+
+        type private ``purchaseorderdetail (base)`` = purchaseorderdetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type purchaseorderdetail =
+            { [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              purchaseorderdetailid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              receivedqty: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              rejectedqty: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``purchaseorderdetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``purchaseorderdetail (base)`` option =
+                match this.purchaseorderid with
+                | Some value ->
+                    let record: ``purchaseorderdetail (base)`` =
+                        { purchaseorderid = value
+                          purchaseorderdetailid = this.purchaseorderdetailid.Value
+                          duedate = this.duedate.Value
+                          orderqty = this.orderqty.Value
+                          productid = this.productid.Value
+                          unitprice = this.unitprice.Value
+                          receivedqty = this.receivedqty.Value
+                          rejectedqty = this.rejectedqty.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let purchaseorderdetail =
+            leftTable<``purchaseorderdetail (base)``, purchaseorderdetail>
+
+        type private ``purchaseorderheader (base)`` = purchaseorderheader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type purchaseorderheader =
+            { [<ProviderDbType("Integer")>]
+              purchaseorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Integer")>]
+              employeeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              vendorid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``purchaseorderheader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``purchaseorderheader (base)`` option =
+                match this.purchaseorderid with
+                | Some value ->
+                    let record: ``purchaseorderheader (base)`` =
+                        { purchaseorderid = value
+                          revisionnumber = this.revisionnumber.Value
+                          status = this.status.Value
+                          employeeid = this.employeeid.Value
+                          vendorid = this.vendorid.Value
+                          shipmethodid = this.shipmethodid.Value
+                          orderdate = this.orderdate.Value
+                          shipdate = this.shipdate
+                          subtotal = this.subtotal.Value
+                          taxamt = this.taxamt.Value
+                          freight = this.freight.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let purchaseorderheader =
+            leftTable<``purchaseorderheader (base)``, purchaseorderheader>
+
+        type private ``shipmethod (base)`` = shipmethod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shipmethod =
+            { [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Numeric")>]
+              shipbase: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              shiprate: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shipmethod (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shipmethod (base)`` option =
+                match this.shipmethodid with
+                | Some value ->
+                    let record: ``shipmethod (base)`` =
+                        { shipmethodid = value
+                          name = this.name.Value
+                          shipbase = this.shipbase.Value
+                          shiprate = this.shiprate.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shipmethod = leftTable<``shipmethod (base)``, shipmethod>
+
+        type private ``vendor (base)`` = vendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vendor =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Smallint")>]
+              creditrating: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              preferredvendorstatus: Option<bool>
+              [<ProviderDbType("Boolean")>]
+              activeflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchasingwebserviceurl: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``vendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``vendor (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``vendor (base)`` =
+                        { businessentityid = value
+                          accountnumber = this.accountnumber.Value
+                          name = this.name.Value
+                          creditrating = this.creditrating.Value
+                          preferredvendorstatus = this.preferredvendorstatus.Value
+                          activeflag = this.activeflag.Value
+                          purchasingwebserviceurl = this.purchasingwebserviceurl
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let vendor = leftTable<``vendor (base)``, vendor>
+
+        type private ``vvendorwithaddresses (base)`` = vvendorwithaddresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vvendorwithaddresses =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vvendorwithaddresses (base)``>
+
+        let vvendorwithaddresses =
+            leftTable<``vvendorwithaddresses (base)``, vvendorwithaddresses>
+
+        type private ``vvendorwithcontacts (base)`` = vvendorwithcontacts
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vvendorwithcontacts =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              contacttype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int> }
+
+            interface ILeftViewOf<``vvendorwithcontacts (base)``>
+
+        let vvendorwithcontacts =
+            leftTable<``vvendorwithcontacts (base)``, vvendorwithcontacts>
+
 
 module sa =
 
@@ -3960,6 +7546,517 @@ module sa =
                   { WriteColumn.Name = "modifieddate"; Value = box this.modifieddate; ProviderDbType = Some "Timestamp" } ]
 
     let tr = table<tr>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``c (base)`` = c
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type c =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              storeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``c (base)``>
+
+        let c = leftTable<``c (base)``, c>
+
+        type private ``cc (base)`` = cc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              cardtype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              cardnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              expmonth: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              expyear: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cc (base)``>
+
+        let cc = leftTable<``cc (base)``, cc>
+
+        type private ``cr (base)`` = cr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cr =
+            { [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              currencyratedate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              fromcurrencycode: Option<string>
+              [<ProviderDbType("Char")>]
+              tocurrencycode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              averagerate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              endofdayrate: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cr (base)``>
+
+        let cr = leftTable<``cr (base)``, cr>
+
+        type private ``crc (base)`` = crc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type crc =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``crc (base)``>
+
+        let crc = leftTable<``crc (base)``, crc>
+
+        type private ``cu (base)`` = cu
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type cu =
+            { [<ProviderDbType("Char")>]
+              id: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``cu (base)``>
+
+        let cu = leftTable<``cu (base)``, cu>
+
+        type private ``pcc (base)`` = pcc
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type pcc =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``pcc (base)``>
+
+        let pcc = leftTable<``pcc (base)``, pcc>
+
+        type private ``s (base)`` = s
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type s =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``s (base)``>
+
+        let s = leftTable<``s (base)``, s>
+
+        type private ``sci (base)`` = sci
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sci =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              shoppingcartitemid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              shoppingcartid: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              datecreated: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sci (base)``>
+
+        let sci = leftTable<``sci (base)``, sci>
+
+        type private ``so (base)`` = so
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type so =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Numeric")>]
+              discountpct: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              ``type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              category: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxqty: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``so (base)``>
+
+        let so = leftTable<``so (base)``, so>
+
+        type private ``sod (base)`` = sod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sod =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderdetailid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              carriertrackingnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              unitpricediscount: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sod (base)``>
+
+        let sod = leftTable<``sod (base)``, sod>
+
+        type private ``soh (base)`` = soh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type soh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              onlineorderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchaseordernumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              billtoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shiptoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              creditcardapprovalcode: Option<string>
+              [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              totaldue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              comment: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``soh (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``soh (base)`` option =
+                match this.onlineorderflag with
+                | Some value ->
+                    let record: ``soh (base)`` =
+                        { id = this.id
+                          salesorderid = this.salesorderid
+                          revisionnumber = this.revisionnumber
+                          orderdate = this.orderdate
+                          duedate = this.duedate
+                          shipdate = this.shipdate
+                          status = this.status
+                          onlineorderflag = value
+                          purchaseordernumber = this.purchaseordernumber
+                          accountnumber = this.accountnumber
+                          customerid = this.customerid
+                          salespersonid = this.salespersonid
+                          territoryid = this.territoryid
+                          billtoaddressid = this.billtoaddressid
+                          shiptoaddressid = this.shiptoaddressid
+                          shipmethodid = this.shipmethodid
+                          creditcardid = this.creditcardid
+                          creditcardapprovalcode = this.creditcardapprovalcode
+                          currencyrateid = this.currencyrateid
+                          subtotal = this.subtotal
+                          taxamt = this.taxamt
+                          freight = this.freight
+                          totaldue = this.totaldue
+                          comment = this.comment
+                          rowguid = this.rowguid
+                          modifieddate = this.modifieddate }
+
+                    Some record
+                | None -> None
+
+        let soh = leftTable<``soh (base)``, soh>
+
+        type private ``sohsr (base)`` = sohsr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sohsr =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sohsr (base)``>
+
+        let sohsr = leftTable<``sohsr (base)``, sohsr>
+
+        type private ``sop (base)`` = sop
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sop =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sop (base)``>
+
+        let sop = leftTable<``sop (base)``, sop>
+
+        type private ``sp (base)`` = sp
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sp =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              bonus: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              commissionpct: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sp (base)``>
+
+        let sp = leftTable<``sp (base)``, sp>
+
+        type private ``spqh (base)`` = spqh
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type spqh =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              quotadate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``spqh (base)``>
+
+        let spqh = leftTable<``spqh (base)``, spqh>
+
+        type private ``sr (base)`` = sr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              reasontype: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sr (base)``>
+
+        let sr = leftTable<``sr (base)``, sr>
+
+        type private ``st (base)`` = st
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type st =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              group: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costlastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``st (base)``>
+
+        let st = leftTable<``st (base)``, st>
+
+        type private ``sth (base)`` = sth
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type sth =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``sth (base)``>
+
+        let sth = leftTable<``sth (base)``, sth>
+
+        type private ``tr (base)`` = tr
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type tr =
+            { [<ProviderDbType("Integer")>]
+              id: Option<int>
+              [<ProviderDbType("Integer")>]
+              salestaxrateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              taxtype: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              taxrate: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``tr (base)``>
+
+        let tr = leftTable<``tr (base)``, tr>
+
 
 module sales =
 
@@ -4877,6 +8974,1032 @@ module sales =
                   { WriteColumn.Name = "NumberEmployees"; Value = box this.NumberEmployees; ProviderDbType = Some "Integer" } ]
 
     let vstorewithdemographics = table<vstorewithdemographics>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``countryregioncurrency (base)`` = countryregioncurrency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type countryregioncurrency =
+            { [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``countryregioncurrency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``countryregioncurrency (base)`` option =
+                match this.countryregioncode with
+                | Some value ->
+                    let record: ``countryregioncurrency (base)`` =
+                        { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let countryregioncurrency =
+            leftTable<``countryregioncurrency (base)``, countryregioncurrency>
+
+        type private ``creditcard (base)`` = creditcard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type creditcard =
+            { [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              cardtype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              cardnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              expmonth: Option<int16>
+              [<ProviderDbType("Smallint")>]
+              expyear: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``creditcard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``creditcard (base)`` option =
+                match this.creditcardid with
+                | Some value ->
+                    let record: ``creditcard (base)`` =
+                        { creditcardid = value
+                          cardtype = this.cardtype.Value
+                          cardnumber = this.cardnumber.Value
+                          expmonth = this.expmonth.Value
+                          expyear = this.expyear.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let creditcard = leftTable<``creditcard (base)``, creditcard>
+
+        type private ``currency (base)`` = currency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type currency =
+            { [<ProviderDbType("Char")>]
+              currencycode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``currency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``currency (base)`` option =
+                match this.currencycode with
+                | Some value ->
+                    let record: ``currency (base)`` =
+                        { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let currency = leftTable<``currency (base)``, currency>
+
+        type private ``currencyrate (base)`` = currencyrate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type currencyrate =
+            { [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              currencyratedate: Option<System.DateTime>
+              [<ProviderDbType("Char")>]
+              fromcurrencycode: Option<string>
+              [<ProviderDbType("Char")>]
+              tocurrencycode: Option<string>
+              [<ProviderDbType("Numeric")>]
+              averagerate: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              endofdayrate: Option<decimal>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``currencyrate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``currencyrate (base)`` option =
+                match this.currencyrateid with
+                | Some value ->
+                    let record: ``currencyrate (base)`` =
+                        { currencyrateid = value
+                          currencyratedate = this.currencyratedate.Value
+                          fromcurrencycode = this.fromcurrencycode.Value
+                          tocurrencycode = this.tocurrencycode.Value
+                          averagerate = this.averagerate.Value
+                          endofdayrate = this.endofdayrate.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let currencyrate = leftTable<``currencyrate (base)``, currencyrate>
+
+        type private ``customer (base)`` = customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type customer =
+            { [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              personid: Option<int>
+              [<ProviderDbType("Integer")>]
+              storeid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``customer (base)`` option =
+                match this.customerid with
+                | Some value ->
+                    let record: ``customer (base)`` =
+                        { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let customer = leftTable<``customer (base)``, customer>
+
+        type private ``personcreditcard (base)`` = personcreditcard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type personcreditcard =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``personcreditcard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``personcreditcard (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``personcreditcard (base)`` =
+                        { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let personcreditcard = leftTable<``personcreditcard (base)``, personcreditcard>
+
+        type private ``salesorderdetail (base)`` = salesorderdetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderdetail =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesorderdetailid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              carriertrackingnumber: Option<string>
+              [<ProviderDbType("Smallint")>]
+              orderqty: Option<int16>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              unitprice: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              unitpricediscount: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderdetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderdetail (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderdetail (base)`` =
+                        { salesorderid = value
+                          salesorderdetailid = this.salesorderdetailid.Value
+                          carriertrackingnumber = this.carriertrackingnumber
+                          orderqty = this.orderqty.Value
+                          productid = this.productid.Value
+                          specialofferid = this.specialofferid.Value
+                          unitprice = this.unitprice.Value
+                          unitpricediscount = this.unitpricediscount.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderdetail = leftTable<``salesorderdetail (base)``, salesorderdetail>
+
+        type private ``salesorderheader (base)`` = salesorderheader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderheader =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              revisionnumber: Option<int16>
+              [<ProviderDbType("Timestamp")>]
+              orderdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              duedate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              shipdate: Option<System.DateTime>
+              [<ProviderDbType("Smallint")>]
+              status: Option<int16>
+              [<ProviderDbType("Boolean")>]
+              onlineorderflag: Option<bool>
+              [<ProviderDbType("Varchar")>]
+              purchaseordernumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              accountnumber: Option<string>
+              [<ProviderDbType("Integer")>]
+              customerid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Integer")>]
+              billtoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shiptoaddressid: Option<int>
+              [<ProviderDbType("Integer")>]
+              shipmethodid: Option<int>
+              [<ProviderDbType("Integer")>]
+              creditcardid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              creditcardapprovalcode: Option<string>
+              [<ProviderDbType("Integer")>]
+              currencyrateid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              subtotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              taxamt: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              freight: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              totaldue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              comment: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderheader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderheader (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderheader (base)`` =
+                        { salesorderid = value
+                          revisionnumber = this.revisionnumber.Value
+                          orderdate = this.orderdate.Value
+                          duedate = this.duedate.Value
+                          shipdate = this.shipdate
+                          status = this.status.Value
+                          onlineorderflag = this.onlineorderflag.Value
+                          purchaseordernumber = this.purchaseordernumber
+                          accountnumber = this.accountnumber
+                          customerid = this.customerid.Value
+                          salespersonid = this.salespersonid
+                          territoryid = this.territoryid
+                          billtoaddressid = this.billtoaddressid.Value
+                          shiptoaddressid = this.shiptoaddressid.Value
+                          shipmethodid = this.shipmethodid.Value
+                          creditcardid = this.creditcardid
+                          creditcardapprovalcode = this.creditcardapprovalcode
+                          currencyrateid = this.currencyrateid
+                          subtotal = this.subtotal.Value
+                          taxamt = this.taxamt.Value
+                          freight = this.freight.Value
+                          totaldue = this.totaldue
+                          comment = this.comment
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderheader = leftTable<``salesorderheader (base)``, salesorderheader>
+
+        type private ``salesorderheadersalesreason (base)`` = salesorderheadersalesreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesorderheadersalesreason =
+            { [<ProviderDbType("Integer")>]
+              salesorderid: Option<int>
+              [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesorderheadersalesreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesorderheadersalesreason (base)`` option =
+                match this.salesorderid with
+                | Some value ->
+                    let record: ``salesorderheadersalesreason (base)`` =
+                        { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesorderheadersalesreason =
+            leftTable<``salesorderheadersalesreason (base)``, salesorderheadersalesreason>
+
+        type private ``salesperson (base)`` = salesperson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesperson =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              bonus: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              commissionpct: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesperson (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesperson (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salesperson (base)`` =
+                        { businessentityid = value
+                          territoryid = this.territoryid
+                          salesquota = this.salesquota
+                          bonus = this.bonus.Value
+                          commissionpct = this.commissionpct.Value
+                          salesytd = this.salesytd.Value
+                          saleslastyear = this.saleslastyear.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesperson = leftTable<``salesperson (base)``, salesperson>
+
+        type private ``salespersonquotahistory (base)`` = salespersonquotahistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salespersonquotahistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              quotadate: Option<System.DateTime>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salespersonquotahistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salespersonquotahistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salespersonquotahistory (base)`` =
+                        { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salespersonquotahistory =
+            leftTable<``salespersonquotahistory (base)``, salespersonquotahistory>
+
+        type private ``salesreason (base)`` = salesreason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesreason =
+            { [<ProviderDbType("Integer")>]
+              salesreasonid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              reasontype: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesreason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesreason (base)`` option =
+                match this.salesreasonid with
+                | Some value ->
+                    let record: ``salesreason (base)`` =
+                        { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesreason = leftTable<``salesreason (base)``, salesreason>
+
+        type private ``salestaxrate (base)`` = salestaxrate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salestaxrate =
+            { [<ProviderDbType("Integer")>]
+              salestaxrateid: Option<int>
+              [<ProviderDbType("Integer")>]
+              stateprovinceid: Option<int>
+              [<ProviderDbType("Smallint")>]
+              taxtype: Option<int16>
+              [<ProviderDbType("Numeric")>]
+              taxrate: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salestaxrate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salestaxrate (base)`` option =
+                match this.salestaxrateid with
+                | Some value ->
+                    let record: ``salestaxrate (base)`` =
+                        { salestaxrateid = value
+                          stateprovinceid = this.stateprovinceid.Value
+                          taxtype = this.taxtype.Value
+                          taxrate = this.taxrate.Value
+                          name = this.name.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salestaxrate = leftTable<``salestaxrate (base)``, salestaxrate>
+
+        type private ``salesterritory (base)`` = salesterritory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesterritory =
+            { [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregioncode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              group: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              costlastyear: Option<decimal>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesterritory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesterritory (base)`` option =
+                match this.territoryid with
+                | Some value ->
+                    let record: ``salesterritory (base)`` =
+                        { territoryid = value
+                          name = this.name.Value
+                          countryregioncode = this.countryregioncode.Value
+                          group = this.group.Value
+                          salesytd = this.salesytd.Value
+                          saleslastyear = this.saleslastyear.Value
+                          costytd = this.costytd.Value
+                          costlastyear = this.costlastyear.Value
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesterritory = leftTable<``salesterritory (base)``, salesterritory>
+
+        type private ``salesterritoryhistory (base)`` = salesterritoryhistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type salesterritoryhistory =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Integer")>]
+              territoryid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``salesterritoryhistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``salesterritoryhistory (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``salesterritoryhistory (base)`` =
+                        { businessentityid = value
+                          territoryid = this.territoryid.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let salesterritoryhistory =
+            leftTable<``salesterritoryhistory (base)``, salesterritoryhistory>
+
+        type private ``shoppingcartitem (base)`` = shoppingcartitem
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type shoppingcartitem =
+            { [<ProviderDbType("Integer")>]
+              shoppingcartitemid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              shoppingcartid: Option<string>
+              [<ProviderDbType("Integer")>]
+              quantity: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Timestamp")>]
+              datecreated: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``shoppingcartitem (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``shoppingcartitem (base)`` option =
+                match this.shoppingcartitemid with
+                | Some value ->
+                    let record: ``shoppingcartitem (base)`` =
+                        { shoppingcartitemid = value
+                          shoppingcartid = this.shoppingcartid.Value
+                          quantity = this.quantity.Value
+                          productid = this.productid.Value
+                          datecreated = this.datecreated.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let shoppingcartitem = leftTable<``shoppingcartitem (base)``, shoppingcartitem>
+
+        type private ``specialoffer (base)`` = specialoffer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type specialoffer =
+            { [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              description: Option<string>
+              [<ProviderDbType("Numeric")>]
+              discountpct: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              ``type``: Option<string>
+              [<ProviderDbType("Varchar")>]
+              category: Option<string>
+              [<ProviderDbType("Timestamp")>]
+              startdate: Option<System.DateTime>
+              [<ProviderDbType("Timestamp")>]
+              enddate: Option<System.DateTime>
+              [<ProviderDbType("Integer")>]
+              minqty: Option<int>
+              [<ProviderDbType("Integer")>]
+              maxqty: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``specialoffer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``specialoffer (base)`` option =
+                match this.specialofferid with
+                | Some value ->
+                    let record: ``specialoffer (base)`` =
+                        { specialofferid = value
+                          description = this.description.Value
+                          discountpct = this.discountpct.Value
+                          ``type`` = this.``type``.Value
+                          category = this.category.Value
+                          startdate = this.startdate.Value
+                          enddate = this.enddate.Value
+                          minqty = this.minqty.Value
+                          maxqty = this.maxqty
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let specialoffer = leftTable<``specialoffer (base)``, specialoffer>
+
+        type private ``specialofferproduct (base)`` = specialofferproduct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type specialofferproduct =
+            { [<ProviderDbType("Integer")>]
+              specialofferid: Option<int>
+              [<ProviderDbType("Integer")>]
+              productid: Option<int>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``specialofferproduct (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``specialofferproduct (base)`` option =
+                match this.specialofferid with
+                | Some value ->
+                    let record: ``specialofferproduct (base)`` =
+                        { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let specialofferproduct =
+            leftTable<``specialofferproduct (base)``, specialofferproduct>
+
+        type private ``store (base)`` = store
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type store =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string>
+              [<ProviderDbType("Uuid")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("Timestamp")>]
+              modifieddate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``store (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``store (base)`` option =
+                match this.businessentityid with
+                | Some value ->
+                    let record: ``store (base)`` =
+                        { businessentityid = value
+                          name = this.name.Value
+                          salespersonid = this.salespersonid
+                          demographics = this.demographics
+                          rowguid = this.rowguid.Value
+                          modifieddate = this.modifieddate.Value }
+
+                    Some record
+                | None -> None
+
+        let store = leftTable<``store (base)``, store>
+
+        type private ``vindividualcustomer (base)`` = vindividualcustomer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vindividualcustomer =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Xml")>]
+              demographics: Option<string> }
+
+            interface ILeftViewOf<``vindividualcustomer (base)``>
+
+        let vindividualcustomer =
+            leftTable<``vindividualcustomer (base)``, vindividualcustomer>
+
+        type private ``vpersondemographics (base)`` = vpersondemographics
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vpersondemographics =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Money")>]
+              totalpurchaseytd: Option<decimal>
+              [<ProviderDbType("Date")>]
+              datefirstpurchase: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              birthdate: Option<System.DateOnly>
+              [<ProviderDbType("Varchar")>]
+              maritalstatus: Option<string>
+              [<ProviderDbType("Varchar")>]
+              yearlyincome: Option<string>
+              [<ProviderDbType("Varchar")>]
+              gender: Option<string>
+              [<ProviderDbType("Integer")>]
+              totalchildren: Option<int>
+              [<ProviderDbType("Integer")>]
+              numberchildrenathome: Option<int>
+              [<ProviderDbType("Varchar")>]
+              education: Option<string>
+              [<ProviderDbType("Varchar")>]
+              occupation: Option<string>
+              [<ProviderDbType("Boolean")>]
+              homeownerflag: Option<bool>
+              [<ProviderDbType("Integer")>]
+              numbercarsowned: Option<int> }
+
+            interface ILeftViewOf<``vpersondemographics (base)``>
+
+        let vpersondemographics =
+            leftTable<``vpersondemographics (base)``, vpersondemographics>
+
+        type private ``vsalesperson (base)`` = vsalesperson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalesperson =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              territoryname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              territorygroup: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salesquota: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              salesytd: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              saleslastyear: Option<decimal> }
+
+            interface ILeftViewOf<``vsalesperson (base)``>
+
+        let vsalesperson = leftTable<``vsalesperson (base)``, vsalesperson>
+
+        type private ``vsalespersonsalesbyfiscalyears (base)`` = vsalespersonsalesbyfiscalyears
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalespersonsalesbyfiscalyears =
+            { [<ProviderDbType("Integer")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("Text")>]
+              FullName: Option<string>
+              [<ProviderDbType("Text")>]
+              JobTitle: Option<string>
+              [<ProviderDbType("Text")>]
+              SalesTerritory: Option<string>
+              [<ProviderDbType("Numeric")>]
+              ``2012``: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              ``2013``: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              ``2014``: Option<decimal> }
+
+            interface ILeftViewOf<``vsalespersonsalesbyfiscalyears (base)``>
+
+        let vsalespersonsalesbyfiscalyears =
+            leftTable<``vsalespersonsalesbyfiscalyears (base)``, vsalespersonsalesbyfiscalyears>
+
+        type private ``vsalespersonsalesbyfiscalyearsdata (base)`` = vsalespersonsalesbyfiscalyearsdata
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vsalespersonsalesbyfiscalyearsdata =
+            { [<ProviderDbType("Integer")>]
+              salespersonid: Option<int>
+              [<ProviderDbType("Text")>]
+              fullname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              jobtitle: Option<string>
+              [<ProviderDbType("Varchar")>]
+              salesterritory: Option<string>
+              [<ProviderDbType("Numeric")>]
+              salestotal: Option<decimal>
+              [<ProviderDbType("Numeric")>]
+              fiscalyear: Option<decimal> }
+
+            interface ILeftViewOf<``vsalespersonsalesbyfiscalyearsdata (base)``>
+
+        let vsalespersonsalesbyfiscalyearsdata =
+            leftTable<``vsalespersonsalesbyfiscalyearsdata (base)``, vsalespersonsalesbyfiscalyearsdata>
+
+        type private ``vstorewithaddresses (base)`` = vstorewithaddresses
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithaddresses =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addresstype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline1: Option<string>
+              [<ProviderDbType("Varchar")>]
+              addressline2: Option<string>
+              [<ProviderDbType("Varchar")>]
+              city: Option<string>
+              [<ProviderDbType("Varchar")>]
+              stateprovincename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              postalcode: Option<string>
+              [<ProviderDbType("Varchar")>]
+              countryregionname: Option<string> }
+
+            interface ILeftViewOf<``vstorewithaddresses (base)``>
+
+        let vstorewithaddresses =
+            leftTable<``vstorewithaddresses (base)``, vstorewithaddresses>
+
+        type private ``vstorewithcontacts (base)`` = vstorewithcontacts
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithcontacts =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Varchar")>]
+              contacttype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              title: Option<string>
+              [<ProviderDbType("Varchar")>]
+              firstname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              middlename: Option<string>
+              [<ProviderDbType("Varchar")>]
+              lastname: Option<string>
+              [<ProviderDbType("Varchar")>]
+              suffix: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumber: Option<string>
+              [<ProviderDbType("Varchar")>]
+              phonenumbertype: Option<string>
+              [<ProviderDbType("Varchar")>]
+              emailaddress: Option<string>
+              [<ProviderDbType("Integer")>]
+              emailpromotion: Option<int> }
+
+            interface ILeftViewOf<``vstorewithcontacts (base)``>
+
+        let vstorewithcontacts =
+            leftTable<``vstorewithcontacts (base)``, vstorewithcontacts>
+
+        type private ``vstorewithdemographics (base)`` = vstorewithdemographics
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type vstorewithdemographics =
+            { [<ProviderDbType("Integer")>]
+              businessentityid: Option<int>
+              [<ProviderDbType("Varchar")>]
+              name: Option<string>
+              [<ProviderDbType("Money")>]
+              AnnualSales: Option<decimal>
+              [<ProviderDbType("Money")>]
+              AnnualRevenue: Option<decimal>
+              [<ProviderDbType("Varchar")>]
+              BankName: Option<string>
+              [<ProviderDbType("Varchar")>]
+              BusinessType: Option<string>
+              [<ProviderDbType("Integer")>]
+              YearOpened: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Specialty: Option<string>
+              [<ProviderDbType("Integer")>]
+              SquareFeet: Option<int>
+              [<ProviderDbType("Varchar")>]
+              Brands: Option<string>
+              [<ProviderDbType("Varchar")>]
+              Internet: Option<string>
+              [<ProviderDbType("Integer")>]
+              NumberEmployees: Option<int> }
+
+            interface ILeftViewOf<``vstorewithdemographics (base)``>
+
+        let vstorewithdemographics =
+            leftTable<``vstorewithdemographics (base)``, vstorewithdemographics>
+
 
 
 [<RequireQualifiedAccess>]

--- a/src/Tests/Npgsql/AdventureWorksNet9.fs
+++ b/src/Tests/Npgsql/AdventureWorksNet9.fs
@@ -78,17 +78,6 @@ module ext =
 
             interface ILeftViewOf<``arrays (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``arrays (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``arrays (base)`` =
-                        { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
-
-                    Some record
-                | None -> None
-
         let arrays = leftTable<``arrays (base)``, arrays>
 
         type private ``jsonsupport (base)`` = jsonsupport
@@ -104,17 +93,6 @@ module ext =
 
             interface ILeftViewOf<``jsonsupport (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``jsonsupport (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``jsonsupport (base)`` =
-                        { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
-
-                    Some record
-                | None -> None
-
         let jsonsupport = leftTable<``jsonsupport (base)``, jsonsupport>
 
         type private ``person (base)`` = person
@@ -126,17 +104,6 @@ module ext =
               currentmood: Option<mood> }
 
             interface ILeftViewOf<``person (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``person (base)`` option =
-                match this.name with
-                | Some value ->
-                    let record: ``person (base)`` =
-                        { name = value; currentmood = this.currentmood.Value }
-
-                    Some record
-                | None -> None
 
         let person = leftTable<``person (base)``, person>
 
@@ -611,17 +578,6 @@ module humanresources =
 
             interface ILeftViewOf<``department (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``department (base)`` option =
-                match this.departmentid with
-                | Some value ->
-                    let record: ``department (base)`` =
-                        { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let department = leftTable<``department (base)``, department>
 
         type private ``employee (base)`` = employee
@@ -661,31 +617,6 @@ module humanresources =
 
             interface ILeftViewOf<``employee (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employee (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employee (base)`` =
-                        { businessentityid = value
-                          nationalidnumber = this.nationalidnumber.Value
-                          loginid = this.loginid.Value
-                          jobtitle = this.jobtitle.Value
-                          birthdate = this.birthdate.Value
-                          maritalstatus = this.maritalstatus.Value
-                          gender = this.gender.Value
-                          hiredate = this.hiredate.Value
-                          salariedflag = this.salariedflag.Value
-                          vacationhours = this.vacationhours.Value
-                          sickleavehours = this.sickleavehours.Value
-                          currentflag = this.currentflag.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value
-                          organizationnode = this.organizationnode }
-
-                    Some record
-                | None -> None
-
         let employee = leftTable<``employee (base)``, employee>
 
         type private ``employeedepartmenthistory (base)`` = employeedepartmenthistory
@@ -707,22 +638,6 @@ module humanresources =
 
             interface ILeftViewOf<``employeedepartmenthistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employeedepartmenthistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employeedepartmenthistory (base)`` =
-                        { businessentityid = value
-                          departmentid = this.departmentid.Value
-                          shiftid = this.shiftid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let employeedepartmenthistory =
             leftTable<``employeedepartmenthistory (base)``, employeedepartmenthistory>
 
@@ -743,17 +658,6 @@ module humanresources =
 
             interface ILeftViewOf<``employeepayhistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``employeepayhistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``employeepayhistory (base)`` =
-                        { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let employeepayhistory =
             leftTable<``employeepayhistory (base)``, employeepayhistory>
 
@@ -771,17 +675,6 @@ module humanresources =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``jobcandidate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``jobcandidate (base)`` option =
-                match this.jobcandidateid with
-                | Some value ->
-                    let record: ``jobcandidate (base)`` =
-                        { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let jobcandidate = leftTable<``jobcandidate (base)``, jobcandidate>
 
@@ -801,17 +694,6 @@ module humanresources =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shift (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shift (base)`` option =
-                match this.shiftid with
-                | Some value ->
-                    let record: ``shift (base)`` =
-                        { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shift = leftTable<``shift (base)``, shift>
 
@@ -1076,17 +958,6 @@ module network_sample =
               net_macaddr8: Option<System.Net.NetworkInformation.PhysicalAddress> }
 
             interface ILeftViewOf<``network_addresses (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``network_addresses (base)`` option =
-                match this.id with
-                | Some value ->
-                    let record: ``network_addresses (base)`` =
-                        { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
-
-                    Some record
-                | None -> None
 
         let network_addresses = leftTable<``network_addresses (base)``, network_addresses>
 
@@ -1641,30 +1512,6 @@ module pe =
 
             interface ILeftViewOf<``p (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``p (base)`` option =
-                match this.namestyle with
-                | Some value ->
-                    let record: ``p (base)`` =
-                        { id = this.id
-                          businessentityid = this.businessentityid
-                          persontype = this.persontype
-                          namestyle = value
-                          title = this.title
-                          firstname = this.firstname
-                          middlename = this.middlename
-                          lastname = this.lastname
-                          suffix = this.suffix
-                          emailpromotion = this.emailpromotion
-                          additionalcontactinfo = this.additionalcontactinfo
-                          demographics = this.demographics
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
-
         let p = leftTable<``p (base)``, p>
 
         type private ``pa (base)`` = pa
@@ -1748,25 +1595,6 @@ module pe =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``sp (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``sp (base)`` option =
-                match this.isonlystateprovinceflag with
-                | Some value ->
-                    let record: ``sp (base)`` =
-                        { id = this.id
-                          stateprovinceid = this.stateprovinceid
-                          stateprovincecode = this.stateprovincecode
-                          countryregioncode = this.countryregioncode
-                          isonlystateprovinceflag = value
-                          name = this.name
-                          territoryid = this.territoryid
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let sp = leftTable<``sp (base)``, sp>
 
@@ -2197,25 +2025,6 @@ module person =
 
             interface ILeftViewOf<``address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``address (base)`` option =
-                match this.addressid with
-                | Some value ->
-                    let record: ``address (base)`` =
-                        { addressid = value
-                          addressline1 = this.addressline1.Value
-                          addressline2 = this.addressline2
-                          city = this.city.Value
-                          stateprovinceid = this.stateprovinceid.Value
-                          postalcode = this.postalcode.Value
-                          spatiallocation = this.spatiallocation
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let address = leftTable<``address (base)``, address>
 
         type private ``addresstype (base)`` = addresstype
@@ -2233,17 +2042,6 @@ module person =
 
             interface ILeftViewOf<``addresstype (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``addresstype (base)`` option =
-                match this.addresstypeid with
-                | Some value ->
-                    let record: ``addresstype (base)`` =
-                        { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let addresstype = leftTable<``addresstype (base)``, addresstype>
 
         type private ``businessentity (base)`` = businessentity
@@ -2258,17 +2056,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``businessentity (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentity (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentity (base)`` =
-                        { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let businessentity = leftTable<``businessentity (base)``, businessentity>
 
@@ -2288,17 +2075,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``businessentityaddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentityaddress (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentityaddress (base)`` =
-                        { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let businessentityaddress =
             leftTable<``businessentityaddress (base)``, businessentityaddress>
@@ -2320,17 +2096,6 @@ module person =
 
             interface ILeftViewOf<``businessentitycontact (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``businessentitycontact (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``businessentitycontact (base)`` =
-                        { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let businessentitycontact =
             leftTable<``businessentitycontact (base)``, businessentitycontact>
 
@@ -2347,17 +2112,6 @@ module person =
 
             interface ILeftViewOf<``contacttype (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``contacttype (base)`` option =
-                match this.contacttypeid with
-                | Some value ->
-                    let record: ``contacttype (base)`` =
-                        { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let contacttype = leftTable<``contacttype (base)``, contacttype>
 
         type private ``countryregion (base)`` = countryregion
@@ -2372,17 +2126,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``countryregion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``countryregion (base)`` option =
-                match this.countryregioncode with
-                | Some value ->
-                    let record: ``countryregion (base)`` =
-                        { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let countryregion = leftTable<``countryregion (base)``, countryregion>
 
@@ -2403,17 +2146,6 @@ module person =
 
             interface ILeftViewOf<``emailaddress (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``emailaddress (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``emailaddress (base)`` =
-                        { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let emailaddress = leftTable<``emailaddress (base)``, emailaddress>
 
         type private ``password (base)`` = password
@@ -2432,21 +2164,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``password (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``password (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``password (base)`` =
-                        { businessentityid = value
-                          passwordhash = this.passwordhash.Value
-                          passwordsalt = this.passwordsalt.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let password = leftTable<``password (base)``, password>
 
@@ -2483,29 +2200,6 @@ module person =
 
             interface ILeftViewOf<``person (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``person (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``person (base)`` =
-                        { businessentityid = value
-                          persontype = this.persontype.Value
-                          namestyle = this.namestyle.Value
-                          title = this.title
-                          firstname = this.firstname.Value
-                          middlename = this.middlename
-                          lastname = this.lastname.Value
-                          suffix = this.suffix
-                          emailpromotion = this.emailpromotion.Value
-                          additionalcontactinfo = this.additionalcontactinfo
-                          demographics = this.demographics
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let person = leftTable<``person (base)``, person>
 
         type private ``personphone (base)`` = personphone
@@ -2523,17 +2217,6 @@ module person =
 
             interface ILeftViewOf<``personphone (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``personphone (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``personphone (base)`` =
-                        { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let personphone = leftTable<``personphone (base)``, personphone>
 
         type private ``phonenumbertype (base)`` = phonenumbertype
@@ -2548,17 +2231,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``phonenumbertype (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``phonenumbertype (base)`` option =
-                match this.phonenumbertypeid with
-                | Some value ->
-                    let record: ``phonenumbertype (base)`` =
-                        { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let phonenumbertype = leftTable<``phonenumbertype (base)``, phonenumbertype>
 
@@ -2584,24 +2256,6 @@ module person =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``stateprovince (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``stateprovince (base)`` option =
-                match this.stateprovinceid with
-                | Some value ->
-                    let record: ``stateprovince (base)`` =
-                        { stateprovinceid = value
-                          stateprovincecode = this.stateprovincecode.Value
-                          countryregioncode = this.countryregioncode.Value
-                          isonlystateprovinceflag = this.isonlystateprovinceflag.Value
-                          name = this.name.Value
-                          territoryid = this.territoryid.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let stateprovince = leftTable<``stateprovince (base)``, stateprovince>
 
@@ -3518,29 +3172,6 @@ module pr =
 
             interface ILeftViewOf<``d (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``d (base)`` option =
-                match this.folderflag with
-                | Some value ->
-                    let record: ``d (base)`` =
-                        { title = this.title
-                          owner = this.owner
-                          folderflag = value
-                          filename = this.filename
-                          fileextension = this.fileextension
-                          revision = this.revision
-                          changenumber = this.changenumber
-                          status = this.status
-                          documentsummary = this.documentsummary
-                          document = this.document
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate
-                          documentnode = this.documentnode }
-
-                    Some record
-                | None -> None
-
         let d = leftTable<``d (base)``, d>
 
         type private ``i (base)`` = i
@@ -3639,42 +3270,6 @@ module pr =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``p (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``p (base)`` option =
-                match this.makeflag with
-                | Some value ->
-                    let record: ``p (base)`` =
-                        { id = this.id
-                          productid = this.productid
-                          name = this.name
-                          productnumber = this.productnumber
-                          makeflag = value
-                          finishedgoodsflag = this.finishedgoodsflag.Value
-                          color = this.color
-                          safetystocklevel = this.safetystocklevel
-                          reorderpoint = this.reorderpoint
-                          standardcost = this.standardcost
-                          listprice = this.listprice
-                          size = this.size
-                          sizeunitmeasurecode = this.sizeunitmeasurecode
-                          weightunitmeasurecode = this.weightunitmeasurecode
-                          weight = this.weight
-                          daystomanufacture = this.daystomanufacture
-                          productline = this.productline
-                          ``class`` = this.``class``
-                          style = this.style
-                          productsubcategoryid = this.productsubcategoryid
-                          productmodelid = this.productmodelid
-                          sellstartdate = this.sellstartdate
-                          sellenddate = this.sellenddate
-                          discontinueddate = this.discontinueddate
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let p = leftTable<``p (base)``, p>
 
@@ -3892,17 +3487,6 @@ module pr =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ppp (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ppp (base)`` option =
-                match this.primary with
-                | Some value ->
-                    let record: ``ppp (base)`` =
-                        { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let ppp = leftTable<``ppp (base)``, ppp>
 
@@ -4987,25 +4571,6 @@ module production =
 
             interface ILeftViewOf<``billofmaterials (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``billofmaterials (base)`` option =
-                match this.billofmaterialsid with
-                | Some value ->
-                    let record: ``billofmaterials (base)`` =
-                        { billofmaterialsid = value
-                          productassemblyid = this.productassemblyid
-                          componentid = this.componentid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          unitmeasurecode = this.unitmeasurecode.Value
-                          bomlevel = this.bomlevel.Value
-                          perassemblyqty = this.perassemblyqty.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let billofmaterials = leftTable<``billofmaterials (base)``, billofmaterials>
 
         type private ``culture (base)`` = culture
@@ -5020,17 +4585,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``culture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``culture (base)`` option =
-                match this.cultureid with
-                | Some value ->
-                    let record: ``culture (base)`` =
-                        { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let culture = leftTable<``culture (base)``, culture>
 
@@ -5067,29 +4621,6 @@ module production =
 
             interface ILeftViewOf<``document (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``document (base)`` option =
-                match this.documentnode with
-                | Some value ->
-                    let record: ``document (base)`` =
-                        { title = this.title.Value
-                          owner = this.owner.Value
-                          folderflag = this.folderflag.Value
-                          filename = this.filename.Value
-                          fileextension = this.fileextension
-                          revision = this.revision.Value
-                          changenumber = this.changenumber.Value
-                          status = this.status.Value
-                          documentsummary = this.documentsummary
-                          document = this.document
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value
-                          documentnode = value }
-
-                    Some record
-                | None -> None
-
         let document = leftTable<``document (base)``, document>
 
         type private ``illustration (base)`` = illustration
@@ -5104,17 +4635,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``illustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``illustration (base)`` option =
-                match this.illustrationid with
-                | Some value ->
-                    let record: ``illustration (base)`` =
-                        { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let illustration = leftTable<``illustration (base)``, illustration>
 
@@ -5134,17 +4654,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``location (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``location (base)`` option =
-                match this.locationid with
-                | Some value ->
-                    let record: ``location (base)`` =
-                        { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let location = leftTable<``location (base)``, location>
 
@@ -5205,41 +4714,6 @@ module production =
 
             interface ILeftViewOf<``product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``product (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``product (base)`` =
-                        { productid = value
-                          name = this.name.Value
-                          productnumber = this.productnumber.Value
-                          makeflag = this.makeflag.Value
-                          finishedgoodsflag = this.finishedgoodsflag.Value
-                          color = this.color
-                          safetystocklevel = this.safetystocklevel.Value
-                          reorderpoint = this.reorderpoint.Value
-                          standardcost = this.standardcost.Value
-                          listprice = this.listprice.Value
-                          size = this.size
-                          sizeunitmeasurecode = this.sizeunitmeasurecode
-                          weightunitmeasurecode = this.weightunitmeasurecode
-                          weight = this.weight
-                          daystomanufacture = this.daystomanufacture.Value
-                          productline = this.productline
-                          ``class`` = this.``class``
-                          style = this.style
-                          productsubcategoryid = this.productsubcategoryid
-                          productmodelid = this.productmodelid
-                          sellstartdate = this.sellstartdate.Value
-                          sellenddate = this.sellenddate
-                          discontinueddate = this.discontinueddate
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let product = leftTable<``product (base)``, product>
 
         type private ``productcategory (base)`` = productcategory
@@ -5256,17 +4730,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productcategory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productcategory (base)`` option =
-                match this.productcategoryid with
-                | Some value ->
-                    let record: ``productcategory (base)`` =
-                        { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productcategory = leftTable<``productcategory (base)``, productcategory>
 
@@ -5287,17 +4750,6 @@ module production =
 
             interface ILeftViewOf<``productcosthistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productcosthistory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productcosthistory (base)`` =
-                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productcosthistory =
             leftTable<``productcosthistory (base)``, productcosthistory>
 
@@ -5316,17 +4768,6 @@ module production =
 
             interface ILeftViewOf<``productdescription (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productdescription (base)`` option =
-                match this.productdescriptionid with
-                | Some value ->
-                    let record: ``productdescription (base)`` =
-                        { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productdescription =
             leftTable<``productdescription (base)``, productdescription>
 
@@ -5342,17 +4783,6 @@ module production =
               documentnode: Option<string> }
 
             interface ILeftViewOf<``productdocument (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productdocument (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productdocument (base)`` =
-                        { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
-
-                    Some record
-                | None -> None
 
         let productdocument = leftTable<``productdocument (base)``, productdocument>
 
@@ -5377,23 +4807,6 @@ module production =
 
             interface ILeftViewOf<``productinventory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productinventory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productinventory (base)`` =
-                        { productid = value
-                          locationid = this.locationid.Value
-                          shelf = this.shelf.Value
-                          bin = this.bin.Value
-                          quantity = this.quantity.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productinventory = leftTable<``productinventory (base)``, productinventory>
 
         type private ``productlistpricehistory (base)`` = productlistpricehistory
@@ -5412,17 +4825,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productlistpricehistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productlistpricehistory (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productlistpricehistory (base)`` =
-                        { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productlistpricehistory =
             leftTable<``productlistpricehistory (base)``, productlistpricehistory>
@@ -5446,22 +4848,6 @@ module production =
 
             interface ILeftViewOf<``productmodel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodel (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodel (base)`` =
-                        { productmodelid = value
-                          name = this.name.Value
-                          catalogdescription = this.catalogdescription
-                          instructions = this.instructions
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productmodel = leftTable<``productmodel (base)``, productmodel>
 
         type private ``productmodelillustration (base)`` = productmodelillustration
@@ -5476,17 +4862,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productmodelillustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodelillustration (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodelillustration (base)`` =
-                        { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productmodelillustration =
             leftTable<``productmodelillustration (base)``, productmodelillustration>
@@ -5505,17 +4880,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productmodelproductdescriptionculture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productmodelproductdescriptionculture (base)`` option =
-                match this.productmodelid with
-                | Some value ->
-                    let record: ``productmodelproductdescriptionculture (base)`` =
-                        { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productmodelproductdescriptionculture =
             leftTable<``productmodelproductdescriptionculture (base)``, productmodelproductdescriptionculture>
@@ -5539,22 +4903,6 @@ module production =
 
             interface ILeftViewOf<``productphoto (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productphoto (base)`` option =
-                match this.productphotoid with
-                | Some value ->
-                    let record: ``productphoto (base)`` =
-                        { productphotoid = value
-                          thumbnailphoto = this.thumbnailphoto
-                          thumbnailphotofilename = this.thumbnailphotofilename
-                          largephoto = this.largephoto
-                          largephotofilename = this.largephotofilename
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productphoto = leftTable<``productphoto (base)``, productphoto>
 
         type private ``productproductphoto (base)`` = productproductphoto
@@ -5571,17 +4919,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``productproductphoto (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productproductphoto (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productproductphoto (base)`` =
-                        { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let productproductphoto =
             leftTable<``productproductphoto (base)``, productproductphoto>
@@ -5609,24 +4946,6 @@ module production =
 
             interface ILeftViewOf<``productreview (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productreview (base)`` option =
-                match this.productreviewid with
-                | Some value ->
-                    let record: ``productreview (base)`` =
-                        { productreviewid = value
-                          productid = this.productid.Value
-                          reviewername = this.reviewername.Value
-                          reviewdate = this.reviewdate.Value
-                          emailaddress = this.emailaddress.Value
-                          rating = this.rating.Value
-                          comments = this.comments
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productreview = leftTable<``productreview (base)``, productreview>
 
         type private ``productsubcategory (base)`` = productsubcategory
@@ -5646,17 +4965,6 @@ module production =
 
             interface ILeftViewOf<``productsubcategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productsubcategory (base)`` option =
-                match this.productsubcategoryid with
-                | Some value ->
-                    let record: ``productsubcategory (base)`` =
-                        { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productsubcategory =
             leftTable<``productsubcategory (base)``, productsubcategory>
 
@@ -5672,17 +4980,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``scrapreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``scrapreason (base)`` option =
-                match this.scrapreasonid with
-                | Some value ->
-                    let record: ``scrapreason (base)`` =
-                        { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let scrapreason = leftTable<``scrapreason (base)``, scrapreason>
 
@@ -5710,25 +5007,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``transactionhistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``transactionhistory (base)`` option =
-                match this.transactionid with
-                | Some value ->
-                    let record: ``transactionhistory (base)`` =
-                        { transactionid = value
-                          productid = this.productid.Value
-                          referenceorderid = this.referenceorderid.Value
-                          referenceorderlineid = this.referenceorderlineid.Value
-                          transactiondate = this.transactiondate.Value
-                          transactiontype = this.transactiontype.Value
-                          quantity = this.quantity.Value
-                          actualcost = this.actualcost.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let transactionhistory =
             leftTable<``transactionhistory (base)``, transactionhistory>
@@ -5758,25 +5036,6 @@ module production =
 
             interface ILeftViewOf<``transactionhistoryarchive (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``transactionhistoryarchive (base)`` option =
-                match this.transactionid with
-                | Some value ->
-                    let record: ``transactionhistoryarchive (base)`` =
-                        { transactionid = value
-                          productid = this.productid.Value
-                          referenceorderid = this.referenceorderid.Value
-                          referenceorderlineid = this.referenceorderlineid.Value
-                          transactiondate = this.transactiondate.Value
-                          transactiontype = this.transactiontype.Value
-                          quantity = this.quantity.Value
-                          actualcost = this.actualcost.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let transactionhistoryarchive =
             leftTable<``transactionhistoryarchive (base)``, transactionhistoryarchive>
 
@@ -5792,17 +5051,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``unitmeasure (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``unitmeasure (base)`` option =
-                match this.unitmeasurecode with
-                | Some value ->
-                    let record: ``unitmeasure (base)`` =
-                        { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let unitmeasure = leftTable<``unitmeasure (base)``, unitmeasure>
 
@@ -5941,25 +5189,6 @@ module production =
 
             interface ILeftViewOf<``workorder (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``workorder (base)`` option =
-                match this.workorderid with
-                | Some value ->
-                    let record: ``workorder (base)`` =
-                        { workorderid = value
-                          productid = this.productid.Value
-                          orderqty = this.orderqty.Value
-                          scrappedqty = this.scrappedqty.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          duedate = this.duedate.Value
-                          scrapreasonid = this.scrapreasonid
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let workorder = leftTable<``workorder (base)``, workorder>
 
         type private ``workorderrouting (base)`` = workorderrouting
@@ -5992,28 +5221,6 @@ module production =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``workorderrouting (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``workorderrouting (base)`` option =
-                match this.workorderid with
-                | Some value ->
-                    let record: ``workorderrouting (base)`` =
-                        { workorderid = value
-                          productid = this.productid.Value
-                          operationsequence = this.operationsequence.Value
-                          locationid = this.locationid.Value
-                          scheduledstartdate = this.scheduledstartdate.Value
-                          scheduledenddate = this.scheduledenddate.Value
-                          actualstartdate = this.actualstartdate
-                          actualenddate = this.actualenddate
-                          actualresourcehrs = this.actualresourcehrs
-                          plannedcost = this.plannedcost.Value
-                          actualcost = this.actualcost
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let workorderrouting = leftTable<``workorderrouting (base)``, workorderrouting>
 
@@ -6361,25 +5568,6 @@ module pu =
 
             interface ILeftViewOf<``v (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``v (base)`` option =
-                match this.preferredvendorstatus with
-                | Some value ->
-                    let record: ``v (base)`` =
-                        { id = this.id
-                          businessentityid = this.businessentityid
-                          accountnumber = this.accountnumber
-                          name = this.name
-                          creditrating = this.creditrating
-                          preferredvendorstatus = value
-                          activeflag = this.activeflag.Value
-                          purchasingwebserviceurl = this.purchasingwebserviceurl
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
-
         let v = leftTable<``v (base)``, v>
 
 
@@ -6674,27 +5862,6 @@ module purchasing =
 
             interface ILeftViewOf<``productvendor (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``productvendor (base)`` option =
-                match this.productid with
-                | Some value ->
-                    let record: ``productvendor (base)`` =
-                        { productid = value
-                          businessentityid = this.businessentityid.Value
-                          averageleadtime = this.averageleadtime.Value
-                          standardprice = this.standardprice.Value
-                          lastreceiptcost = this.lastreceiptcost
-                          lastreceiptdate = this.lastreceiptdate
-                          minorderqty = this.minorderqty.Value
-                          maxorderqty = this.maxorderqty.Value
-                          onorderqty = this.onorderqty
-                          unitmeasurecode = this.unitmeasurecode.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let productvendor = leftTable<``productvendor (base)``, productvendor>
 
         type private ``purchaseorderdetail (base)`` = purchaseorderdetail
@@ -6721,25 +5888,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``purchaseorderdetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``purchaseorderdetail (base)`` option =
-                match this.purchaseorderid with
-                | Some value ->
-                    let record: ``purchaseorderdetail (base)`` =
-                        { purchaseorderid = value
-                          purchaseorderdetailid = this.purchaseorderdetailid.Value
-                          duedate = this.duedate.Value
-                          orderqty = this.orderqty.Value
-                          productid = this.productid.Value
-                          unitprice = this.unitprice.Value
-                          receivedqty = this.receivedqty.Value
-                          rejectedqty = this.rejectedqty.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let purchaseorderdetail =
             leftTable<``purchaseorderdetail (base)``, purchaseorderdetail>
@@ -6775,28 +5923,6 @@ module purchasing =
 
             interface ILeftViewOf<``purchaseorderheader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``purchaseorderheader (base)`` option =
-                match this.purchaseorderid with
-                | Some value ->
-                    let record: ``purchaseorderheader (base)`` =
-                        { purchaseorderid = value
-                          revisionnumber = this.revisionnumber.Value
-                          status = this.status.Value
-                          employeeid = this.employeeid.Value
-                          vendorid = this.vendorid.Value
-                          shipmethodid = this.shipmethodid.Value
-                          orderdate = this.orderdate.Value
-                          shipdate = this.shipdate
-                          subtotal = this.subtotal.Value
-                          taxamt = this.taxamt.Value
-                          freight = this.freight.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let purchaseorderheader =
             leftTable<``purchaseorderheader (base)``, purchaseorderheader>
 
@@ -6818,22 +5944,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shipmethod (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shipmethod (base)`` option =
-                match this.shipmethodid with
-                | Some value ->
-                    let record: ``shipmethod (base)`` =
-                        { shipmethodid = value
-                          name = this.name.Value
-                          shipbase = this.shipbase.Value
-                          shiprate = this.shiprate.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shipmethod = leftTable<``shipmethod (base)``, shipmethod>
 
@@ -6859,24 +5969,6 @@ module purchasing =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``vendor (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``vendor (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``vendor (base)`` =
-                        { businessentityid = value
-                          accountnumber = this.accountnumber.Value
-                          name = this.name.Value
-                          creditrating = this.creditrating.Value
-                          preferredvendorstatus = this.preferredvendorstatus.Value
-                          activeflag = this.activeflag.Value
-                          purchasingwebserviceurl = this.purchasingwebserviceurl
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let vendor = leftTable<``vendor (base)``, vendor>
 
@@ -7836,42 +6928,6 @@ module sa =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``soh (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``soh (base)`` option =
-                match this.onlineorderflag with
-                | Some value ->
-                    let record: ``soh (base)`` =
-                        { id = this.id
-                          salesorderid = this.salesorderid
-                          revisionnumber = this.revisionnumber
-                          orderdate = this.orderdate
-                          duedate = this.duedate
-                          shipdate = this.shipdate
-                          status = this.status
-                          onlineorderflag = value
-                          purchaseordernumber = this.purchaseordernumber
-                          accountnumber = this.accountnumber
-                          customerid = this.customerid
-                          salespersonid = this.salespersonid
-                          territoryid = this.territoryid
-                          billtoaddressid = this.billtoaddressid
-                          shiptoaddressid = this.shiptoaddressid
-                          shipmethodid = this.shipmethodid
-                          creditcardid = this.creditcardid
-                          creditcardapprovalcode = this.creditcardapprovalcode
-                          currencyrateid = this.currencyrateid
-                          subtotal = this.subtotal
-                          taxamt = this.taxamt
-                          freight = this.freight
-                          totaldue = this.totaldue
-                          comment = this.comment
-                          rowguid = this.rowguid
-                          modifieddate = this.modifieddate }
-
-                    Some record
-                | None -> None
 
         let soh = leftTable<``soh (base)``, soh>
 
@@ -8991,17 +8047,6 @@ module sales =
 
             interface ILeftViewOf<``countryregioncurrency (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``countryregioncurrency (base)`` option =
-                match this.countryregioncode with
-                | Some value ->
-                    let record: ``countryregioncurrency (base)`` =
-                        { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let countryregioncurrency =
             leftTable<``countryregioncurrency (base)``, countryregioncurrency>
 
@@ -9024,22 +8069,6 @@ module sales =
 
             interface ILeftViewOf<``creditcard (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``creditcard (base)`` option =
-                match this.creditcardid with
-                | Some value ->
-                    let record: ``creditcard (base)`` =
-                        { creditcardid = value
-                          cardtype = this.cardtype.Value
-                          cardnumber = this.cardnumber.Value
-                          expmonth = this.expmonth.Value
-                          expyear = this.expyear.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let creditcard = leftTable<``creditcard (base)``, creditcard>
 
         type private ``currency (base)`` = currency
@@ -9054,17 +8083,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``currency (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``currency (base)`` option =
-                match this.currencycode with
-                | Some value ->
-                    let record: ``currency (base)`` =
-                        { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let currency = leftTable<``currency (base)``, currency>
 
@@ -9089,23 +8107,6 @@ module sales =
 
             interface ILeftViewOf<``currencyrate (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``currencyrate (base)`` option =
-                match this.currencyrateid with
-                | Some value ->
-                    let record: ``currencyrate (base)`` =
-                        { currencyrateid = value
-                          currencyratedate = this.currencyratedate.Value
-                          fromcurrencycode = this.fromcurrencycode.Value
-                          tocurrencycode = this.tocurrencycode.Value
-                          averagerate = this.averagerate.Value
-                          endofdayrate = this.endofdayrate.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let currencyrate = leftTable<``currencyrate (base)``, currencyrate>
 
         type private ``customer (base)`` = customer
@@ -9127,17 +8128,6 @@ module sales =
 
             interface ILeftViewOf<``customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``customer (base)`` option =
-                match this.customerid with
-                | Some value ->
-                    let record: ``customer (base)`` =
-                        { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let customer = leftTable<``customer (base)``, customer>
 
         type private ``personcreditcard (base)`` = personcreditcard
@@ -9152,17 +8142,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``personcreditcard (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``personcreditcard (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``personcreditcard (base)`` =
-                        { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let personcreditcard = leftTable<``personcreditcard (base)``, personcreditcard>
 
@@ -9192,26 +8171,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesorderdetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderdetail (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderdetail (base)`` =
-                        { salesorderid = value
-                          salesorderdetailid = this.salesorderdetailid.Value
-                          carriertrackingnumber = this.carriertrackingnumber
-                          orderqty = this.orderqty.Value
-                          productid = this.productid.Value
-                          specialofferid = this.specialofferid.Value
-                          unitprice = this.unitprice.Value
-                          unitpricediscount = this.unitpricediscount.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesorderdetail = leftTable<``salesorderdetail (base)``, salesorderdetail>
 
@@ -9272,41 +8231,6 @@ module sales =
 
             interface ILeftViewOf<``salesorderheader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderheader (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderheader (base)`` =
-                        { salesorderid = value
-                          revisionnumber = this.revisionnumber.Value
-                          orderdate = this.orderdate.Value
-                          duedate = this.duedate.Value
-                          shipdate = this.shipdate
-                          status = this.status.Value
-                          onlineorderflag = this.onlineorderflag.Value
-                          purchaseordernumber = this.purchaseordernumber
-                          accountnumber = this.accountnumber
-                          customerid = this.customerid.Value
-                          salespersonid = this.salespersonid
-                          territoryid = this.territoryid
-                          billtoaddressid = this.billtoaddressid.Value
-                          shiptoaddressid = this.shiptoaddressid.Value
-                          shipmethodid = this.shipmethodid.Value
-                          creditcardid = this.creditcardid
-                          creditcardapprovalcode = this.creditcardapprovalcode
-                          currencyrateid = this.currencyrateid
-                          subtotal = this.subtotal.Value
-                          taxamt = this.taxamt.Value
-                          freight = this.freight.Value
-                          totaldue = this.totaldue
-                          comment = this.comment
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesorderheader = leftTable<``salesorderheader (base)``, salesorderheader>
 
         type private ``salesorderheadersalesreason (base)`` = salesorderheadersalesreason
@@ -9321,17 +8245,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesorderheadersalesreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesorderheadersalesreason (base)`` option =
-                match this.salesorderid with
-                | Some value ->
-                    let record: ``salesorderheadersalesreason (base)`` =
-                        { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesorderheadersalesreason =
             leftTable<``salesorderheadersalesreason (base)``, salesorderheadersalesreason>
@@ -9361,25 +8274,6 @@ module sales =
 
             interface ILeftViewOf<``salesperson (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesperson (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salesperson (base)`` =
-                        { businessentityid = value
-                          territoryid = this.territoryid
-                          salesquota = this.salesquota
-                          bonus = this.bonus.Value
-                          commissionpct = this.commissionpct.Value
-                          salesytd = this.salesytd.Value
-                          saleslastyear = this.saleslastyear.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesperson = leftTable<``salesperson (base)``, salesperson>
 
         type private ``salespersonquotahistory (base)`` = salespersonquotahistory
@@ -9399,17 +8293,6 @@ module sales =
 
             interface ILeftViewOf<``salespersonquotahistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salespersonquotahistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salespersonquotahistory (base)`` =
-                        { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salespersonquotahistory =
             leftTable<``salespersonquotahistory (base)``, salespersonquotahistory>
 
@@ -9427,17 +8310,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesreason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesreason (base)`` option =
-                match this.salesreasonid with
-                | Some value ->
-                    let record: ``salesreason (base)`` =
-                        { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesreason = leftTable<``salesreason (base)``, salesreason>
 
@@ -9461,23 +8333,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salestaxrate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salestaxrate (base)`` option =
-                match this.salestaxrateid with
-                | Some value ->
-                    let record: ``salestaxrate (base)`` =
-                        { salestaxrateid = value
-                          stateprovinceid = this.stateprovinceid.Value
-                          taxtype = this.taxtype.Value
-                          taxrate = this.taxrate.Value
-                          name = this.name.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salestaxrate = leftTable<``salestaxrate (base)``, salestaxrate>
 
@@ -9508,26 +8363,6 @@ module sales =
 
             interface ILeftViewOf<``salesterritory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesterritory (base)`` option =
-                match this.territoryid with
-                | Some value ->
-                    let record: ``salesterritory (base)`` =
-                        { territoryid = value
-                          name = this.name.Value
-                          countryregioncode = this.countryregioncode.Value
-                          group = this.group.Value
-                          salesytd = this.salesytd.Value
-                          saleslastyear = this.saleslastyear.Value
-                          costytd = this.costytd.Value
-                          costlastyear = this.costlastyear.Value
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let salesterritory = leftTable<``salesterritory (base)``, salesterritory>
 
         type private ``salesterritoryhistory (base)`` = salesterritoryhistory
@@ -9548,22 +8383,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``salesterritoryhistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``salesterritoryhistory (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``salesterritoryhistory (base)`` =
-                        { businessentityid = value
-                          territoryid = this.territoryid.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let salesterritoryhistory =
             leftTable<``salesterritoryhistory (base)``, salesterritoryhistory>
@@ -9586,22 +8405,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``shoppingcartitem (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``shoppingcartitem (base)`` option =
-                match this.shoppingcartitemid with
-                | Some value ->
-                    let record: ``shoppingcartitem (base)`` =
-                        { shoppingcartitemid = value
-                          shoppingcartid = this.shoppingcartid.Value
-                          quantity = this.quantity.Value
-                          productid = this.productid.Value
-                          datecreated = this.datecreated.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let shoppingcartitem = leftTable<``shoppingcartitem (base)``, shoppingcartitem>
 
@@ -9634,27 +8437,6 @@ module sales =
 
             interface ILeftViewOf<``specialoffer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``specialoffer (base)`` option =
-                match this.specialofferid with
-                | Some value ->
-                    let record: ``specialoffer (base)`` =
-                        { specialofferid = value
-                          description = this.description.Value
-                          discountpct = this.discountpct.Value
-                          ``type`` = this.``type``.Value
-                          category = this.category.Value
-                          startdate = this.startdate.Value
-                          enddate = this.enddate.Value
-                          minqty = this.minqty.Value
-                          maxqty = this.maxqty
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
-
         let specialoffer = leftTable<``specialoffer (base)``, specialoffer>
 
         type private ``specialofferproduct (base)`` = specialofferproduct
@@ -9671,17 +8453,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``specialofferproduct (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``specialofferproduct (base)`` option =
-                match this.specialofferid with
-                | Some value ->
-                    let record: ``specialofferproduct (base)`` =
-                        { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let specialofferproduct =
             leftTable<``specialofferproduct (base)``, specialofferproduct>
@@ -9704,22 +8475,6 @@ module sales =
               modifieddate: Option<System.DateTime> }
 
             interface ILeftViewOf<``store (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``store (base)`` option =
-                match this.businessentityid with
-                | Some value ->
-                    let record: ``store (base)`` =
-                        { businessentityid = value
-                          name = this.name.Value
-                          salespersonid = this.salespersonid
-                          demographics = this.demographics
-                          rowguid = this.rowguid.Value
-                          modifieddate = this.modifieddate.Value }
-
-                    Some record
-                | None -> None
 
         let store = leftTable<``store (base)``, store>
 
@@ -9999,6 +8754,1327 @@ module sales =
 
         let vstorewithdemographics =
             leftTable<``vstorewithdemographics (base)``, vstorewithdemographics>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type ext.LeftJoined.arrays with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.arrays option =
+            match this.id with
+            | Some value ->
+                let record: ext.arrays =
+                    { id = value; text_array = this.text_array.Value; integer_array = this.integer_array.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.jsonsupport with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.jsonsupport option =
+            match this.id with
+            | Some value ->
+                let record: ext.jsonsupport =
+                    { id = value; json_field = this.json_field.Value; jsonb_field = this.jsonb_field.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.person option =
+            match this.name with
+            | Some value ->
+                let record: ext.person = { name = value; currentmood = this.currentmood.Value }
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.department with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.department option =
+            match this.departmentid with
+            | Some value ->
+                let record: humanresources.department =
+                    { departmentid = value; name = this.name.Value; groupname = this.groupname.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employee with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employee option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employee =
+                    { businessentityid = value
+                      nationalidnumber = this.nationalidnumber.Value
+                      loginid = this.loginid.Value
+                      jobtitle = this.jobtitle.Value
+                      birthdate = this.birthdate.Value
+                      maritalstatus = this.maritalstatus.Value
+                      gender = this.gender.Value
+                      hiredate = this.hiredate.Value
+                      salariedflag = this.salariedflag.Value
+                      vacationhours = this.vacationhours.Value
+                      sickleavehours = this.sickleavehours.Value
+                      currentflag = this.currentflag.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value
+                      organizationnode = this.organizationnode }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employeedepartmenthistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employeedepartmenthistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employeedepartmenthistory =
+                    { businessentityid = value
+                      departmentid = this.departmentid.Value
+                      shiftid = this.shiftid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.employeepayhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.employeepayhistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: humanresources.employeepayhistory =
+                    { businessentityid = value; ratechangedate = this.ratechangedate.Value; rate = this.rate.Value; payfrequency = this.payfrequency.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.jobcandidate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.jobcandidate option =
+            match this.jobcandidateid with
+            | Some value ->
+                let record: humanresources.jobcandidate =
+                    { jobcandidateid = value; businessentityid = this.businessentityid; resume = this.resume; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type humanresources.LeftJoined.shift with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : humanresources.shift option =
+            match this.shiftid with
+            | Some value ->
+                let record: humanresources.shift =
+                    { shiftid = value; name = this.name.Value; starttime = this.starttime.Value; endtime = this.endtime.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type network_sample.LeftJoined.network_addresses with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : network_sample.network_addresses option =
+            match this.id with
+            | Some value ->
+                let record: network_sample.network_addresses =
+                    { id = value; net_cidr = this.net_cidr.Value; net_inet = this.net_inet.Value; net_macaddr = this.net_macaddr.Value; net_macaddr8 = this.net_macaddr8.Value }
+
+                Some record
+            | None -> None
+
+    type pe.LeftJoined.p with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pe.p option =
+            match this.namestyle with
+            | Some value ->
+                let record: pe.p =
+                    { id = this.id
+                      businessentityid = this.businessentityid
+                      persontype = this.persontype
+                      namestyle = value
+                      title = this.title
+                      firstname = this.firstname
+                      middlename = this.middlename
+                      lastname = this.lastname
+                      suffix = this.suffix
+                      emailpromotion = this.emailpromotion
+                      additionalcontactinfo = this.additionalcontactinfo
+                      demographics = this.demographics
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type pe.LeftJoined.sp with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pe.sp option =
+            match this.isonlystateprovinceflag with
+            | Some value ->
+                let record: pe.sp =
+                    { id = this.id
+                      stateprovinceid = this.stateprovinceid
+                      stateprovincecode = this.stateprovincecode
+                      countryregioncode = this.countryregioncode
+                      isonlystateprovinceflag = value
+                      name = this.name
+                      territoryid = this.territoryid
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.address option =
+            match this.addressid with
+            | Some value ->
+                let record: person.address =
+                    { addressid = value
+                      addressline1 = this.addressline1.Value
+                      addressline2 = this.addressline2
+                      city = this.city.Value
+                      stateprovinceid = this.stateprovinceid.Value
+                      postalcode = this.postalcode.Value
+                      spatiallocation = this.spatiallocation
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.addresstype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.addresstype option =
+            match this.addresstypeid with
+            | Some value ->
+                let record: person.addresstype =
+                    { addresstypeid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentity with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentity option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentity =
+                    { businessentityid = value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentityaddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentityaddress option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentityaddress =
+                    { businessentityid = value; addressid = this.addressid.Value; addresstypeid = this.addresstypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.businessentitycontact with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.businessentitycontact option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.businessentitycontact =
+                    { businessentityid = value; personid = this.personid.Value; contacttypeid = this.contacttypeid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.contacttype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.contacttype option =
+            match this.contacttypeid with
+            | Some value ->
+                let record: person.contacttype =
+                    { contacttypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.countryregion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.countryregion option =
+            match this.countryregioncode with
+            | Some value ->
+                let record: person.countryregion =
+                    { countryregioncode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.emailaddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.emailaddress option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.emailaddress =
+                    { businessentityid = value; emailaddressid = this.emailaddressid.Value; emailaddress = this.emailaddress; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.password with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.password option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.password =
+                    { businessentityid = value; passwordhash = this.passwordhash.Value; passwordsalt = this.passwordsalt.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.person option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.person =
+                    { businessentityid = value
+                      persontype = this.persontype.Value
+                      namestyle = this.namestyle.Value
+                      title = this.title
+                      firstname = this.firstname.Value
+                      middlename = this.middlename
+                      lastname = this.lastname.Value
+                      suffix = this.suffix
+                      emailpromotion = this.emailpromotion.Value
+                      additionalcontactinfo = this.additionalcontactinfo
+                      demographics = this.demographics
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.personphone with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.personphone option =
+            match this.businessentityid with
+            | Some value ->
+                let record: person.personphone =
+                    { businessentityid = value; phonenumber = this.phonenumber.Value; phonenumbertypeid = this.phonenumbertypeid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.phonenumbertype with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.phonenumbertype option =
+            match this.phonenumbertypeid with
+            | Some value ->
+                let record: person.phonenumbertype =
+                    { phonenumbertypeid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type person.LeftJoined.stateprovince with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : person.stateprovince option =
+            match this.stateprovinceid with
+            | Some value ->
+                let record: person.stateprovince =
+                    { stateprovinceid = value
+                      stateprovincecode = this.stateprovincecode.Value
+                      countryregioncode = this.countryregioncode.Value
+                      isonlystateprovinceflag = this.isonlystateprovinceflag.Value
+                      name = this.name.Value
+                      territoryid = this.territoryid.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.d with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.d option =
+            match this.folderflag with
+            | Some value ->
+                let record: pr.d =
+                    { title = this.title
+                      owner = this.owner
+                      folderflag = value
+                      filename = this.filename
+                      fileextension = this.fileextension
+                      revision = this.revision
+                      changenumber = this.changenumber
+                      status = this.status
+                      documentsummary = this.documentsummary
+                      document = this.document
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate
+                      documentnode = this.documentnode }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.p with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.p option =
+            match this.makeflag with
+            | Some value ->
+                let record: pr.p =
+                    { id = this.id
+                      productid = this.productid
+                      name = this.name
+                      productnumber = this.productnumber
+                      makeflag = value
+                      finishedgoodsflag = this.finishedgoodsflag.Value
+                      color = this.color
+                      safetystocklevel = this.safetystocklevel
+                      reorderpoint = this.reorderpoint
+                      standardcost = this.standardcost
+                      listprice = this.listprice
+                      size = this.size
+                      sizeunitmeasurecode = this.sizeunitmeasurecode
+                      weightunitmeasurecode = this.weightunitmeasurecode
+                      weight = this.weight
+                      daystomanufacture = this.daystomanufacture
+                      productline = this.productline
+                      ``class`` = this.``class``
+                      style = this.style
+                      productsubcategoryid = this.productsubcategoryid
+                      productmodelid = this.productmodelid
+                      sellstartdate = this.sellstartdate
+                      sellenddate = this.sellenddate
+                      discontinueddate = this.discontinueddate
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type pr.LeftJoined.ppp with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pr.ppp option =
+            match this.primary with
+            | Some value ->
+                let record: pr.ppp =
+                    { productid = this.productid; productphotoid = this.productphotoid; primary = value; modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.billofmaterials with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.billofmaterials option =
+            match this.billofmaterialsid with
+            | Some value ->
+                let record: production.billofmaterials =
+                    { billofmaterialsid = value
+                      productassemblyid = this.productassemblyid
+                      componentid = this.componentid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      unitmeasurecode = this.unitmeasurecode.Value
+                      bomlevel = this.bomlevel.Value
+                      perassemblyqty = this.perassemblyqty.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.culture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.culture option =
+            match this.cultureid with
+            | Some value ->
+                let record: production.culture =
+                    { cultureid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.document with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.document option =
+            match this.documentnode with
+            | Some value ->
+                let record: production.document =
+                    { title = this.title.Value
+                      owner = this.owner.Value
+                      folderflag = this.folderflag.Value
+                      filename = this.filename.Value
+                      fileextension = this.fileextension
+                      revision = this.revision.Value
+                      changenumber = this.changenumber.Value
+                      status = this.status.Value
+                      documentsummary = this.documentsummary
+                      document = this.document
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value
+                      documentnode = value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.illustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.illustration option =
+            match this.illustrationid with
+            | Some value ->
+                let record: production.illustration =
+                    { illustrationid = value; diagram = this.diagram; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.location with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.location option =
+            match this.locationid with
+            | Some value ->
+                let record: production.location =
+                    { locationid = value; name = this.name.Value; costrate = this.costrate.Value; availability = this.availability.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.product option =
+            match this.productid with
+            | Some value ->
+                let record: production.product =
+                    { productid = value
+                      name = this.name.Value
+                      productnumber = this.productnumber.Value
+                      makeflag = this.makeflag.Value
+                      finishedgoodsflag = this.finishedgoodsflag.Value
+                      color = this.color
+                      safetystocklevel = this.safetystocklevel.Value
+                      reorderpoint = this.reorderpoint.Value
+                      standardcost = this.standardcost.Value
+                      listprice = this.listprice.Value
+                      size = this.size
+                      sizeunitmeasurecode = this.sizeunitmeasurecode
+                      weightunitmeasurecode = this.weightunitmeasurecode
+                      weight = this.weight
+                      daystomanufacture = this.daystomanufacture.Value
+                      productline = this.productline
+                      ``class`` = this.``class``
+                      style = this.style
+                      productsubcategoryid = this.productsubcategoryid
+                      productmodelid = this.productmodelid
+                      sellstartdate = this.sellstartdate.Value
+                      sellenddate = this.sellenddate
+                      discontinueddate = this.discontinueddate
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productcategory option =
+            match this.productcategoryid with
+            | Some value ->
+                let record: production.productcategory =
+                    { productcategoryid = value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productcosthistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productcosthistory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productcosthistory =
+                    { productid = value; startdate = this.startdate.Value; enddate = this.enddate; standardcost = this.standardcost.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productdescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productdescription option =
+            match this.productdescriptionid with
+            | Some value ->
+                let record: production.productdescription =
+                    { productdescriptionid = value; description = this.description.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productdocument with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productdocument option =
+            match this.productid with
+            | Some value ->
+                let record: production.productdocument =
+                    { productid = value; modifieddate = this.modifieddate.Value; documentnode = this.documentnode.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productinventory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productinventory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productinventory =
+                    { productid = value
+                      locationid = this.locationid.Value
+                      shelf = this.shelf.Value
+                      bin = this.bin.Value
+                      quantity = this.quantity.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productlistpricehistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productlistpricehistory option =
+            match this.productid with
+            | Some value ->
+                let record: production.productlistpricehistory =
+                    { productid = value; startdate = this.startdate.Value; enddate = this.enddate; listprice = this.listprice.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodel option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodel =
+                    { productmodelid = value
+                      name = this.name.Value
+                      catalogdescription = this.catalogdescription
+                      instructions = this.instructions
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodelillustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodelillustration option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodelillustration =
+                    { productmodelid = value; illustrationid = this.illustrationid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productmodelproductdescriptionculture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productmodelproductdescriptionculture option =
+            match this.productmodelid with
+            | Some value ->
+                let record: production.productmodelproductdescriptionculture =
+                    { productmodelid = value; productdescriptionid = this.productdescriptionid.Value; cultureid = this.cultureid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productphoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productphoto option =
+            match this.productphotoid with
+            | Some value ->
+                let record: production.productphoto =
+                    { productphotoid = value
+                      thumbnailphoto = this.thumbnailphoto
+                      thumbnailphotofilename = this.thumbnailphotofilename
+                      largephoto = this.largephoto
+                      largephotofilename = this.largephotofilename
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productproductphoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productproductphoto option =
+            match this.productid with
+            | Some value ->
+                let record: production.productproductphoto =
+                    { productid = value; productphotoid = this.productphotoid.Value; primary = this.primary.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productreview with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productreview option =
+            match this.productreviewid with
+            | Some value ->
+                let record: production.productreview =
+                    { productreviewid = value
+                      productid = this.productid.Value
+                      reviewername = this.reviewername.Value
+                      reviewdate = this.reviewdate.Value
+                      emailaddress = this.emailaddress.Value
+                      rating = this.rating.Value
+                      comments = this.comments
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.productsubcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.productsubcategory option =
+            match this.productsubcategoryid with
+            | Some value ->
+                let record: production.productsubcategory =
+                    { productsubcategoryid = value; productcategoryid = this.productcategoryid.Value; name = this.name.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.scrapreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.scrapreason option =
+            match this.scrapreasonid with
+            | Some value ->
+                let record: production.scrapreason =
+                    { scrapreasonid = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.transactionhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.transactionhistory option =
+            match this.transactionid with
+            | Some value ->
+                let record: production.transactionhistory =
+                    { transactionid = value
+                      productid = this.productid.Value
+                      referenceorderid = this.referenceorderid.Value
+                      referenceorderlineid = this.referenceorderlineid.Value
+                      transactiondate = this.transactiondate.Value
+                      transactiontype = this.transactiontype.Value
+                      quantity = this.quantity.Value
+                      actualcost = this.actualcost.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.transactionhistoryarchive with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.transactionhistoryarchive option =
+            match this.transactionid with
+            | Some value ->
+                let record: production.transactionhistoryarchive =
+                    { transactionid = value
+                      productid = this.productid.Value
+                      referenceorderid = this.referenceorderid.Value
+                      referenceorderlineid = this.referenceorderlineid.Value
+                      transactiondate = this.transactiondate.Value
+                      transactiontype = this.transactiontype.Value
+                      quantity = this.quantity.Value
+                      actualcost = this.actualcost.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.unitmeasure with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.unitmeasure option =
+            match this.unitmeasurecode with
+            | Some value ->
+                let record: production.unitmeasure =
+                    { unitmeasurecode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.workorder with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.workorder option =
+            match this.workorderid with
+            | Some value ->
+                let record: production.workorder =
+                    { workorderid = value
+                      productid = this.productid.Value
+                      orderqty = this.orderqty.Value
+                      scrappedqty = this.scrappedqty.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      duedate = this.duedate.Value
+                      scrapreasonid = this.scrapreasonid
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type production.LeftJoined.workorderrouting with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : production.workorderrouting option =
+            match this.workorderid with
+            | Some value ->
+                let record: production.workorderrouting =
+                    { workorderid = value
+                      productid = this.productid.Value
+                      operationsequence = this.operationsequence.Value
+                      locationid = this.locationid.Value
+                      scheduledstartdate = this.scheduledstartdate.Value
+                      scheduledenddate = this.scheduledenddate.Value
+                      actualstartdate = this.actualstartdate
+                      actualenddate = this.actualenddate
+                      actualresourcehrs = this.actualresourcehrs
+                      plannedcost = this.plannedcost.Value
+                      actualcost = this.actualcost
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type pu.LeftJoined.v with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : pu.v option =
+            match this.preferredvendorstatus with
+            | Some value ->
+                let record: pu.v =
+                    { id = this.id
+                      businessentityid = this.businessentityid
+                      accountnumber = this.accountnumber
+                      name = this.name
+                      creditrating = this.creditrating
+                      preferredvendorstatus = value
+                      activeflag = this.activeflag.Value
+                      purchasingwebserviceurl = this.purchasingwebserviceurl
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.productvendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.productvendor option =
+            match this.productid with
+            | Some value ->
+                let record: purchasing.productvendor =
+                    { productid = value
+                      businessentityid = this.businessentityid.Value
+                      averageleadtime = this.averageleadtime.Value
+                      standardprice = this.standardprice.Value
+                      lastreceiptcost = this.lastreceiptcost
+                      lastreceiptdate = this.lastreceiptdate
+                      minorderqty = this.minorderqty.Value
+                      maxorderqty = this.maxorderqty.Value
+                      onorderqty = this.onorderqty
+                      unitmeasurecode = this.unitmeasurecode.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.purchaseorderdetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.purchaseorderdetail option =
+            match this.purchaseorderid with
+            | Some value ->
+                let record: purchasing.purchaseorderdetail =
+                    { purchaseorderid = value
+                      purchaseorderdetailid = this.purchaseorderdetailid.Value
+                      duedate = this.duedate.Value
+                      orderqty = this.orderqty.Value
+                      productid = this.productid.Value
+                      unitprice = this.unitprice.Value
+                      receivedqty = this.receivedqty.Value
+                      rejectedqty = this.rejectedqty.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.purchaseorderheader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.purchaseorderheader option =
+            match this.purchaseorderid with
+            | Some value ->
+                let record: purchasing.purchaseorderheader =
+                    { purchaseorderid = value
+                      revisionnumber = this.revisionnumber.Value
+                      status = this.status.Value
+                      employeeid = this.employeeid.Value
+                      vendorid = this.vendorid.Value
+                      shipmethodid = this.shipmethodid.Value
+                      orderdate = this.orderdate.Value
+                      shipdate = this.shipdate
+                      subtotal = this.subtotal.Value
+                      taxamt = this.taxamt.Value
+                      freight = this.freight.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.shipmethod with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.shipmethod option =
+            match this.shipmethodid with
+            | Some value ->
+                let record: purchasing.shipmethod =
+                    { shipmethodid = value
+                      name = this.name.Value
+                      shipbase = this.shipbase.Value
+                      shiprate = this.shiprate.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type purchasing.LeftJoined.vendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : purchasing.vendor option =
+            match this.businessentityid with
+            | Some value ->
+                let record: purchasing.vendor =
+                    { businessentityid = value
+                      accountnumber = this.accountnumber.Value
+                      name = this.name.Value
+                      creditrating = this.creditrating.Value
+                      preferredvendorstatus = this.preferredvendorstatus.Value
+                      activeflag = this.activeflag.Value
+                      purchasingwebserviceurl = this.purchasingwebserviceurl
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sa.LeftJoined.soh with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sa.soh option =
+            match this.onlineorderflag with
+            | Some value ->
+                let record: sa.soh =
+                    { id = this.id
+                      salesorderid = this.salesorderid
+                      revisionnumber = this.revisionnumber
+                      orderdate = this.orderdate
+                      duedate = this.duedate
+                      shipdate = this.shipdate
+                      status = this.status
+                      onlineorderflag = value
+                      purchaseordernumber = this.purchaseordernumber
+                      accountnumber = this.accountnumber
+                      customerid = this.customerid
+                      salespersonid = this.salespersonid
+                      territoryid = this.territoryid
+                      billtoaddressid = this.billtoaddressid
+                      shiptoaddressid = this.shiptoaddressid
+                      shipmethodid = this.shipmethodid
+                      creditcardid = this.creditcardid
+                      creditcardapprovalcode = this.creditcardapprovalcode
+                      currencyrateid = this.currencyrateid
+                      subtotal = this.subtotal
+                      taxamt = this.taxamt
+                      freight = this.freight
+                      totaldue = this.totaldue
+                      comment = this.comment
+                      rowguid = this.rowguid
+                      modifieddate = this.modifieddate }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.countryregioncurrency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.countryregioncurrency option =
+            match this.countryregioncode with
+            | Some value ->
+                let record: sales.countryregioncurrency =
+                    { countryregioncode = value; currencycode = this.currencycode.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.creditcard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.creditcard option =
+            match this.creditcardid with
+            | Some value ->
+                let record: sales.creditcard =
+                    { creditcardid = value
+                      cardtype = this.cardtype.Value
+                      cardnumber = this.cardnumber.Value
+                      expmonth = this.expmonth.Value
+                      expyear = this.expyear.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.currency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.currency option =
+            match this.currencycode with
+            | Some value ->
+                let record: sales.currency =
+                    { currencycode = value; name = this.name.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.currencyrate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.currencyrate option =
+            match this.currencyrateid with
+            | Some value ->
+                let record: sales.currencyrate =
+                    { currencyrateid = value
+                      currencyratedate = this.currencyratedate.Value
+                      fromcurrencycode = this.fromcurrencycode.Value
+                      tocurrencycode = this.tocurrencycode.Value
+                      averagerate = this.averagerate.Value
+                      endofdayrate = this.endofdayrate.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.customer option =
+            match this.customerid with
+            | Some value ->
+                let record: sales.customer =
+                    { customerid = value; personid = this.personid; storeid = this.storeid; territoryid = this.territoryid; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.personcreditcard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.personcreditcard option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.personcreditcard =
+                    { businessentityid = value; creditcardid = this.creditcardid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderdetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderdetail option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderdetail =
+                    { salesorderid = value
+                      salesorderdetailid = this.salesorderdetailid.Value
+                      carriertrackingnumber = this.carriertrackingnumber
+                      orderqty = this.orderqty.Value
+                      productid = this.productid.Value
+                      specialofferid = this.specialofferid.Value
+                      unitprice = this.unitprice.Value
+                      unitpricediscount = this.unitpricediscount.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderheader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderheader option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderheader =
+                    { salesorderid = value
+                      revisionnumber = this.revisionnumber.Value
+                      orderdate = this.orderdate.Value
+                      duedate = this.duedate.Value
+                      shipdate = this.shipdate
+                      status = this.status.Value
+                      onlineorderflag = this.onlineorderflag.Value
+                      purchaseordernumber = this.purchaseordernumber
+                      accountnumber = this.accountnumber
+                      customerid = this.customerid.Value
+                      salespersonid = this.salespersonid
+                      territoryid = this.territoryid
+                      billtoaddressid = this.billtoaddressid.Value
+                      shiptoaddressid = this.shiptoaddressid.Value
+                      shipmethodid = this.shipmethodid.Value
+                      creditcardid = this.creditcardid
+                      creditcardapprovalcode = this.creditcardapprovalcode
+                      currencyrateid = this.currencyrateid
+                      subtotal = this.subtotal.Value
+                      taxamt = this.taxamt.Value
+                      freight = this.freight.Value
+                      totaldue = this.totaldue
+                      comment = this.comment
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesorderheadersalesreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesorderheadersalesreason option =
+            match this.salesorderid with
+            | Some value ->
+                let record: sales.salesorderheadersalesreason =
+                    { salesorderid = value; salesreasonid = this.salesreasonid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesperson with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesperson option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salesperson =
+                    { businessentityid = value
+                      territoryid = this.territoryid
+                      salesquota = this.salesquota
+                      bonus = this.bonus.Value
+                      commissionpct = this.commissionpct.Value
+                      salesytd = this.salesytd.Value
+                      saleslastyear = this.saleslastyear.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salespersonquotahistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salespersonquotahistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salespersonquotahistory =
+                    { businessentityid = value; quotadate = this.quotadate.Value; salesquota = this.salesquota.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesreason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesreason option =
+            match this.salesreasonid with
+            | Some value ->
+                let record: sales.salesreason =
+                    { salesreasonid = value; name = this.name.Value; reasontype = this.reasontype.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salestaxrate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salestaxrate option =
+            match this.salestaxrateid with
+            | Some value ->
+                let record: sales.salestaxrate =
+                    { salestaxrateid = value
+                      stateprovinceid = this.stateprovinceid.Value
+                      taxtype = this.taxtype.Value
+                      taxrate = this.taxrate.Value
+                      name = this.name.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesterritory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesterritory option =
+            match this.territoryid with
+            | Some value ->
+                let record: sales.salesterritory =
+                    { territoryid = value
+                      name = this.name.Value
+                      countryregioncode = this.countryregioncode.Value
+                      group = this.group.Value
+                      salesytd = this.salesytd.Value
+                      saleslastyear = this.saleslastyear.Value
+                      costytd = this.costytd.Value
+                      costlastyear = this.costlastyear.Value
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.salesterritoryhistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.salesterritoryhistory option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.salesterritoryhistory =
+                    { businessentityid = value
+                      territoryid = this.territoryid.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.shoppingcartitem with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.shoppingcartitem option =
+            match this.shoppingcartitemid with
+            | Some value ->
+                let record: sales.shoppingcartitem =
+                    { shoppingcartitemid = value
+                      shoppingcartid = this.shoppingcartid.Value
+                      quantity = this.quantity.Value
+                      productid = this.productid.Value
+                      datecreated = this.datecreated.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.specialoffer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.specialoffer option =
+            match this.specialofferid with
+            | Some value ->
+                let record: sales.specialoffer =
+                    { specialofferid = value
+                      description = this.description.Value
+                      discountpct = this.discountpct.Value
+                      ``type`` = this.``type``.Value
+                      category = this.category.Value
+                      startdate = this.startdate.Value
+                      enddate = this.enddate.Value
+                      minqty = this.minqty.Value
+                      maxqty = this.maxqty
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.specialofferproduct with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.specialofferproduct option =
+            match this.specialofferid with
+            | Some value ->
+                let record: sales.specialofferproduct =
+                    { specialofferid = value; productid = this.productid.Value; rowguid = this.rowguid.Value; modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
+
+    type sales.LeftJoined.store with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : sales.store option =
+            match this.businessentityid with
+            | Some value ->
+                let record: sales.store =
+                    { businessentityid = value
+                      name = this.name.Value
+                      salespersonid = this.salespersonid
+                      demographics = this.demographics
+                      rowguid = this.rowguid.Value
+                      modifieddate = this.modifieddate.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Npgsql/Generation.fs
+++ b/src/Tests/Npgsql/Generation.fs
@@ -315,7 +315,12 @@ let ``The left view makes every column nullable, without double-wrapping``() =
 [<Test>]
 let ``The left view recovers the whole-record option through its PK witness``() =
     let code = generateTableWith leftViewCfg [ currencycode; name; nullableNotes ]
-    code.Contains("member this.ToOption() : ``currency (base)`` option =") =! true
+    // ToOption is an AutoOpen extension declared after the schema modules close, so its
+    // signature can name the base record honestly instead of through a `(base)` alias.
+    code.Contains("module LeftViewExtensions =") =! true
+    code.Contains("type sales.LeftJoined.currency with") =! true
+    code.Contains("member this.ToOption() : sales.currency option =") =! true
+    code.IndexOf("module LeftViewExtensions =") >! code.IndexOf("module LeftJoined =")
     code.Contains("match this.currencycode with") =! true
     code.Contains("currencycode = value") =! true
     code.Contains("name = this.name.Value") =! true
@@ -335,6 +340,8 @@ let ``A table whose columns are all nullable gets a view but no ToOption``() =
             [ { currencycode with Column.IsPK = false; Column.IsNullable = true }; nullableNotes ]
     code.Contains("module LeftJoined =") =! true
     code.Contains("ToOption") =! false
+    // With no eligible view, the extensions module is not emitted at all.
+    code.Contains("LeftViewExtensions") =! false
 
 [<Test>]
 let ``The left view keeps ProviderDbType attributes for parameter binding``() =

--- a/src/Tests/Npgsql/Generation.fs
+++ b/src/Tests/Npgsql/Generation.fs
@@ -149,6 +149,7 @@ let private baseCfg : Config =
         NullablePropertyType = NullablePropertyType.Option
         ProviderDbTypeAttributes = true
         TableDeclarations = true
+        LeftJoinedViews = false
         Readers = None
         Filters = Filters.Empty
         TypeMappingExtensions = []
@@ -188,7 +189,7 @@ let private generatedRate =
                 TypeMapping.ProviderDbType = Some "Numeric"
             } }
 
-let private generateTable columns =
+let private generateTableWith cfg columns =
     let schema : Schema =
         {
             Tables =
@@ -203,7 +204,9 @@ let private generateTable columns =
             Enums = []
         }
 
-    SchemaTemplate.generate baseCfg Provider.instance schema (Version.get()) []
+    SchemaTemplate.generate cfg Provider.instance schema (Version.get()) []
+
+let private generateTable columns = generateTableWith baseCfg columns
 
 /// `currency` with its two writable columns and the given ones.
 let private generateColumns columns = generateTable (currencycode :: name :: columns)
@@ -278,6 +281,79 @@ let ``A table with no write record has no ToWrite``() =
 let ``A table where every column is read-only gets no write record, since a record cannot be empty``() =
     let code = generateTable [ { currencycode with Column.IsReadOnly = true }; generatedRate ]
     code.Contains("_write") =! false
+
+// The left-view module (`left_joined_views`), DB-free: drives SchemaTemplate.generate with a
+// synthetic schema and asserts the generated `LeftJoined` module's shape.
+
+let private leftViewCfg = { baseCfg with LeftJoinedViews = true }
+
+let private nullableNotes =
+    { currencycode with
+        Column.Name = "notes"
+        Column.IsPK = false
+        Column.IsNullable = true }
+
+[<Test>]
+let ``left_joined_views generates a LeftJoined module with a view record and token``() =
+    let code = generateTableWith leftViewCfg [ currencycode; name; nullableNotes ]
+    code.Contains("module LeftJoined =") =! true
+    code.Contains("type private ``currency (base)`` = currency") =! true
+    code.Contains("interface ILeftViewOf<``currency (base)``>") =! true
+    code.Contains("let currency = leftTable<``currency (base)``, currency>") =! true
+
+[<Test>]
+let ``The left view makes every column nullable, without double-wrapping``() =
+    let code = generateTableWith leftViewCfg [ currencycode; name; nullableNotes ]
+    let leftJoined = code.Substring(code.IndexOf "module LeftJoined =")
+    leftJoined.Contains("currencycode: Option<string>") =! true
+    leftJoined.Contains("name: Option<string>") =! true
+    // Already-nullable stays a single Option: a NULL from a missed join is
+    // indistinguishable from a stored NULL.
+    leftJoined.Contains("notes: Option<string>") =! true
+    leftJoined.Contains("Option<Option<") =! false
+
+[<Test>]
+let ``The left view recovers the whole-record option through its PK witness``() =
+    let code = generateTableWith leftViewCfg [ currencycode; name; nullableNotes ]
+    code.Contains("member this.ToOption() : ``currency (base)`` option =") =! true
+    code.Contains("match this.currencycode with") =! true
+    code.Contains("currencycode = value") =! true
+    code.Contains("name = this.name.Value") =! true
+    // The nullable column carries over as-is.
+    code.Contains("notes = this.notes") =! true
+
+[<Test>]
+let ``Without a PK the witness is the first NOT NULL column``() =
+    let code = generateTableWith leftViewCfg [ { currencycode with Column.IsPK = false }; name; nullableNotes ]
+    code.Contains("match this.currencycode with") =! true
+
+[<Test>]
+let ``A table whose columns are all nullable gets a view but no ToOption``() =
+    // A row of all NULLs is indistinguishable from a missed join, in SQL itself.
+    let code =
+        generateTableWith leftViewCfg
+            [ { currencycode with Column.IsPK = false; Column.IsNullable = true }; nullableNotes ]
+    code.Contains("module LeftJoined =") =! true
+    code.Contains("ToOption") =! false
+
+[<Test>]
+let ``The left view keeps ProviderDbType attributes for parameter binding``() =
+    let code = generateTableWith leftViewCfg [ currencycode; name ]
+    let leftJoined = code.Substring(code.IndexOf "module LeftJoined =")
+    leftJoined.Contains("[<ProviderDbType(\"Char\")>]") =! true
+
+[<Test>]
+let ``No left views without the flag``() =
+    let code = generateTable [ currencycode; name ]
+    code.Contains("LeftJoined") =! false
+    code.Contains("leftTable") =! false
+
+[<Test>]
+let ``No left views for a Nullable-typed config``() =
+    // The views are Option-shaped by design.
+    let cfg = { leftViewCfg with NullablePropertyType = NullablePropertyType.Nullable }
+    let code = generateTableWith cfg [ currencycode; name ]
+    code.Contains("LeftJoined") =! false
 
 // Read-only detection against a live PostgreSQL: the four column kinds in one table, plus a
 // writable `tax` in the same schema and another in a same-named table elsewhere. Drop either

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -288,7 +288,36 @@ let ``Left Join - Multi Column``() =
     sql.Contains("LEFT JOIN \"sales\".\"salesorderdetail\" AS \"d\" ON (\"o\".\"salesorderid\" = \"d\".\"salesorderid\" AND \"o\".\"modifieddate\" = \"d\".\"modifieddate\")") =! true
 
 [<Test>]
-let ``Correlated Subquery``() = 
+let ``Left Join Left-View - plain ON, nullable columns downstream``() =
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            leftJoin d in sales.LeftJoined.salesorderdetail on (o.salesorderid = d.salesorderid)
+            where (d.orderqty = Some 1s)
+            select (o, d)
+        }
+        |> toSql
+
+    sql =!
+        "SELECT \"o\".*, \"d\".* FROM \"sales\".\"salesorderheader\" AS \"o\" \
+        LEFT JOIN \"sales\".\"salesorderdetail\" AS \"d\" ON (\"o\".\"salesorderid\" = \"d\".\"salesorderid\") \
+        WHERE (\"d\".\"orderqty\" = @p0)"
+
+[<Test>]
+let ``Left Join Left-View - anti-join via isNullValue on the witness column``() =
+    let sql =
+        select {
+            for o in sales.salesorderheader do
+            leftJoin d in sales.LeftJoined.salesorderdetail on (o.salesorderid = d.salesorderid)
+            where (isNullValue d.salesorderdetailid)
+            select o.salesorderid
+        }
+        |> toSql
+
+    sql.Contains("WHERE (\"d\".\"salesorderdetailid\" IS NULL)") =! true
+
+[<Test>]
+let ``Correlated Subquery``() =
     let latestOrderByCustomer = 
         select {
             for d in sales.salesorderheader do

--- a/src/Tests/Oracle/AdventureWorksNet10.fs
+++ b/src/Tests/Oracle/AdventureWorksNet10.fs
@@ -231,17 +231,6 @@ module OT =
 
             interface ILeftViewOf<``CONTACTS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CONTACTS (base)`` option =
-                match this.CONTACT_ID with
-                | Some value ->
-                    let record: ``CONTACTS (base)`` =
-                        { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
-
-                    Some record
-                | None -> None
-
         let CONTACTS = leftTable<``CONTACTS (base)``, CONTACTS>
 
         type private ``COUNTRIES (base)`` = COUNTRIES
@@ -253,17 +242,6 @@ module OT =
               REGION_ID: Option<int64> }
 
             interface ILeftViewOf<``COUNTRIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``COUNTRIES (base)`` option =
-                match this.COUNTRY_ID with
-                | Some value ->
-                    let record: ``COUNTRIES (base)`` =
-                        { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
-
-                    Some record
-                | None -> None
 
         let COUNTRIES = leftTable<``COUNTRIES (base)``, COUNTRIES>
 
@@ -278,17 +256,6 @@ module OT =
               WEBSITE: Option<string> }
 
             interface ILeftViewOf<``CUSTOMERS (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CUSTOMERS (base)`` option =
-                match this.CUSTOMER_ID with
-                | Some value ->
-                    let record: ``CUSTOMERS (base)`` =
-                        { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
-
-                    Some record
-                | None -> None
 
         let CUSTOMERS = leftTable<``CUSTOMERS (base)``, CUSTOMERS>
 
@@ -307,24 +274,6 @@ module OT =
 
             interface ILeftViewOf<``EMPLOYEES (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EMPLOYEES (base)`` option =
-                match this.EMPLOYEE_ID with
-                | Some value ->
-                    let record: ``EMPLOYEES (base)`` =
-                        { EMAIL = this.EMAIL.Value
-                          EMPLOYEE_ID = value
-                          FIRST_NAME = this.FIRST_NAME.Value
-                          HIRE_DATE = this.HIRE_DATE.Value
-                          JOB_TITLE = this.JOB_TITLE.Value
-                          LAST_NAME = this.LAST_NAME.Value
-                          MANAGER_ID = this.MANAGER_ID
-                          PHONE = this.PHONE.Value }
-
-                    Some record
-                | None -> None
-
         let EMPLOYEES = leftTable<``EMPLOYEES (base)``, EMPLOYEES>
 
         type private ``INVENTORIES (base)`` = INVENTORIES
@@ -336,17 +285,6 @@ module OT =
               WAREHOUSE_ID: Option<int64> }
 
             interface ILeftViewOf<``INVENTORIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``INVENTORIES (base)`` option =
-                match this.PRODUCT_ID with
-                | Some value ->
-                    let record: ``INVENTORIES (base)`` =
-                        { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
-
-                    Some record
-                | None -> None
 
         let INVENTORIES = leftTable<``INVENTORIES (base)``, INVENTORIES>
 
@@ -363,17 +301,6 @@ module OT =
 
             interface ILeftViewOf<``LOCATIONS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``LOCATIONS (base)`` option =
-                match this.LOCATION_ID with
-                | Some value ->
-                    let record: ``LOCATIONS (base)`` =
-                        { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
-
-                    Some record
-                | None -> None
-
         let LOCATIONS = leftTable<``LOCATIONS (base)``, LOCATIONS>
 
         type private ``ORDERS (base)`` = ORDERS
@@ -388,17 +315,6 @@ module OT =
 
             interface ILeftViewOf<``ORDERS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ORDERS (base)`` option =
-                match this.ORDER_ID with
-                | Some value ->
-                    let record: ``ORDERS (base)`` =
-                        { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
-
-                    Some record
-                | None -> None
-
         let ORDERS = leftTable<``ORDERS (base)``, ORDERS>
 
         type private ``ORDER_ITEMS (base)`` = ORDER_ITEMS
@@ -412,17 +328,6 @@ module OT =
               UNIT_PRICE: Option<decimal> }
 
             interface ILeftViewOf<``ORDER_ITEMS (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ORDER_ITEMS (base)`` option =
-                match this.ITEM_ID with
-                | Some value ->
-                    let record: ``ORDER_ITEMS (base)`` =
-                        { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
-
-                    Some record
-                | None -> None
 
         let ORDER_ITEMS = leftTable<``ORDER_ITEMS (base)``, ORDER_ITEMS>
 
@@ -439,22 +344,6 @@ module OT =
 
             interface ILeftViewOf<``PRODUCTS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PRODUCTS (base)`` option =
-                match this.PRODUCT_ID with
-                | Some value ->
-                    let record: ``PRODUCTS (base)`` =
-                        { CATEGORY_ID = this.CATEGORY_ID.Value
-                          DESCRIPTION = this.DESCRIPTION
-                          LIST_PRICE = this.LIST_PRICE
-                          PRODUCT_ID = value
-                          PRODUCT_NAME = this.PRODUCT_NAME.Value
-                          STANDARD_COST = this.STANDARD_COST }
-
-                    Some record
-                | None -> None
-
         let PRODUCTS = leftTable<``PRODUCTS (base)``, PRODUCTS>
 
         type private ``PRODUCT_CATEGORIES (base)`` = PRODUCT_CATEGORIES
@@ -465,17 +354,6 @@ module OT =
               CATEGORY_NAME: Option<string> }
 
             interface ILeftViewOf<``PRODUCT_CATEGORIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PRODUCT_CATEGORIES (base)`` option =
-                match this.CATEGORY_ID with
-                | Some value ->
-                    let record: ``PRODUCT_CATEGORIES (base)`` =
-                        { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
-
-                    Some record
-                | None -> None
 
         let PRODUCT_CATEGORIES =
             leftTable<``PRODUCT_CATEGORIES (base)``, PRODUCT_CATEGORIES>
@@ -489,17 +367,6 @@ module OT =
 
             interface ILeftViewOf<``REGIONS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``REGIONS (base)`` option =
-                match this.REGION_ID with
-                | Some value ->
-                    let record: ``REGIONS (base)`` =
-                        { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
-
-                    Some record
-                | None -> None
-
         let REGIONS = leftTable<``REGIONS (base)``, REGIONS>
 
         type private ``WAREHOUSES (base)`` = WAREHOUSES
@@ -512,18 +379,164 @@ module OT =
 
             interface ILeftViewOf<``WAREHOUSES (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WAREHOUSES (base)`` option =
-                match this.WAREHOUSE_ID with
-                | Some value ->
-                    let record: ``WAREHOUSES (base)`` =
-                        { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
-
-                    Some record
-                | None -> None
-
         let WAREHOUSES = leftTable<``WAREHOUSES (base)``, WAREHOUSES>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type OT.LeftJoined.CONTACTS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.CONTACTS option =
+            match this.CONTACT_ID with
+            | Some value ->
+                let record: OT.CONTACTS =
+                    { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.COUNTRIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.COUNTRIES option =
+            match this.COUNTRY_ID with
+            | Some value ->
+                let record: OT.COUNTRIES =
+                    { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.CUSTOMERS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.CUSTOMERS option =
+            match this.CUSTOMER_ID with
+            | Some value ->
+                let record: OT.CUSTOMERS =
+                    { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.EMPLOYEES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.EMPLOYEES option =
+            match this.EMPLOYEE_ID with
+            | Some value ->
+                let record: OT.EMPLOYEES =
+                    { EMAIL = this.EMAIL.Value
+                      EMPLOYEE_ID = value
+                      FIRST_NAME = this.FIRST_NAME.Value
+                      HIRE_DATE = this.HIRE_DATE.Value
+                      JOB_TITLE = this.JOB_TITLE.Value
+                      LAST_NAME = this.LAST_NAME.Value
+                      MANAGER_ID = this.MANAGER_ID
+                      PHONE = this.PHONE.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.INVENTORIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.INVENTORIES option =
+            match this.PRODUCT_ID with
+            | Some value ->
+                let record: OT.INVENTORIES =
+                    { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.LOCATIONS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.LOCATIONS option =
+            match this.LOCATION_ID with
+            | Some value ->
+                let record: OT.LOCATIONS =
+                    { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.ORDERS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.ORDERS option =
+            match this.ORDER_ID with
+            | Some value ->
+                let record: OT.ORDERS =
+                    { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.ORDER_ITEMS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.ORDER_ITEMS option =
+            match this.ITEM_ID with
+            | Some value ->
+                let record: OT.ORDER_ITEMS =
+                    { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.PRODUCTS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.PRODUCTS option =
+            match this.PRODUCT_ID with
+            | Some value ->
+                let record: OT.PRODUCTS =
+                    { CATEGORY_ID = this.CATEGORY_ID.Value
+                      DESCRIPTION = this.DESCRIPTION
+                      LIST_PRICE = this.LIST_PRICE
+                      PRODUCT_ID = value
+                      PRODUCT_NAME = this.PRODUCT_NAME.Value
+                      STANDARD_COST = this.STANDARD_COST }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.PRODUCT_CATEGORIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.PRODUCT_CATEGORIES option =
+            match this.CATEGORY_ID with
+            | Some value ->
+                let record: OT.PRODUCT_CATEGORIES =
+                    { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.REGIONS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.REGIONS option =
+            match this.REGION_ID with
+            | Some value ->
+                let record: OT.REGIONS = { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.WAREHOUSES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.WAREHOUSES option =
+            match this.WAREHOUSE_ID with
+            | Some value ->
+                let record: OT.WAREHOUSES =
+                    { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Oracle/AdventureWorksNet10.fs
+++ b/src/Tests/Oracle/AdventureWorksNet10.fs
@@ -215,6 +215,317 @@ module OT =
 
     let WAREHOUSES = table<WAREHOUSES>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``CONTACTS (base)`` = CONTACTS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CONTACTS =
+            { CONTACT_ID: Option<int64>
+              CUSTOMER_ID: Option<int64>
+              EMAIL: Option<string>
+              FIRST_NAME: Option<string>
+              LAST_NAME: Option<string>
+              PHONE: Option<string> }
+
+            interface ILeftViewOf<``CONTACTS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CONTACTS (base)`` option =
+                match this.CONTACT_ID with
+                | Some value ->
+                    let record: ``CONTACTS (base)`` =
+                        { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
+
+                    Some record
+                | None -> None
+
+        let CONTACTS = leftTable<``CONTACTS (base)``, CONTACTS>
+
+        type private ``COUNTRIES (base)`` = COUNTRIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type COUNTRIES =
+            { COUNTRY_ID: Option<string>
+              COUNTRY_NAME: Option<string>
+              REGION_ID: Option<int64> }
+
+            interface ILeftViewOf<``COUNTRIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``COUNTRIES (base)`` option =
+                match this.COUNTRY_ID with
+                | Some value ->
+                    let record: ``COUNTRIES (base)`` =
+                        { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
+
+                    Some record
+                | None -> None
+
+        let COUNTRIES = leftTable<``COUNTRIES (base)``, COUNTRIES>
+
+        type private ``CUSTOMERS (base)`` = CUSTOMERS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CUSTOMERS =
+            { ADDRESS: Option<string>
+              CREDIT_LIMIT: Option<decimal>
+              CUSTOMER_ID: Option<int64>
+              NAME: Option<string>
+              WEBSITE: Option<string> }
+
+            interface ILeftViewOf<``CUSTOMERS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CUSTOMERS (base)`` option =
+                match this.CUSTOMER_ID with
+                | Some value ->
+                    let record: ``CUSTOMERS (base)`` =
+                        { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
+
+                    Some record
+                | None -> None
+
+        let CUSTOMERS = leftTable<``CUSTOMERS (base)``, CUSTOMERS>
+
+        type private ``EMPLOYEES (base)`` = EMPLOYEES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EMPLOYEES =
+            { EMAIL: Option<string>
+              EMPLOYEE_ID: Option<int64>
+              FIRST_NAME: Option<string>
+              HIRE_DATE: Option<System.DateTime>
+              JOB_TITLE: Option<string>
+              LAST_NAME: Option<string>
+              MANAGER_ID: Option<int64>
+              PHONE: Option<string> }
+
+            interface ILeftViewOf<``EMPLOYEES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EMPLOYEES (base)`` option =
+                match this.EMPLOYEE_ID with
+                | Some value ->
+                    let record: ``EMPLOYEES (base)`` =
+                        { EMAIL = this.EMAIL.Value
+                          EMPLOYEE_ID = value
+                          FIRST_NAME = this.FIRST_NAME.Value
+                          HIRE_DATE = this.HIRE_DATE.Value
+                          JOB_TITLE = this.JOB_TITLE.Value
+                          LAST_NAME = this.LAST_NAME.Value
+                          MANAGER_ID = this.MANAGER_ID
+                          PHONE = this.PHONE.Value }
+
+                    Some record
+                | None -> None
+
+        let EMPLOYEES = leftTable<``EMPLOYEES (base)``, EMPLOYEES>
+
+        type private ``INVENTORIES (base)`` = INVENTORIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type INVENTORIES =
+            { PRODUCT_ID: Option<int64>
+              QUANTITY: Option<int64>
+              WAREHOUSE_ID: Option<int64> }
+
+            interface ILeftViewOf<``INVENTORIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``INVENTORIES (base)`` option =
+                match this.PRODUCT_ID with
+                | Some value ->
+                    let record: ``INVENTORIES (base)`` =
+                        { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
+
+                    Some record
+                | None -> None
+
+        let INVENTORIES = leftTable<``INVENTORIES (base)``, INVENTORIES>
+
+        type private ``LOCATIONS (base)`` = LOCATIONS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type LOCATIONS =
+            { ADDRESS: Option<string>
+              CITY: Option<string>
+              COUNTRY_ID: Option<string>
+              LOCATION_ID: Option<int64>
+              POSTAL_CODE: Option<string>
+              STATE: Option<string> }
+
+            interface ILeftViewOf<``LOCATIONS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``LOCATIONS (base)`` option =
+                match this.LOCATION_ID with
+                | Some value ->
+                    let record: ``LOCATIONS (base)`` =
+                        { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
+
+                    Some record
+                | None -> None
+
+        let LOCATIONS = leftTable<``LOCATIONS (base)``, LOCATIONS>
+
+        type private ``ORDERS (base)`` = ORDERS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ORDERS =
+            { CUSTOMER_ID: Option<int64>
+              ORDER_DATE: Option<System.DateTime>
+              ORDER_ID: Option<int64>
+              SALESMAN_ID: Option<int64>
+              STATUS: Option<string> }
+
+            interface ILeftViewOf<``ORDERS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ORDERS (base)`` option =
+                match this.ORDER_ID with
+                | Some value ->
+                    let record: ``ORDERS (base)`` =
+                        { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
+
+                    Some record
+                | None -> None
+
+        let ORDERS = leftTable<``ORDERS (base)``, ORDERS>
+
+        type private ``ORDER_ITEMS (base)`` = ORDER_ITEMS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ORDER_ITEMS =
+            { ITEM_ID: Option<int64>
+              ORDER_ID: Option<int64>
+              PRODUCT_ID: Option<int64>
+              QUANTITY: Option<int64>
+              UNIT_PRICE: Option<decimal> }
+
+            interface ILeftViewOf<``ORDER_ITEMS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ORDER_ITEMS (base)`` option =
+                match this.ITEM_ID with
+                | Some value ->
+                    let record: ``ORDER_ITEMS (base)`` =
+                        { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
+
+                    Some record
+                | None -> None
+
+        let ORDER_ITEMS = leftTable<``ORDER_ITEMS (base)``, ORDER_ITEMS>
+
+        type private ``PRODUCTS (base)`` = PRODUCTS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PRODUCTS =
+            { CATEGORY_ID: Option<int64>
+              DESCRIPTION: Option<string>
+              LIST_PRICE: Option<decimal>
+              PRODUCT_ID: Option<int64>
+              PRODUCT_NAME: Option<string>
+              STANDARD_COST: Option<decimal> }
+
+            interface ILeftViewOf<``PRODUCTS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PRODUCTS (base)`` option =
+                match this.PRODUCT_ID with
+                | Some value ->
+                    let record: ``PRODUCTS (base)`` =
+                        { CATEGORY_ID = this.CATEGORY_ID.Value
+                          DESCRIPTION = this.DESCRIPTION
+                          LIST_PRICE = this.LIST_PRICE
+                          PRODUCT_ID = value
+                          PRODUCT_NAME = this.PRODUCT_NAME.Value
+                          STANDARD_COST = this.STANDARD_COST }
+
+                    Some record
+                | None -> None
+
+        let PRODUCTS = leftTable<``PRODUCTS (base)``, PRODUCTS>
+
+        type private ``PRODUCT_CATEGORIES (base)`` = PRODUCT_CATEGORIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PRODUCT_CATEGORIES =
+            { CATEGORY_ID: Option<int64>
+              CATEGORY_NAME: Option<string> }
+
+            interface ILeftViewOf<``PRODUCT_CATEGORIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PRODUCT_CATEGORIES (base)`` option =
+                match this.CATEGORY_ID with
+                | Some value ->
+                    let record: ``PRODUCT_CATEGORIES (base)`` =
+                        { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
+
+                    Some record
+                | None -> None
+
+        let PRODUCT_CATEGORIES =
+            leftTable<``PRODUCT_CATEGORIES (base)``, PRODUCT_CATEGORIES>
+
+        type private ``REGIONS (base)`` = REGIONS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type REGIONS =
+            { REGION_ID: Option<int64>
+              REGION_NAME: Option<string> }
+
+            interface ILeftViewOf<``REGIONS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``REGIONS (base)`` option =
+                match this.REGION_ID with
+                | Some value ->
+                    let record: ``REGIONS (base)`` =
+                        { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
+
+                    Some record
+                | None -> None
+
+        let REGIONS = leftTable<``REGIONS (base)``, REGIONS>
+
+        type private ``WAREHOUSES (base)`` = WAREHOUSES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WAREHOUSES =
+            { LOCATION_ID: Option<int64>
+              WAREHOUSE_ID: Option<int64>
+              WAREHOUSE_NAME: Option<string> }
+
+            interface ILeftViewOf<``WAREHOUSES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WAREHOUSES (base)`` option =
+                match this.WAREHOUSE_ID with
+                | Some value ->
+                    let record: ``WAREHOUSES (base)`` =
+                        { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
+
+                    Some record
+                | None -> None
+
+        let WAREHOUSES = leftTable<``WAREHOUSES (base)``, WAREHOUSES>
+
+
 
 
 type QueryContextFactory =

--- a/src/Tests/Oracle/AdventureWorksNet8.fs
+++ b/src/Tests/Oracle/AdventureWorksNet8.fs
@@ -231,17 +231,6 @@ module OT =
 
             interface ILeftViewOf<``CONTACTS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CONTACTS (base)`` option =
-                match this.CONTACT_ID with
-                | Some value ->
-                    let record: ``CONTACTS (base)`` =
-                        { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
-
-                    Some record
-                | None -> None
-
         let CONTACTS = leftTable<``CONTACTS (base)``, CONTACTS>
 
         type private ``COUNTRIES (base)`` = COUNTRIES
@@ -253,17 +242,6 @@ module OT =
               REGION_ID: Option<int64> }
 
             interface ILeftViewOf<``COUNTRIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``COUNTRIES (base)`` option =
-                match this.COUNTRY_ID with
-                | Some value ->
-                    let record: ``COUNTRIES (base)`` =
-                        { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
-
-                    Some record
-                | None -> None
 
         let COUNTRIES = leftTable<``COUNTRIES (base)``, COUNTRIES>
 
@@ -278,17 +256,6 @@ module OT =
               WEBSITE: Option<string> }
 
             interface ILeftViewOf<``CUSTOMERS (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CUSTOMERS (base)`` option =
-                match this.CUSTOMER_ID with
-                | Some value ->
-                    let record: ``CUSTOMERS (base)`` =
-                        { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
-
-                    Some record
-                | None -> None
 
         let CUSTOMERS = leftTable<``CUSTOMERS (base)``, CUSTOMERS>
 
@@ -307,24 +274,6 @@ module OT =
 
             interface ILeftViewOf<``EMPLOYEES (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EMPLOYEES (base)`` option =
-                match this.EMPLOYEE_ID with
-                | Some value ->
-                    let record: ``EMPLOYEES (base)`` =
-                        { EMAIL = this.EMAIL.Value
-                          EMPLOYEE_ID = value
-                          FIRST_NAME = this.FIRST_NAME.Value
-                          HIRE_DATE = this.HIRE_DATE.Value
-                          JOB_TITLE = this.JOB_TITLE.Value
-                          LAST_NAME = this.LAST_NAME.Value
-                          MANAGER_ID = this.MANAGER_ID
-                          PHONE = this.PHONE.Value }
-
-                    Some record
-                | None -> None
-
         let EMPLOYEES = leftTable<``EMPLOYEES (base)``, EMPLOYEES>
 
         type private ``INVENTORIES (base)`` = INVENTORIES
@@ -336,17 +285,6 @@ module OT =
               WAREHOUSE_ID: Option<int64> }
 
             interface ILeftViewOf<``INVENTORIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``INVENTORIES (base)`` option =
-                match this.PRODUCT_ID with
-                | Some value ->
-                    let record: ``INVENTORIES (base)`` =
-                        { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
-
-                    Some record
-                | None -> None
 
         let INVENTORIES = leftTable<``INVENTORIES (base)``, INVENTORIES>
 
@@ -363,17 +301,6 @@ module OT =
 
             interface ILeftViewOf<``LOCATIONS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``LOCATIONS (base)`` option =
-                match this.LOCATION_ID with
-                | Some value ->
-                    let record: ``LOCATIONS (base)`` =
-                        { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
-
-                    Some record
-                | None -> None
-
         let LOCATIONS = leftTable<``LOCATIONS (base)``, LOCATIONS>
 
         type private ``ORDERS (base)`` = ORDERS
@@ -388,17 +315,6 @@ module OT =
 
             interface ILeftViewOf<``ORDERS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ORDERS (base)`` option =
-                match this.ORDER_ID with
-                | Some value ->
-                    let record: ``ORDERS (base)`` =
-                        { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
-
-                    Some record
-                | None -> None
-
         let ORDERS = leftTable<``ORDERS (base)``, ORDERS>
 
         type private ``ORDER_ITEMS (base)`` = ORDER_ITEMS
@@ -412,17 +328,6 @@ module OT =
               UNIT_PRICE: Option<decimal> }
 
             interface ILeftViewOf<``ORDER_ITEMS (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ORDER_ITEMS (base)`` option =
-                match this.ITEM_ID with
-                | Some value ->
-                    let record: ``ORDER_ITEMS (base)`` =
-                        { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
-
-                    Some record
-                | None -> None
 
         let ORDER_ITEMS = leftTable<``ORDER_ITEMS (base)``, ORDER_ITEMS>
 
@@ -439,22 +344,6 @@ module OT =
 
             interface ILeftViewOf<``PRODUCTS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PRODUCTS (base)`` option =
-                match this.PRODUCT_ID with
-                | Some value ->
-                    let record: ``PRODUCTS (base)`` =
-                        { CATEGORY_ID = this.CATEGORY_ID.Value
-                          DESCRIPTION = this.DESCRIPTION
-                          LIST_PRICE = this.LIST_PRICE
-                          PRODUCT_ID = value
-                          PRODUCT_NAME = this.PRODUCT_NAME.Value
-                          STANDARD_COST = this.STANDARD_COST }
-
-                    Some record
-                | None -> None
-
         let PRODUCTS = leftTable<``PRODUCTS (base)``, PRODUCTS>
 
         type private ``PRODUCT_CATEGORIES (base)`` = PRODUCT_CATEGORIES
@@ -465,17 +354,6 @@ module OT =
               CATEGORY_NAME: Option<string> }
 
             interface ILeftViewOf<``PRODUCT_CATEGORIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PRODUCT_CATEGORIES (base)`` option =
-                match this.CATEGORY_ID with
-                | Some value ->
-                    let record: ``PRODUCT_CATEGORIES (base)`` =
-                        { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
-
-                    Some record
-                | None -> None
 
         let PRODUCT_CATEGORIES =
             leftTable<``PRODUCT_CATEGORIES (base)``, PRODUCT_CATEGORIES>
@@ -489,17 +367,6 @@ module OT =
 
             interface ILeftViewOf<``REGIONS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``REGIONS (base)`` option =
-                match this.REGION_ID with
-                | Some value ->
-                    let record: ``REGIONS (base)`` =
-                        { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
-
-                    Some record
-                | None -> None
-
         let REGIONS = leftTable<``REGIONS (base)``, REGIONS>
 
         type private ``WAREHOUSES (base)`` = WAREHOUSES
@@ -512,18 +379,164 @@ module OT =
 
             interface ILeftViewOf<``WAREHOUSES (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WAREHOUSES (base)`` option =
-                match this.WAREHOUSE_ID with
-                | Some value ->
-                    let record: ``WAREHOUSES (base)`` =
-                        { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
-
-                    Some record
-                | None -> None
-
         let WAREHOUSES = leftTable<``WAREHOUSES (base)``, WAREHOUSES>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type OT.LeftJoined.CONTACTS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.CONTACTS option =
+            match this.CONTACT_ID with
+            | Some value ->
+                let record: OT.CONTACTS =
+                    { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.COUNTRIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.COUNTRIES option =
+            match this.COUNTRY_ID with
+            | Some value ->
+                let record: OT.COUNTRIES =
+                    { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.CUSTOMERS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.CUSTOMERS option =
+            match this.CUSTOMER_ID with
+            | Some value ->
+                let record: OT.CUSTOMERS =
+                    { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.EMPLOYEES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.EMPLOYEES option =
+            match this.EMPLOYEE_ID with
+            | Some value ->
+                let record: OT.EMPLOYEES =
+                    { EMAIL = this.EMAIL.Value
+                      EMPLOYEE_ID = value
+                      FIRST_NAME = this.FIRST_NAME.Value
+                      HIRE_DATE = this.HIRE_DATE.Value
+                      JOB_TITLE = this.JOB_TITLE.Value
+                      LAST_NAME = this.LAST_NAME.Value
+                      MANAGER_ID = this.MANAGER_ID
+                      PHONE = this.PHONE.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.INVENTORIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.INVENTORIES option =
+            match this.PRODUCT_ID with
+            | Some value ->
+                let record: OT.INVENTORIES =
+                    { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.LOCATIONS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.LOCATIONS option =
+            match this.LOCATION_ID with
+            | Some value ->
+                let record: OT.LOCATIONS =
+                    { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.ORDERS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.ORDERS option =
+            match this.ORDER_ID with
+            | Some value ->
+                let record: OT.ORDERS =
+                    { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.ORDER_ITEMS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.ORDER_ITEMS option =
+            match this.ITEM_ID with
+            | Some value ->
+                let record: OT.ORDER_ITEMS =
+                    { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.PRODUCTS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.PRODUCTS option =
+            match this.PRODUCT_ID with
+            | Some value ->
+                let record: OT.PRODUCTS =
+                    { CATEGORY_ID = this.CATEGORY_ID.Value
+                      DESCRIPTION = this.DESCRIPTION
+                      LIST_PRICE = this.LIST_PRICE
+                      PRODUCT_ID = value
+                      PRODUCT_NAME = this.PRODUCT_NAME.Value
+                      STANDARD_COST = this.STANDARD_COST }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.PRODUCT_CATEGORIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.PRODUCT_CATEGORIES option =
+            match this.CATEGORY_ID with
+            | Some value ->
+                let record: OT.PRODUCT_CATEGORIES =
+                    { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.REGIONS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.REGIONS option =
+            match this.REGION_ID with
+            | Some value ->
+                let record: OT.REGIONS = { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.WAREHOUSES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.WAREHOUSES option =
+            match this.WAREHOUSE_ID with
+            | Some value ->
+                let record: OT.WAREHOUSES =
+                    { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Oracle/AdventureWorksNet8.fs
+++ b/src/Tests/Oracle/AdventureWorksNet8.fs
@@ -215,6 +215,317 @@ module OT =
 
     let WAREHOUSES = table<WAREHOUSES>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``CONTACTS (base)`` = CONTACTS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CONTACTS =
+            { CONTACT_ID: Option<int64>
+              CUSTOMER_ID: Option<int64>
+              EMAIL: Option<string>
+              FIRST_NAME: Option<string>
+              LAST_NAME: Option<string>
+              PHONE: Option<string> }
+
+            interface ILeftViewOf<``CONTACTS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CONTACTS (base)`` option =
+                match this.CONTACT_ID with
+                | Some value ->
+                    let record: ``CONTACTS (base)`` =
+                        { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
+
+                    Some record
+                | None -> None
+
+        let CONTACTS = leftTable<``CONTACTS (base)``, CONTACTS>
+
+        type private ``COUNTRIES (base)`` = COUNTRIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type COUNTRIES =
+            { COUNTRY_ID: Option<string>
+              COUNTRY_NAME: Option<string>
+              REGION_ID: Option<int64> }
+
+            interface ILeftViewOf<``COUNTRIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``COUNTRIES (base)`` option =
+                match this.COUNTRY_ID with
+                | Some value ->
+                    let record: ``COUNTRIES (base)`` =
+                        { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
+
+                    Some record
+                | None -> None
+
+        let COUNTRIES = leftTable<``COUNTRIES (base)``, COUNTRIES>
+
+        type private ``CUSTOMERS (base)`` = CUSTOMERS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CUSTOMERS =
+            { ADDRESS: Option<string>
+              CREDIT_LIMIT: Option<decimal>
+              CUSTOMER_ID: Option<int64>
+              NAME: Option<string>
+              WEBSITE: Option<string> }
+
+            interface ILeftViewOf<``CUSTOMERS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CUSTOMERS (base)`` option =
+                match this.CUSTOMER_ID with
+                | Some value ->
+                    let record: ``CUSTOMERS (base)`` =
+                        { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
+
+                    Some record
+                | None -> None
+
+        let CUSTOMERS = leftTable<``CUSTOMERS (base)``, CUSTOMERS>
+
+        type private ``EMPLOYEES (base)`` = EMPLOYEES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EMPLOYEES =
+            { EMAIL: Option<string>
+              EMPLOYEE_ID: Option<int64>
+              FIRST_NAME: Option<string>
+              HIRE_DATE: Option<System.DateTime>
+              JOB_TITLE: Option<string>
+              LAST_NAME: Option<string>
+              MANAGER_ID: Option<int64>
+              PHONE: Option<string> }
+
+            interface ILeftViewOf<``EMPLOYEES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EMPLOYEES (base)`` option =
+                match this.EMPLOYEE_ID with
+                | Some value ->
+                    let record: ``EMPLOYEES (base)`` =
+                        { EMAIL = this.EMAIL.Value
+                          EMPLOYEE_ID = value
+                          FIRST_NAME = this.FIRST_NAME.Value
+                          HIRE_DATE = this.HIRE_DATE.Value
+                          JOB_TITLE = this.JOB_TITLE.Value
+                          LAST_NAME = this.LAST_NAME.Value
+                          MANAGER_ID = this.MANAGER_ID
+                          PHONE = this.PHONE.Value }
+
+                    Some record
+                | None -> None
+
+        let EMPLOYEES = leftTable<``EMPLOYEES (base)``, EMPLOYEES>
+
+        type private ``INVENTORIES (base)`` = INVENTORIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type INVENTORIES =
+            { PRODUCT_ID: Option<int64>
+              QUANTITY: Option<int64>
+              WAREHOUSE_ID: Option<int64> }
+
+            interface ILeftViewOf<``INVENTORIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``INVENTORIES (base)`` option =
+                match this.PRODUCT_ID with
+                | Some value ->
+                    let record: ``INVENTORIES (base)`` =
+                        { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
+
+                    Some record
+                | None -> None
+
+        let INVENTORIES = leftTable<``INVENTORIES (base)``, INVENTORIES>
+
+        type private ``LOCATIONS (base)`` = LOCATIONS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type LOCATIONS =
+            { ADDRESS: Option<string>
+              CITY: Option<string>
+              COUNTRY_ID: Option<string>
+              LOCATION_ID: Option<int64>
+              POSTAL_CODE: Option<string>
+              STATE: Option<string> }
+
+            interface ILeftViewOf<``LOCATIONS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``LOCATIONS (base)`` option =
+                match this.LOCATION_ID with
+                | Some value ->
+                    let record: ``LOCATIONS (base)`` =
+                        { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
+
+                    Some record
+                | None -> None
+
+        let LOCATIONS = leftTable<``LOCATIONS (base)``, LOCATIONS>
+
+        type private ``ORDERS (base)`` = ORDERS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ORDERS =
+            { CUSTOMER_ID: Option<int64>
+              ORDER_DATE: Option<System.DateTime>
+              ORDER_ID: Option<int64>
+              SALESMAN_ID: Option<int64>
+              STATUS: Option<string> }
+
+            interface ILeftViewOf<``ORDERS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ORDERS (base)`` option =
+                match this.ORDER_ID with
+                | Some value ->
+                    let record: ``ORDERS (base)`` =
+                        { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
+
+                    Some record
+                | None -> None
+
+        let ORDERS = leftTable<``ORDERS (base)``, ORDERS>
+
+        type private ``ORDER_ITEMS (base)`` = ORDER_ITEMS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ORDER_ITEMS =
+            { ITEM_ID: Option<int64>
+              ORDER_ID: Option<int64>
+              PRODUCT_ID: Option<int64>
+              QUANTITY: Option<int64>
+              UNIT_PRICE: Option<decimal> }
+
+            interface ILeftViewOf<``ORDER_ITEMS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ORDER_ITEMS (base)`` option =
+                match this.ITEM_ID with
+                | Some value ->
+                    let record: ``ORDER_ITEMS (base)`` =
+                        { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
+
+                    Some record
+                | None -> None
+
+        let ORDER_ITEMS = leftTable<``ORDER_ITEMS (base)``, ORDER_ITEMS>
+
+        type private ``PRODUCTS (base)`` = PRODUCTS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PRODUCTS =
+            { CATEGORY_ID: Option<int64>
+              DESCRIPTION: Option<string>
+              LIST_PRICE: Option<decimal>
+              PRODUCT_ID: Option<int64>
+              PRODUCT_NAME: Option<string>
+              STANDARD_COST: Option<decimal> }
+
+            interface ILeftViewOf<``PRODUCTS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PRODUCTS (base)`` option =
+                match this.PRODUCT_ID with
+                | Some value ->
+                    let record: ``PRODUCTS (base)`` =
+                        { CATEGORY_ID = this.CATEGORY_ID.Value
+                          DESCRIPTION = this.DESCRIPTION
+                          LIST_PRICE = this.LIST_PRICE
+                          PRODUCT_ID = value
+                          PRODUCT_NAME = this.PRODUCT_NAME.Value
+                          STANDARD_COST = this.STANDARD_COST }
+
+                    Some record
+                | None -> None
+
+        let PRODUCTS = leftTable<``PRODUCTS (base)``, PRODUCTS>
+
+        type private ``PRODUCT_CATEGORIES (base)`` = PRODUCT_CATEGORIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PRODUCT_CATEGORIES =
+            { CATEGORY_ID: Option<int64>
+              CATEGORY_NAME: Option<string> }
+
+            interface ILeftViewOf<``PRODUCT_CATEGORIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PRODUCT_CATEGORIES (base)`` option =
+                match this.CATEGORY_ID with
+                | Some value ->
+                    let record: ``PRODUCT_CATEGORIES (base)`` =
+                        { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
+
+                    Some record
+                | None -> None
+
+        let PRODUCT_CATEGORIES =
+            leftTable<``PRODUCT_CATEGORIES (base)``, PRODUCT_CATEGORIES>
+
+        type private ``REGIONS (base)`` = REGIONS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type REGIONS =
+            { REGION_ID: Option<int64>
+              REGION_NAME: Option<string> }
+
+            interface ILeftViewOf<``REGIONS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``REGIONS (base)`` option =
+                match this.REGION_ID with
+                | Some value ->
+                    let record: ``REGIONS (base)`` =
+                        { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
+
+                    Some record
+                | None -> None
+
+        let REGIONS = leftTable<``REGIONS (base)``, REGIONS>
+
+        type private ``WAREHOUSES (base)`` = WAREHOUSES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WAREHOUSES =
+            { LOCATION_ID: Option<int64>
+              WAREHOUSE_ID: Option<int64>
+              WAREHOUSE_NAME: Option<string> }
+
+            interface ILeftViewOf<``WAREHOUSES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WAREHOUSES (base)`` option =
+                match this.WAREHOUSE_ID with
+                | Some value ->
+                    let record: ``WAREHOUSES (base)`` =
+                        { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
+
+                    Some record
+                | None -> None
+
+        let WAREHOUSES = leftTable<``WAREHOUSES (base)``, WAREHOUSES>
+
+
 
 
 type QueryContextFactory =

--- a/src/Tests/Oracle/AdventureWorksNet9.fs
+++ b/src/Tests/Oracle/AdventureWorksNet9.fs
@@ -231,17 +231,6 @@ module OT =
 
             interface ILeftViewOf<``CONTACTS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CONTACTS (base)`` option =
-                match this.CONTACT_ID with
-                | Some value ->
-                    let record: ``CONTACTS (base)`` =
-                        { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
-
-                    Some record
-                | None -> None
-
         let CONTACTS = leftTable<``CONTACTS (base)``, CONTACTS>
 
         type private ``COUNTRIES (base)`` = COUNTRIES
@@ -253,17 +242,6 @@ module OT =
               REGION_ID: Option<int64> }
 
             interface ILeftViewOf<``COUNTRIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``COUNTRIES (base)`` option =
-                match this.COUNTRY_ID with
-                | Some value ->
-                    let record: ``COUNTRIES (base)`` =
-                        { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
-
-                    Some record
-                | None -> None
 
         let COUNTRIES = leftTable<``COUNTRIES (base)``, COUNTRIES>
 
@@ -278,17 +256,6 @@ module OT =
               WEBSITE: Option<string> }
 
             interface ILeftViewOf<``CUSTOMERS (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CUSTOMERS (base)`` option =
-                match this.CUSTOMER_ID with
-                | Some value ->
-                    let record: ``CUSTOMERS (base)`` =
-                        { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
-
-                    Some record
-                | None -> None
 
         let CUSTOMERS = leftTable<``CUSTOMERS (base)``, CUSTOMERS>
 
@@ -307,24 +274,6 @@ module OT =
 
             interface ILeftViewOf<``EMPLOYEES (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EMPLOYEES (base)`` option =
-                match this.EMPLOYEE_ID with
-                | Some value ->
-                    let record: ``EMPLOYEES (base)`` =
-                        { EMAIL = this.EMAIL.Value
-                          EMPLOYEE_ID = value
-                          FIRST_NAME = this.FIRST_NAME.Value
-                          HIRE_DATE = this.HIRE_DATE.Value
-                          JOB_TITLE = this.JOB_TITLE.Value
-                          LAST_NAME = this.LAST_NAME.Value
-                          MANAGER_ID = this.MANAGER_ID
-                          PHONE = this.PHONE.Value }
-
-                    Some record
-                | None -> None
-
         let EMPLOYEES = leftTable<``EMPLOYEES (base)``, EMPLOYEES>
 
         type private ``INVENTORIES (base)`` = INVENTORIES
@@ -336,17 +285,6 @@ module OT =
               WAREHOUSE_ID: Option<int64> }
 
             interface ILeftViewOf<``INVENTORIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``INVENTORIES (base)`` option =
-                match this.PRODUCT_ID with
-                | Some value ->
-                    let record: ``INVENTORIES (base)`` =
-                        { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
-
-                    Some record
-                | None -> None
 
         let INVENTORIES = leftTable<``INVENTORIES (base)``, INVENTORIES>
 
@@ -363,17 +301,6 @@ module OT =
 
             interface ILeftViewOf<``LOCATIONS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``LOCATIONS (base)`` option =
-                match this.LOCATION_ID with
-                | Some value ->
-                    let record: ``LOCATIONS (base)`` =
-                        { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
-
-                    Some record
-                | None -> None
-
         let LOCATIONS = leftTable<``LOCATIONS (base)``, LOCATIONS>
 
         type private ``ORDERS (base)`` = ORDERS
@@ -388,17 +315,6 @@ module OT =
 
             interface ILeftViewOf<``ORDERS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ORDERS (base)`` option =
-                match this.ORDER_ID with
-                | Some value ->
-                    let record: ``ORDERS (base)`` =
-                        { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
-
-                    Some record
-                | None -> None
-
         let ORDERS = leftTable<``ORDERS (base)``, ORDERS>
 
         type private ``ORDER_ITEMS (base)`` = ORDER_ITEMS
@@ -412,17 +328,6 @@ module OT =
               UNIT_PRICE: Option<decimal> }
 
             interface ILeftViewOf<``ORDER_ITEMS (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ORDER_ITEMS (base)`` option =
-                match this.ITEM_ID with
-                | Some value ->
-                    let record: ``ORDER_ITEMS (base)`` =
-                        { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
-
-                    Some record
-                | None -> None
 
         let ORDER_ITEMS = leftTable<``ORDER_ITEMS (base)``, ORDER_ITEMS>
 
@@ -439,22 +344,6 @@ module OT =
 
             interface ILeftViewOf<``PRODUCTS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PRODUCTS (base)`` option =
-                match this.PRODUCT_ID with
-                | Some value ->
-                    let record: ``PRODUCTS (base)`` =
-                        { CATEGORY_ID = this.CATEGORY_ID.Value
-                          DESCRIPTION = this.DESCRIPTION
-                          LIST_PRICE = this.LIST_PRICE
-                          PRODUCT_ID = value
-                          PRODUCT_NAME = this.PRODUCT_NAME.Value
-                          STANDARD_COST = this.STANDARD_COST }
-
-                    Some record
-                | None -> None
-
         let PRODUCTS = leftTable<``PRODUCTS (base)``, PRODUCTS>
 
         type private ``PRODUCT_CATEGORIES (base)`` = PRODUCT_CATEGORIES
@@ -465,17 +354,6 @@ module OT =
               CATEGORY_NAME: Option<string> }
 
             interface ILeftViewOf<``PRODUCT_CATEGORIES (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PRODUCT_CATEGORIES (base)`` option =
-                match this.CATEGORY_ID with
-                | Some value ->
-                    let record: ``PRODUCT_CATEGORIES (base)`` =
-                        { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
-
-                    Some record
-                | None -> None
 
         let PRODUCT_CATEGORIES =
             leftTable<``PRODUCT_CATEGORIES (base)``, PRODUCT_CATEGORIES>
@@ -489,17 +367,6 @@ module OT =
 
             interface ILeftViewOf<``REGIONS (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``REGIONS (base)`` option =
-                match this.REGION_ID with
-                | Some value ->
-                    let record: ``REGIONS (base)`` =
-                        { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
-
-                    Some record
-                | None -> None
-
         let REGIONS = leftTable<``REGIONS (base)``, REGIONS>
 
         type private ``WAREHOUSES (base)`` = WAREHOUSES
@@ -512,18 +379,164 @@ module OT =
 
             interface ILeftViewOf<``WAREHOUSES (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WAREHOUSES (base)`` option =
-                match this.WAREHOUSE_ID with
-                | Some value ->
-                    let record: ``WAREHOUSES (base)`` =
-                        { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
-
-                    Some record
-                | None -> None
-
         let WAREHOUSES = leftTable<``WAREHOUSES (base)``, WAREHOUSES>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type OT.LeftJoined.CONTACTS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.CONTACTS option =
+            match this.CONTACT_ID with
+            | Some value ->
+                let record: OT.CONTACTS =
+                    { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.COUNTRIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.COUNTRIES option =
+            match this.COUNTRY_ID with
+            | Some value ->
+                let record: OT.COUNTRIES =
+                    { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.CUSTOMERS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.CUSTOMERS option =
+            match this.CUSTOMER_ID with
+            | Some value ->
+                let record: OT.CUSTOMERS =
+                    { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.EMPLOYEES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.EMPLOYEES option =
+            match this.EMPLOYEE_ID with
+            | Some value ->
+                let record: OT.EMPLOYEES =
+                    { EMAIL = this.EMAIL.Value
+                      EMPLOYEE_ID = value
+                      FIRST_NAME = this.FIRST_NAME.Value
+                      HIRE_DATE = this.HIRE_DATE.Value
+                      JOB_TITLE = this.JOB_TITLE.Value
+                      LAST_NAME = this.LAST_NAME.Value
+                      MANAGER_ID = this.MANAGER_ID
+                      PHONE = this.PHONE.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.INVENTORIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.INVENTORIES option =
+            match this.PRODUCT_ID with
+            | Some value ->
+                let record: OT.INVENTORIES =
+                    { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.LOCATIONS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.LOCATIONS option =
+            match this.LOCATION_ID with
+            | Some value ->
+                let record: OT.LOCATIONS =
+                    { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.ORDERS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.ORDERS option =
+            match this.ORDER_ID with
+            | Some value ->
+                let record: OT.ORDERS =
+                    { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.ORDER_ITEMS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.ORDER_ITEMS option =
+            match this.ITEM_ID with
+            | Some value ->
+                let record: OT.ORDER_ITEMS =
+                    { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.PRODUCTS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.PRODUCTS option =
+            match this.PRODUCT_ID with
+            | Some value ->
+                let record: OT.PRODUCTS =
+                    { CATEGORY_ID = this.CATEGORY_ID.Value
+                      DESCRIPTION = this.DESCRIPTION
+                      LIST_PRICE = this.LIST_PRICE
+                      PRODUCT_ID = value
+                      PRODUCT_NAME = this.PRODUCT_NAME.Value
+                      STANDARD_COST = this.STANDARD_COST }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.PRODUCT_CATEGORIES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.PRODUCT_CATEGORIES option =
+            match this.CATEGORY_ID with
+            | Some value ->
+                let record: OT.PRODUCT_CATEGORIES =
+                    { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
+
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.REGIONS with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.REGIONS option =
+            match this.REGION_ID with
+            | Some value ->
+                let record: OT.REGIONS = { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
+                Some record
+            | None -> None
+
+    type OT.LeftJoined.WAREHOUSES with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : OT.WAREHOUSES option =
+            match this.WAREHOUSE_ID with
+            | Some value ->
+                let record: OT.WAREHOUSES =
+                    { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Oracle/AdventureWorksNet9.fs
+++ b/src/Tests/Oracle/AdventureWorksNet9.fs
@@ -215,6 +215,317 @@ module OT =
 
     let WAREHOUSES = table<WAREHOUSES>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``CONTACTS (base)`` = CONTACTS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CONTACTS =
+            { CONTACT_ID: Option<int64>
+              CUSTOMER_ID: Option<int64>
+              EMAIL: Option<string>
+              FIRST_NAME: Option<string>
+              LAST_NAME: Option<string>
+              PHONE: Option<string> }
+
+            interface ILeftViewOf<``CONTACTS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CONTACTS (base)`` option =
+                match this.CONTACT_ID with
+                | Some value ->
+                    let record: ``CONTACTS (base)`` =
+                        { CONTACT_ID = value; CUSTOMER_ID = this.CUSTOMER_ID; EMAIL = this.EMAIL.Value; FIRST_NAME = this.FIRST_NAME.Value; LAST_NAME = this.LAST_NAME.Value; PHONE = this.PHONE }
+
+                    Some record
+                | None -> None
+
+        let CONTACTS = leftTable<``CONTACTS (base)``, CONTACTS>
+
+        type private ``COUNTRIES (base)`` = COUNTRIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type COUNTRIES =
+            { COUNTRY_ID: Option<string>
+              COUNTRY_NAME: Option<string>
+              REGION_ID: Option<int64> }
+
+            interface ILeftViewOf<``COUNTRIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``COUNTRIES (base)`` option =
+                match this.COUNTRY_ID with
+                | Some value ->
+                    let record: ``COUNTRIES (base)`` =
+                        { COUNTRY_ID = value; COUNTRY_NAME = this.COUNTRY_NAME.Value; REGION_ID = this.REGION_ID }
+
+                    Some record
+                | None -> None
+
+        let COUNTRIES = leftTable<``COUNTRIES (base)``, COUNTRIES>
+
+        type private ``CUSTOMERS (base)`` = CUSTOMERS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CUSTOMERS =
+            { ADDRESS: Option<string>
+              CREDIT_LIMIT: Option<decimal>
+              CUSTOMER_ID: Option<int64>
+              NAME: Option<string>
+              WEBSITE: Option<string> }
+
+            interface ILeftViewOf<``CUSTOMERS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CUSTOMERS (base)`` option =
+                match this.CUSTOMER_ID with
+                | Some value ->
+                    let record: ``CUSTOMERS (base)`` =
+                        { ADDRESS = this.ADDRESS; CREDIT_LIMIT = this.CREDIT_LIMIT; CUSTOMER_ID = value; NAME = this.NAME.Value; WEBSITE = this.WEBSITE }
+
+                    Some record
+                | None -> None
+
+        let CUSTOMERS = leftTable<``CUSTOMERS (base)``, CUSTOMERS>
+
+        type private ``EMPLOYEES (base)`` = EMPLOYEES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EMPLOYEES =
+            { EMAIL: Option<string>
+              EMPLOYEE_ID: Option<int64>
+              FIRST_NAME: Option<string>
+              HIRE_DATE: Option<System.DateTime>
+              JOB_TITLE: Option<string>
+              LAST_NAME: Option<string>
+              MANAGER_ID: Option<int64>
+              PHONE: Option<string> }
+
+            interface ILeftViewOf<``EMPLOYEES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EMPLOYEES (base)`` option =
+                match this.EMPLOYEE_ID with
+                | Some value ->
+                    let record: ``EMPLOYEES (base)`` =
+                        { EMAIL = this.EMAIL.Value
+                          EMPLOYEE_ID = value
+                          FIRST_NAME = this.FIRST_NAME.Value
+                          HIRE_DATE = this.HIRE_DATE.Value
+                          JOB_TITLE = this.JOB_TITLE.Value
+                          LAST_NAME = this.LAST_NAME.Value
+                          MANAGER_ID = this.MANAGER_ID
+                          PHONE = this.PHONE.Value }
+
+                    Some record
+                | None -> None
+
+        let EMPLOYEES = leftTable<``EMPLOYEES (base)``, EMPLOYEES>
+
+        type private ``INVENTORIES (base)`` = INVENTORIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type INVENTORIES =
+            { PRODUCT_ID: Option<int64>
+              QUANTITY: Option<int64>
+              WAREHOUSE_ID: Option<int64> }
+
+            interface ILeftViewOf<``INVENTORIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``INVENTORIES (base)`` option =
+                match this.PRODUCT_ID with
+                | Some value ->
+                    let record: ``INVENTORIES (base)`` =
+                        { PRODUCT_ID = value; QUANTITY = this.QUANTITY.Value; WAREHOUSE_ID = this.WAREHOUSE_ID.Value }
+
+                    Some record
+                | None -> None
+
+        let INVENTORIES = leftTable<``INVENTORIES (base)``, INVENTORIES>
+
+        type private ``LOCATIONS (base)`` = LOCATIONS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type LOCATIONS =
+            { ADDRESS: Option<string>
+              CITY: Option<string>
+              COUNTRY_ID: Option<string>
+              LOCATION_ID: Option<int64>
+              POSTAL_CODE: Option<string>
+              STATE: Option<string> }
+
+            interface ILeftViewOf<``LOCATIONS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``LOCATIONS (base)`` option =
+                match this.LOCATION_ID with
+                | Some value ->
+                    let record: ``LOCATIONS (base)`` =
+                        { ADDRESS = this.ADDRESS.Value; CITY = this.CITY; COUNTRY_ID = this.COUNTRY_ID; LOCATION_ID = value; POSTAL_CODE = this.POSTAL_CODE; STATE = this.STATE }
+
+                    Some record
+                | None -> None
+
+        let LOCATIONS = leftTable<``LOCATIONS (base)``, LOCATIONS>
+
+        type private ``ORDERS (base)`` = ORDERS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ORDERS =
+            { CUSTOMER_ID: Option<int64>
+              ORDER_DATE: Option<System.DateTime>
+              ORDER_ID: Option<int64>
+              SALESMAN_ID: Option<int64>
+              STATUS: Option<string> }
+
+            interface ILeftViewOf<``ORDERS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ORDERS (base)`` option =
+                match this.ORDER_ID with
+                | Some value ->
+                    let record: ``ORDERS (base)`` =
+                        { CUSTOMER_ID = this.CUSTOMER_ID.Value; ORDER_DATE = this.ORDER_DATE.Value; ORDER_ID = value; SALESMAN_ID = this.SALESMAN_ID; STATUS = this.STATUS.Value }
+
+                    Some record
+                | None -> None
+
+        let ORDERS = leftTable<``ORDERS (base)``, ORDERS>
+
+        type private ``ORDER_ITEMS (base)`` = ORDER_ITEMS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ORDER_ITEMS =
+            { ITEM_ID: Option<int64>
+              ORDER_ID: Option<int64>
+              PRODUCT_ID: Option<int64>
+              QUANTITY: Option<int64>
+              UNIT_PRICE: Option<decimal> }
+
+            interface ILeftViewOf<``ORDER_ITEMS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ORDER_ITEMS (base)`` option =
+                match this.ITEM_ID with
+                | Some value ->
+                    let record: ``ORDER_ITEMS (base)`` =
+                        { ITEM_ID = value; ORDER_ID = this.ORDER_ID.Value; PRODUCT_ID = this.PRODUCT_ID.Value; QUANTITY = this.QUANTITY.Value; UNIT_PRICE = this.UNIT_PRICE.Value }
+
+                    Some record
+                | None -> None
+
+        let ORDER_ITEMS = leftTable<``ORDER_ITEMS (base)``, ORDER_ITEMS>
+
+        type private ``PRODUCTS (base)`` = PRODUCTS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PRODUCTS =
+            { CATEGORY_ID: Option<int64>
+              DESCRIPTION: Option<string>
+              LIST_PRICE: Option<decimal>
+              PRODUCT_ID: Option<int64>
+              PRODUCT_NAME: Option<string>
+              STANDARD_COST: Option<decimal> }
+
+            interface ILeftViewOf<``PRODUCTS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PRODUCTS (base)`` option =
+                match this.PRODUCT_ID with
+                | Some value ->
+                    let record: ``PRODUCTS (base)`` =
+                        { CATEGORY_ID = this.CATEGORY_ID.Value
+                          DESCRIPTION = this.DESCRIPTION
+                          LIST_PRICE = this.LIST_PRICE
+                          PRODUCT_ID = value
+                          PRODUCT_NAME = this.PRODUCT_NAME.Value
+                          STANDARD_COST = this.STANDARD_COST }
+
+                    Some record
+                | None -> None
+
+        let PRODUCTS = leftTable<``PRODUCTS (base)``, PRODUCTS>
+
+        type private ``PRODUCT_CATEGORIES (base)`` = PRODUCT_CATEGORIES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PRODUCT_CATEGORIES =
+            { CATEGORY_ID: Option<int64>
+              CATEGORY_NAME: Option<string> }
+
+            interface ILeftViewOf<``PRODUCT_CATEGORIES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PRODUCT_CATEGORIES (base)`` option =
+                match this.CATEGORY_ID with
+                | Some value ->
+                    let record: ``PRODUCT_CATEGORIES (base)`` =
+                        { CATEGORY_ID = value; CATEGORY_NAME = this.CATEGORY_NAME.Value }
+
+                    Some record
+                | None -> None
+
+        let PRODUCT_CATEGORIES =
+            leftTable<``PRODUCT_CATEGORIES (base)``, PRODUCT_CATEGORIES>
+
+        type private ``REGIONS (base)`` = REGIONS
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type REGIONS =
+            { REGION_ID: Option<int64>
+              REGION_NAME: Option<string> }
+
+            interface ILeftViewOf<``REGIONS (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``REGIONS (base)`` option =
+                match this.REGION_ID with
+                | Some value ->
+                    let record: ``REGIONS (base)`` =
+                        { REGION_ID = value; REGION_NAME = this.REGION_NAME.Value }
+
+                    Some record
+                | None -> None
+
+        let REGIONS = leftTable<``REGIONS (base)``, REGIONS>
+
+        type private ``WAREHOUSES (base)`` = WAREHOUSES
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WAREHOUSES =
+            { LOCATION_ID: Option<int64>
+              WAREHOUSE_ID: Option<int64>
+              WAREHOUSE_NAME: Option<string> }
+
+            interface ILeftViewOf<``WAREHOUSES (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WAREHOUSES (base)`` option =
+                match this.WAREHOUSE_ID with
+                | Some value ->
+                    let record: ``WAREHOUSES (base)`` =
+                        { LOCATION_ID = this.LOCATION_ID; WAREHOUSE_ID = value; WAREHOUSE_NAME = this.WAREHOUSE_NAME }
+
+                    Some record
+                | None -> None
+
+        let WAREHOUSES = leftTable<``WAREHOUSES (base)``, WAREHOUSES>
+
+
 
 
 type QueryContextFactory =

--- a/src/Tests/SqlServer/AdventureWorksNet10.fs
+++ b/src/Tests/SqlServer/AdventureWorksNet10.fs
@@ -176,6 +176,230 @@ module HumanResources =
 
     let Shift = table<Shift>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Department (base)`` = Department
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Department =
+            { [<ProviderDbType("SmallInt")>]
+              DepartmentID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              GroupName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Department (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Department (base)`` option =
+                match this.DepartmentID with
+                | Some value ->
+                    let record: ``Department (base)`` =
+                        { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Department = leftTable<``Department (base)``, Department>
+
+        type private ``Employee (base)`` = Employee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Employee =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              NationalIDNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              LoginID: Option<string>
+              [<ProviderDbType("SqlHierarchyId")>]
+              OrganizationNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("SmallInt")>]
+              OrganizationLevel: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              JobTitle: Option<string>
+              [<ProviderDbType("Date")>]
+              BirthDate: Option<System.DateOnly>
+              [<ProviderDbType("NChar")>]
+              MaritalStatus: Option<string>
+              [<ProviderDbType("NChar")>]
+              Gender: Option<string>
+              [<ProviderDbType("Date")>]
+              HireDate: Option<System.DateOnly>
+              [<ProviderDbType("Bit")>]
+              SalariedFlag: Option<bool>
+              [<ProviderDbType("SmallInt")>]
+              VacationHours: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              SickLeaveHours: Option<int16>
+              [<ProviderDbType("Bit")>]
+              CurrentFlag: Option<bool>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Employee (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Employee (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Employee (base)`` =
+                        { BusinessEntityID = value
+                          NationalIDNumber = this.NationalIDNumber.Value
+                          LoginID = this.LoginID.Value
+                          OrganizationNode = this.OrganizationNode
+                          OrganizationLevel = this.OrganizationLevel
+                          JobTitle = this.JobTitle.Value
+                          BirthDate = this.BirthDate.Value
+                          MaritalStatus = this.MaritalStatus.Value
+                          Gender = this.Gender.Value
+                          HireDate = this.HireDate.Value
+                          SalariedFlag = this.SalariedFlag.Value
+                          VacationHours = this.VacationHours.Value
+                          SickLeaveHours = this.SickLeaveHours.Value
+                          CurrentFlag = this.CurrentFlag.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Employee = leftTable<``Employee (base)``, Employee>
+
+        type private ``EmployeeDepartmentHistory (base)`` = EmployeeDepartmentHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmployeeDepartmentHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              DepartmentID: Option<int16>
+              [<ProviderDbType("TinyInt")>]
+              ShiftID: Option<byte>
+              [<ProviderDbType("Date")>]
+              StartDate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              EndDate: Option<System.DateOnly>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmployeeDepartmentHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmployeeDepartmentHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmployeeDepartmentHistory (base)`` =
+                        { BusinessEntityID = value
+                          DepartmentID = this.DepartmentID.Value
+                          ShiftID = this.ShiftID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmployeeDepartmentHistory =
+            leftTable<``EmployeeDepartmentHistory (base)``, EmployeeDepartmentHistory>
+
+        type private ``EmployeePayHistory (base)`` = EmployeePayHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmployeePayHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              RateChangeDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              Rate: Option<decimal>
+              [<ProviderDbType("TinyInt")>]
+              PayFrequency: Option<byte>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmployeePayHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmployeePayHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmployeePayHistory (base)`` =
+                        { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmployeePayHistory =
+            leftTable<``EmployeePayHistory (base)``, EmployeePayHistory>
+
+        type private ``JobCandidate (base)`` = JobCandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type JobCandidate =
+            { [<ProviderDbType("Int")>]
+              JobCandidateID: Option<int>
+              [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``JobCandidate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``JobCandidate (base)`` option =
+                match this.JobCandidateID with
+                | Some value ->
+                    let record: ``JobCandidate (base)`` =
+                        { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let JobCandidate = leftTable<``JobCandidate (base)``, JobCandidate>
+
+        type private ``Shift (base)`` = Shift
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Shift =
+            { [<ProviderDbType("TinyInt")>]
+              ShiftID: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Time")>]
+              StartTime: Option<System.TimeOnly>
+              [<ProviderDbType("Time")>]
+              EndTime: Option<System.TimeOnly>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Shift (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Shift (base)`` option =
+                match this.ShiftID with
+                | Some value ->
+                    let record: ``Shift (base)`` =
+                        { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Shift = leftTable<``Shift (base)``, Shift>
+
+
 module Person =
 
     [<CLIMutable>]
@@ -482,6 +706,434 @@ module Person =
                   { WriteColumn.Name = "ModifiedDate"; Value = box this.ModifiedDate; ProviderDbType = Some "DateTime" } ]
 
     let StateProvince = table<StateProvince>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Address (base)`` = Address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Address =
+            { [<ProviderDbType("Int")>]
+              AddressID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              AddressLine1: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              AddressLine2: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              City: Option<string>
+              [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              PostalCode: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Address (base)`` option =
+                match this.AddressID with
+                | Some value ->
+                    let record: ``Address (base)`` =
+                        { AddressID = value
+                          AddressLine1 = this.AddressLine1.Value
+                          AddressLine2 = this.AddressLine2
+                          City = this.City.Value
+                          StateProvinceID = this.StateProvinceID.Value
+                          PostalCode = this.PostalCode.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Address = leftTable<``Address (base)``, Address>
+
+        type private ``AddressType (base)`` = AddressType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type AddressType =
+            { [<ProviderDbType("Int")>]
+              AddressTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``AddressType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``AddressType (base)`` option =
+                match this.AddressTypeID with
+                | Some value ->
+                    let record: ``AddressType (base)`` =
+                        { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let AddressType = leftTable<``AddressType (base)``, AddressType>
+
+        type private ``BusinessEntity (base)`` = BusinessEntity
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntity =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntity (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntity (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntity (base)`` =
+                        { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntity = leftTable<``BusinessEntity (base)``, BusinessEntity>
+
+        type private ``BusinessEntityAddress (base)`` = BusinessEntityAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntityAddress =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              AddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              AddressTypeID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntityAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntityAddress (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntityAddress (base)`` =
+                        { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntityAddress =
+            leftTable<``BusinessEntityAddress (base)``, BusinessEntityAddress>
+
+        type private ``BusinessEntityContact (base)`` = BusinessEntityContact
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntityContact =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              PersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              ContactTypeID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntityContact (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntityContact (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntityContact (base)`` =
+                        { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntityContact =
+            leftTable<``BusinessEntityContact (base)``, BusinessEntityContact>
+
+        type private ``ContactType (base)`` = ContactType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ContactType =
+            { [<ProviderDbType("Int")>]
+              ContactTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ContactType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ContactType (base)`` option =
+                match this.ContactTypeID with
+                | Some value ->
+                    let record: ``ContactType (base)`` =
+                        { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ContactType = leftTable<``ContactType (base)``, ContactType>
+
+        type private ``CountryRegion (base)`` = CountryRegion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CountryRegion =
+            { [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CountryRegion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CountryRegion (base)`` option =
+                match this.CountryRegionCode with
+                | Some value ->
+                    let record: ``CountryRegion (base)`` =
+                        { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CountryRegion = leftTable<``CountryRegion (base)``, CountryRegion>
+
+        type private ``EmailAddress (base)`` = EmailAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmailAddress =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              EmailAddressID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              EmailAddress: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmailAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmailAddress (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmailAddress (base)`` =
+                        { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmailAddress = leftTable<``EmailAddress (base)``, EmailAddress>
+
+        type private ``Password (base)`` = Password
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Password =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              PasswordHash: Option<string>
+              [<ProviderDbType("VarChar")>]
+              PasswordSalt: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Password (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Password (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Password (base)`` =
+                        { BusinessEntityID = value
+                          PasswordHash = this.PasswordHash.Value
+                          PasswordSalt = this.PasswordSalt.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Password = leftTable<``Password (base)``, Password>
+
+        type private ``Person (base)`` = Person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Person =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NChar")>]
+              PersonType: Option<string>
+              [<ProviderDbType("Bit")>]
+              NameStyle: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Title: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              FirstName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              MiddleName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              LastName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Suffix: Option<string>
+              [<ProviderDbType("Int")>]
+              EmailPromotion: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Person (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Person (base)`` =
+                        { BusinessEntityID = value
+                          PersonType = this.PersonType.Value
+                          NameStyle = this.NameStyle.Value
+                          Title = this.Title
+                          FirstName = this.FirstName.Value
+                          MiddleName = this.MiddleName
+                          LastName = this.LastName.Value
+                          Suffix = this.Suffix
+                          EmailPromotion = this.EmailPromotion.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Person = leftTable<``Person (base)``, Person>
+
+        type private ``PersonPhone (base)`` = PersonPhone
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PersonPhone =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              PhoneNumber: Option<string>
+              [<ProviderDbType("Int")>]
+              PhoneNumberTypeID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PersonPhone (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PersonPhone (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``PersonPhone (base)`` =
+                        { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PersonPhone = leftTable<``PersonPhone (base)``, PersonPhone>
+
+        type private ``PhoneNumberType (base)`` = PhoneNumberType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PhoneNumberType =
+            { [<ProviderDbType("Int")>]
+              PhoneNumberTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PhoneNumberType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PhoneNumberType (base)`` option =
+                match this.PhoneNumberTypeID with
+                | Some value ->
+                    let record: ``PhoneNumberType (base)`` =
+                        { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PhoneNumberType = leftTable<``PhoneNumberType (base)``, PhoneNumberType>
+
+        type private ``StateProvince (base)`` = StateProvince
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type StateProvince =
+            { [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("NChar")>]
+              StateProvinceCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("Bit")>]
+              IsOnlyStateProvinceFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``StateProvince (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``StateProvince (base)`` option =
+                match this.StateProvinceID with
+                | Some value ->
+                    let record: ``StateProvince (base)`` =
+                        { StateProvinceID = value
+                          StateProvinceCode = this.StateProvinceCode.Value
+                          CountryRegionCode = this.CountryRegionCode.Value
+                          IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
+                          Name = this.Name.Value
+                          TerritoryID = this.TerritoryID.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let StateProvince = leftTable<``StateProvince (base)``, StateProvince>
+
 
 module Production =
 
@@ -1184,6 +1836,950 @@ module Production =
 
     let WorkOrderRouting = table<WorkOrderRouting>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``BillOfMaterials (base)`` = BillOfMaterials
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BillOfMaterials =
+            { [<ProviderDbType("Int")>]
+              BillOfMaterialsID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductAssemblyID: Option<int>
+              [<ProviderDbType("Int")>]
+              ComponentID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              BOMLevel: Option<int16>
+              [<ProviderDbType("Decimal")>]
+              PerAssemblyQty: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BillOfMaterials (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BillOfMaterials (base)`` option =
+                match this.BillOfMaterialsID with
+                | Some value ->
+                    let record: ``BillOfMaterials (base)`` =
+                        { BillOfMaterialsID = value
+                          ProductAssemblyID = this.ProductAssemblyID
+                          ComponentID = this.ComponentID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          UnitMeasureCode = this.UnitMeasureCode.Value
+                          BOMLevel = this.BOMLevel.Value
+                          PerAssemblyQty = this.PerAssemblyQty.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BillOfMaterials = leftTable<``BillOfMaterials (base)``, BillOfMaterials>
+
+        type private ``Culture (base)`` = Culture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Culture =
+            { [<ProviderDbType("NChar")>]
+              CultureID: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Culture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Culture (base)`` option =
+                match this.CultureID with
+                | Some value ->
+                    let record: ``Culture (base)`` =
+                        { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Culture = leftTable<``Culture (base)``, Culture>
+
+        type private ``Document (base)`` = Document
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Document =
+            { [<ProviderDbType("SqlHierarchyId")>]
+              DocumentNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("SmallInt")>]
+              DocumentLevel: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Title: Option<string>
+              [<ProviderDbType("Int")>]
+              Owner: Option<int>
+              [<ProviderDbType("Bit")>]
+              FolderFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              FileName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              FileExtension: Option<string>
+              [<ProviderDbType("NChar")>]
+              Revision: Option<string>
+              [<ProviderDbType("Int")>]
+              ChangeNumber: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              DocumentSummary: Option<string>
+              [<ProviderDbType("VarBinary")>]
+              Document: Option<byte[]>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Document (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Document (base)`` option =
+                match this.DocumentNode with
+                | Some value ->
+                    let record: ``Document (base)`` =
+                        { DocumentNode = value
+                          DocumentLevel = this.DocumentLevel
+                          Title = this.Title.Value
+                          Owner = this.Owner.Value
+                          FolderFlag = this.FolderFlag.Value
+                          FileName = this.FileName.Value
+                          FileExtension = this.FileExtension.Value
+                          Revision = this.Revision.Value
+                          ChangeNumber = this.ChangeNumber.Value
+                          Status = this.Status.Value
+                          DocumentSummary = this.DocumentSummary
+                          Document = this.Document
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Document = leftTable<``Document (base)``, Document>
+
+        type private ``Illustration (base)`` = Illustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Illustration =
+            { [<ProviderDbType("Int")>]
+              IllustrationID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Illustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Illustration (base)`` option =
+                match this.IllustrationID with
+                | Some value ->
+                    let record: ``Illustration (base)`` =
+                        { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Illustration = leftTable<``Illustration (base)``, Illustration>
+
+        type private ``Location (base)`` = Location
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Location =
+            { [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("SmallMoney")>]
+              CostRate: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              Availability: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Location (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Location (base)`` option =
+                match this.LocationID with
+                | Some value ->
+                    let record: ``Location (base)`` =
+                        { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Location = leftTable<``Location (base)``, Location>
+
+        type private ``Product (base)`` = Product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Product =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              ProductNumber: Option<string>
+              [<ProviderDbType("Bit")>]
+              MakeFlag: Option<bool>
+              [<ProviderDbType("Bit")>]
+              FinishedGoodsFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Color: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              SafetyStockLevel: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              ReorderPoint: Option<int16>
+              [<ProviderDbType("Money")>]
+              StandardCost: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ListPrice: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Size: Option<string>
+              [<ProviderDbType("NChar")>]
+              SizeUnitMeasureCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              WeightUnitMeasureCode: Option<string>
+              [<ProviderDbType("Decimal")>]
+              Weight: Option<decimal>
+              [<ProviderDbType("Int")>]
+              DaysToManufacture: Option<int>
+              [<ProviderDbType("NChar")>]
+              ProductLine: Option<string>
+              [<ProviderDbType("NChar")>]
+              Class: Option<string>
+              [<ProviderDbType("NChar")>]
+              Style: Option<string>
+              [<ProviderDbType("Int")>]
+              ProductSubcategoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              SellStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              SellEndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DiscontinuedDate: Option<System.DateTime>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Product (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``Product (base)`` =
+                        { ProductID = value
+                          Name = this.Name.Value
+                          ProductNumber = this.ProductNumber.Value
+                          MakeFlag = this.MakeFlag.Value
+                          FinishedGoodsFlag = this.FinishedGoodsFlag.Value
+                          Color = this.Color
+                          SafetyStockLevel = this.SafetyStockLevel.Value
+                          ReorderPoint = this.ReorderPoint.Value
+                          StandardCost = this.StandardCost.Value
+                          ListPrice = this.ListPrice.Value
+                          Size = this.Size
+                          SizeUnitMeasureCode = this.SizeUnitMeasureCode
+                          WeightUnitMeasureCode = this.WeightUnitMeasureCode
+                          Weight = this.Weight
+                          DaysToManufacture = this.DaysToManufacture.Value
+                          ProductLine = this.ProductLine
+                          Class = this.Class
+                          Style = this.Style
+                          ProductSubcategoryID = this.ProductSubcategoryID
+                          ProductModelID = this.ProductModelID
+                          SellStartDate = this.SellStartDate.Value
+                          SellEndDate = this.SellEndDate
+                          DiscontinuedDate = this.DiscontinuedDate
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Product = leftTable<``Product (base)``, Product>
+
+        type private ``ProductCategory (base)`` = ProductCategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCategory =
+            { [<ProviderDbType("Int")>]
+              ProductCategoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCategory (base)`` option =
+                match this.ProductCategoryID with
+                | Some value ->
+                    let record: ``ProductCategory (base)`` =
+                        { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
+
+        type private ``ProductCostHistory (base)`` = ProductCostHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCostHistory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              StandardCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCostHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCostHistory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductCostHistory (base)`` =
+                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCostHistory =
+            leftTable<``ProductCostHistory (base)``, ProductCostHistory>
+
+        type private ``ProductDescription (base)`` = ProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDescription =
+            { [<ProviderDbType("Int")>]
+              ProductDescriptionID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Description: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDescription (base)`` option =
+                match this.ProductDescriptionID with
+                | Some value ->
+                    let record: ``ProductDescription (base)`` =
+                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDescription =
+            leftTable<``ProductDescription (base)``, ProductDescription>
+
+        type private ``ProductDocument (base)`` = ProductDocument
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDocument =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SqlHierarchyId")>]
+              DocumentNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDocument (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDocument (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductDocument (base)`` =
+                        { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDocument = leftTable<``ProductDocument (base)``, ProductDocument>
+
+        type private ``ProductInventory (base)`` = ProductInventory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductInventory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Shelf: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              Bin: Option<byte>
+              [<ProviderDbType("SmallInt")>]
+              Quantity: Option<int16>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductInventory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductInventory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductInventory (base)`` =
+                        { ProductID = value
+                          LocationID = this.LocationID.Value
+                          Shelf = this.Shelf.Value
+                          Bin = this.Bin.Value
+                          Quantity = this.Quantity.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductInventory = leftTable<``ProductInventory (base)``, ProductInventory>
+
+        type private ``ProductListPriceHistory (base)`` = ProductListPriceHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductListPriceHistory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              ListPrice: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductListPriceHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductListPriceHistory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductListPriceHistory (base)`` =
+                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductListPriceHistory =
+            leftTable<``ProductListPriceHistory (base)``, ProductListPriceHistory>
+
+        type private ``ProductModel (base)`` = ProductModel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModel =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModel (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModel (base)`` =
+                        { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
+
+        type private ``ProductModelIllustration (base)`` = ProductModelIllustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelIllustration =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("Int")>]
+              IllustrationID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelIllustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelIllustration (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelIllustration (base)`` =
+                        { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelIllustration =
+            leftTable<``ProductModelIllustration (base)``, ProductModelIllustration>
+
+        type private ``ProductModelProductDescriptionCulture (base)`` = ProductModelProductDescriptionCulture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelProductDescriptionCulture =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductDescriptionID: Option<int>
+              [<ProviderDbType("NChar")>]
+              CultureID: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelProductDescriptionCulture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelProductDescriptionCulture (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelProductDescriptionCulture (base)`` =
+                        { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelProductDescriptionCulture =
+            leftTable<``ProductModelProductDescriptionCulture (base)``, ProductModelProductDescriptionCulture>
+
+        type private ``ProductPhoto (base)`` = ProductPhoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductPhoto =
+            { [<ProviderDbType("Int")>]
+              ProductPhotoID: Option<int>
+              [<ProviderDbType("VarBinary")>]
+              ThumbNailPhoto: Option<byte[]>
+              [<ProviderDbType("NVarChar")>]
+              ThumbnailPhotoFileName: Option<string>
+              [<ProviderDbType("VarBinary")>]
+              LargePhoto: Option<byte[]>
+              [<ProviderDbType("NVarChar")>]
+              LargePhotoFileName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductPhoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductPhoto (base)`` option =
+                match this.ProductPhotoID with
+                | Some value ->
+                    let record: ``ProductPhoto (base)`` =
+                        { ProductPhotoID = value
+                          ThumbNailPhoto = this.ThumbNailPhoto
+                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                          LargePhoto = this.LargePhoto
+                          LargePhotoFileName = this.LargePhotoFileName
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductPhoto = leftTable<``ProductPhoto (base)``, ProductPhoto>
+
+        type private ``ProductProductPhoto (base)`` = ProductProductPhoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductProductPhoto =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductPhotoID: Option<int>
+              [<ProviderDbType("Bit")>]
+              Primary: Option<bool>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductProductPhoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductProductPhoto (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductProductPhoto (base)`` =
+                        { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductProductPhoto =
+            leftTable<``ProductProductPhoto (base)``, ProductProductPhoto>
+
+        type private ``ProductReview (base)`` = ProductReview
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductReview =
+            { [<ProviderDbType("Int")>]
+              ProductReviewID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ReviewerName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ReviewDate: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              EmailAddress: Option<string>
+              [<ProviderDbType("Int")>]
+              Rating: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Comments: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductReview (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductReview (base)`` option =
+                match this.ProductReviewID with
+                | Some value ->
+                    let record: ``ProductReview (base)`` =
+                        { ProductReviewID = value
+                          ProductID = this.ProductID.Value
+                          ReviewerName = this.ReviewerName.Value
+                          ReviewDate = this.ReviewDate.Value
+                          EmailAddress = this.EmailAddress.Value
+                          Rating = this.Rating.Value
+                          Comments = this.Comments
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductReview = leftTable<``ProductReview (base)``, ProductReview>
+
+        type private ``ProductSubcategory (base)`` = ProductSubcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductSubcategory =
+            { [<ProviderDbType("Int")>]
+              ProductSubcategoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductCategoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductSubcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductSubcategory (base)`` option =
+                match this.ProductSubcategoryID with
+                | Some value ->
+                    let record: ``ProductSubcategory (base)`` =
+                        { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductSubcategory =
+            leftTable<``ProductSubcategory (base)``, ProductSubcategory>
+
+        type private ``ScrapReason (base)`` = ScrapReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ScrapReason =
+            { [<ProviderDbType("SmallInt")>]
+              ScrapReasonID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ScrapReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ScrapReason (base)`` option =
+                match this.ScrapReasonID with
+                | Some value ->
+                    let record: ``ScrapReason (base)`` =
+                        { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ScrapReason = leftTable<``ScrapReason (base)``, ScrapReason>
+
+        type private ``TransactionHistory (base)`` = TransactionHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type TransactionHistory =
+            { [<ProviderDbType("Int")>]
+              TransactionID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderLineID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              TransactionDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              TransactionType: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``TransactionHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``TransactionHistory (base)`` option =
+                match this.TransactionID with
+                | Some value ->
+                    let record: ``TransactionHistory (base)`` =
+                        { TransactionID = value
+                          ProductID = this.ProductID.Value
+                          ReferenceOrderID = this.ReferenceOrderID.Value
+                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                          TransactionDate = this.TransactionDate.Value
+                          TransactionType = this.TransactionType.Value
+                          Quantity = this.Quantity.Value
+                          ActualCost = this.ActualCost.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let TransactionHistory =
+            leftTable<``TransactionHistory (base)``, TransactionHistory>
+
+        type private ``TransactionHistoryArchive (base)`` = TransactionHistoryArchive
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type TransactionHistoryArchive =
+            { [<ProviderDbType("Int")>]
+              TransactionID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderLineID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              TransactionDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              TransactionType: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``TransactionHistoryArchive (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``TransactionHistoryArchive (base)`` option =
+                match this.TransactionID with
+                | Some value ->
+                    let record: ``TransactionHistoryArchive (base)`` =
+                        { TransactionID = value
+                          ProductID = this.ProductID.Value
+                          ReferenceOrderID = this.ReferenceOrderID.Value
+                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                          TransactionDate = this.TransactionDate.Value
+                          TransactionType = this.TransactionType.Value
+                          Quantity = this.Quantity.Value
+                          ActualCost = this.ActualCost.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let TransactionHistoryArchive =
+            leftTable<``TransactionHistoryArchive (base)``, TransactionHistoryArchive>
+
+        type private ``UnitMeasure (base)`` = UnitMeasure
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type UnitMeasure =
+            { [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``UnitMeasure (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``UnitMeasure (base)`` option =
+                match this.UnitMeasureCode with
+                | Some value ->
+                    let record: ``UnitMeasure (base)`` =
+                        { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let UnitMeasure = leftTable<``UnitMeasure (base)``, UnitMeasure>
+
+        type private ``WorkOrder (base)`` = WorkOrder
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WorkOrder =
+            { [<ProviderDbType("Int")>]
+              WorkOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              OrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              StockedQty: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              ScrappedQty: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("SmallInt")>]
+              ScrapReasonID: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``WorkOrder (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WorkOrder (base)`` option =
+                match this.WorkOrderID with
+                | Some value ->
+                    let record: ``WorkOrder (base)`` =
+                        { WorkOrderID = value
+                          ProductID = this.ProductID.Value
+                          OrderQty = this.OrderQty.Value
+                          StockedQty = this.StockedQty.Value
+                          ScrappedQty = this.ScrappedQty.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          DueDate = this.DueDate.Value
+                          ScrapReasonID = this.ScrapReasonID
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let WorkOrder = leftTable<``WorkOrder (base)``, WorkOrder>
+
+        type private ``WorkOrderRouting (base)`` = WorkOrderRouting
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WorkOrderRouting =
+            { [<ProviderDbType("Int")>]
+              WorkOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              OperationSequence: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ScheduledStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ScheduledEndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ActualStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ActualEndDate: Option<System.DateTime>
+              [<ProviderDbType("Decimal")>]
+              ActualResourceHrs: Option<decimal>
+              [<ProviderDbType("Money")>]
+              PlannedCost: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``WorkOrderRouting (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WorkOrderRouting (base)`` option =
+                match this.WorkOrderID with
+                | Some value ->
+                    let record: ``WorkOrderRouting (base)`` =
+                        { WorkOrderID = value
+                          ProductID = this.ProductID.Value
+                          OperationSequence = this.OperationSequence.Value
+                          LocationID = this.LocationID.Value
+                          ScheduledStartDate = this.ScheduledStartDate.Value
+                          ScheduledEndDate = this.ScheduledEndDate.Value
+                          ActualStartDate = this.ActualStartDate
+                          ActualEndDate = this.ActualEndDate
+                          ActualResourceHrs = this.ActualResourceHrs
+                          PlannedCost = this.PlannedCost.Value
+                          ActualCost = this.ActualCost
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let WorkOrderRouting = leftTable<``WorkOrderRouting (base)``, WorkOrderRouting>
+
+
 module Purchasing =
 
     [<CLIMutable>]
@@ -1372,6 +2968,254 @@ module Purchasing =
                   { WriteColumn.Name = "ModifiedDate"; Value = box this.ModifiedDate; ProviderDbType = Some "DateTime" } ]
 
     let Vendor = table<Vendor>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``ProductVendor (base)`` = ProductVendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductVendor =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              AverageLeadTime: Option<int>
+              [<ProviderDbType("Money")>]
+              StandardPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              LastReceiptCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              LastReceiptDate: Option<System.DateTime>
+              [<ProviderDbType("Int")>]
+              MinOrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              MaxOrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              OnOrderQty: Option<int>
+              [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductVendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductVendor (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductVendor (base)`` =
+                        { ProductID = value
+                          BusinessEntityID = this.BusinessEntityID.Value
+                          AverageLeadTime = this.AverageLeadTime.Value
+                          StandardPrice = this.StandardPrice.Value
+                          LastReceiptCost = this.LastReceiptCost
+                          LastReceiptDate = this.LastReceiptDate
+                          MinOrderQty = this.MinOrderQty.Value
+                          MaxOrderQty = this.MaxOrderQty.Value
+                          OnOrderQty = this.OnOrderQty
+                          UnitMeasureCode = this.UnitMeasureCode.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductVendor = leftTable<``ProductVendor (base)``, ProductVendor>
+
+        type private ``PurchaseOrderDetail (base)`` = PurchaseOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PurchaseOrderDetail =
+            { [<ProviderDbType("Int")>]
+              PurchaseOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              PurchaseOrderDetailID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("SmallInt")>]
+              OrderQty: Option<int16>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Money")>]
+              UnitPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              LineTotal: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              ReceivedQty: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              RejectedQty: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              StockedQty: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PurchaseOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PurchaseOrderDetail (base)`` option =
+                match this.PurchaseOrderID with
+                | Some value ->
+                    let record: ``PurchaseOrderDetail (base)`` =
+                        { PurchaseOrderID = value
+                          PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
+                          DueDate = this.DueDate.Value
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          LineTotal = this.LineTotal.Value
+                          ReceivedQty = this.ReceivedQty.Value
+                          RejectedQty = this.RejectedQty.Value
+                          StockedQty = this.StockedQty.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PurchaseOrderDetail =
+            leftTable<``PurchaseOrderDetail (base)``, PurchaseOrderDetail>
+
+        type private ``PurchaseOrderHeader (base)`` = PurchaseOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PurchaseOrderHeader =
+            { [<ProviderDbType("Int")>]
+              PurchaseOrderID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              RevisionNumber: Option<byte>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("Int")>]
+              EmployeeID: Option<int>
+              [<ProviderDbType("Int")>]
+              VendorID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              OrderDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ShipDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              SubTotal: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TaxAmt: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Freight: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TotalDue: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PurchaseOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PurchaseOrderHeader (base)`` option =
+                match this.PurchaseOrderID with
+                | Some value ->
+                    let record: ``PurchaseOrderHeader (base)`` =
+                        { PurchaseOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          Status = this.Status.Value
+                          EmployeeID = this.EmployeeID.Value
+                          VendorID = this.VendorID.Value
+                          ShipMethodID = this.ShipMethodID.Value
+                          OrderDate = this.OrderDate.Value
+                          ShipDate = this.ShipDate
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PurchaseOrderHeader =
+            leftTable<``PurchaseOrderHeader (base)``, PurchaseOrderHeader>
+
+        type private ``ShipMethod (base)`` = ShipMethod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ShipMethod =
+            { [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Money")>]
+              ShipBase: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ShipRate: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ShipMethod (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ShipMethod (base)`` option =
+                match this.ShipMethodID with
+                | Some value ->
+                    let record: ``ShipMethod (base)`` =
+                        { ShipMethodID = value
+                          Name = this.Name.Value
+                          ShipBase = this.ShipBase.Value
+                          ShipRate = this.ShipRate.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ShipMethod = leftTable<``ShipMethod (base)``, ShipMethod>
+
+        type private ``Vendor (base)`` = Vendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Vendor =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              CreditRating: Option<byte>
+              [<ProviderDbType("Bit")>]
+              PreferredVendorStatus: Option<bool>
+              [<ProviderDbType("Bit")>]
+              ActiveFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              PurchasingWebServiceURL: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Vendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Vendor (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Vendor (base)`` =
+                        { BusinessEntityID = value
+                          AccountNumber = this.AccountNumber.Value
+                          Name = this.Name.Value
+                          CreditRating = this.CreditRating.Value
+                          PreferredVendorStatus = this.PreferredVendorStatus.Value
+                          ActiveFlag = this.ActiveFlag.Value
+                          PurchasingWebServiceURL = this.PurchasingWebServiceURL
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Vendor = leftTable<``Vendor (base)``, Vendor>
+
 
 module Sales =
 
@@ -1935,6 +3779,762 @@ module Sales =
 
     let Store = table<Store>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``CountryRegionCurrency (base)`` = CountryRegionCurrency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CountryRegionCurrency =
+            { [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              CurrencyCode: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CountryRegionCurrency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CountryRegionCurrency (base)`` option =
+                match this.CountryRegionCode with
+                | Some value ->
+                    let record: ``CountryRegionCurrency (base)`` =
+                        { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CountryRegionCurrency =
+            leftTable<``CountryRegionCurrency (base)``, CountryRegionCurrency>
+
+        type private ``CreditCard (base)`` = CreditCard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CreditCard =
+            { [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              CardType: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CardNumber: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              ExpMonth: Option<byte>
+              [<ProviderDbType("SmallInt")>]
+              ExpYear: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CreditCard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CreditCard (base)`` option =
+                match this.CreditCardID with
+                | Some value ->
+                    let record: ``CreditCard (base)`` =
+                        { CreditCardID = value
+                          CardType = this.CardType.Value
+                          CardNumber = this.CardNumber.Value
+                          ExpMonth = this.ExpMonth.Value
+                          ExpYear = this.ExpYear.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CreditCard = leftTable<``CreditCard (base)``, CreditCard>
+
+        type private ``Currency (base)`` = Currency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Currency =
+            { [<ProviderDbType("NChar")>]
+              CurrencyCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Currency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Currency (base)`` option =
+                match this.CurrencyCode with
+                | Some value ->
+                    let record: ``Currency (base)`` =
+                        { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Currency = leftTable<``Currency (base)``, Currency>
+
+        type private ``CurrencyRate (base)`` = CurrencyRate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CurrencyRate =
+            { [<ProviderDbType("Int")>]
+              CurrencyRateID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              CurrencyRateDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              FromCurrencyCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              ToCurrencyCode: Option<string>
+              [<ProviderDbType("Money")>]
+              AverageRate: Option<decimal>
+              [<ProviderDbType("Money")>]
+              EndOfDayRate: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CurrencyRate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CurrencyRate (base)`` option =
+                match this.CurrencyRateID with
+                | Some value ->
+                    let record: ``CurrencyRate (base)`` =
+                        { CurrencyRateID = value
+                          CurrencyRateDate = this.CurrencyRateDate.Value
+                          FromCurrencyCode = this.FromCurrencyCode.Value
+                          ToCurrencyCode = this.ToCurrencyCode.Value
+                          AverageRate = this.AverageRate.Value
+                          EndOfDayRate = this.EndOfDayRate.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CurrencyRate = leftTable<``CurrencyRate (base)``, CurrencyRate>
+
+        type private ``Customer (base)`` = Customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Customer =
+            { [<ProviderDbType("Int")>]
+              CustomerID: Option<int>
+              [<ProviderDbType("Int")>]
+              PersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              StoreID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Customer (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``Customer (base)`` =
+                        { CustomerID = value
+                          PersonID = this.PersonID
+                          StoreID = this.StoreID
+                          TerritoryID = this.TerritoryID
+                          AccountNumber = this.AccountNumber.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Customer = leftTable<``Customer (base)``, Customer>
+
+        type private ``PersonCreditCard (base)`` = PersonCreditCard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PersonCreditCard =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PersonCreditCard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PersonCreditCard (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``PersonCreditCard (base)`` =
+                        { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PersonCreditCard = leftTable<``PersonCreditCard (base)``, PersonCreditCard>
+
+        type private ``SalesOrderDetail (base)`` = SalesOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderDetail =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesOrderDetailID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              CarrierTrackingNumber: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              OrderQty: Option<int16>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("Money")>]
+              UnitPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              UnitPriceDiscount: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              LineTotal: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderDetail (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderDetail (base)`` =
+                        { SalesOrderID = value
+                          SalesOrderDetailID = this.SalesOrderDetailID.Value
+                          CarrierTrackingNumber = this.CarrierTrackingNumber
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          SpecialOfferID = this.SpecialOfferID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          UnitPriceDiscount = this.UnitPriceDiscount.Value
+                          LineTotal = this.LineTotal.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
+
+        type private ``SalesOrderHeader (base)`` = SalesOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeader =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              RevisionNumber: Option<byte>
+              [<ProviderDbType("DateTime")>]
+              OrderDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ShipDate: Option<System.DateTime>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("Bit")>]
+              OnlineOrderFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              SalesOrderNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              PurchaseOrderNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("Int")>]
+              CustomerID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              BillToAddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipToAddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              CreditCardApprovalCode: Option<string>
+              [<ProviderDbType("Int")>]
+              CurrencyRateID: Option<int>
+              [<ProviderDbType("Money")>]
+              SubTotal: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TaxAmt: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Freight: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TotalDue: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Comment: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeader (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeader (base)`` =
+                        { SalesOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          OrderDate = this.OrderDate.Value
+                          DueDate = this.DueDate.Value
+                          ShipDate = this.ShipDate
+                          Status = this.Status.Value
+                          OnlineOrderFlag = this.OnlineOrderFlag.Value
+                          SalesOrderNumber = this.SalesOrderNumber.Value
+                          PurchaseOrderNumber = this.PurchaseOrderNumber
+                          AccountNumber = this.AccountNumber
+                          CustomerID = this.CustomerID.Value
+                          SalesPersonID = this.SalesPersonID
+                          TerritoryID = this.TerritoryID
+                          BillToAddressID = this.BillToAddressID.Value
+                          ShipToAddressID = this.ShipToAddressID.Value
+                          ShipMethodID = this.ShipMethodID.Value
+                          CreditCardID = this.CreditCardID
+                          CreditCardApprovalCode = this.CreditCardApprovalCode
+                          CurrencyRateID = this.CurrencyRateID
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          Comment = this.Comment
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+        type private ``SalesOrderHeaderSalesReason (base)`` = SalesOrderHeaderSalesReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeaderSalesReason =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesReasonID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeaderSalesReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeaderSalesReason (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeaderSalesReason (base)`` =
+                        { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeaderSalesReason =
+            leftTable<``SalesOrderHeaderSalesReason (base)``, SalesOrderHeaderSalesReason>
+
+        type private ``SalesPerson (base)`` = SalesPerson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesPerson =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("Money")>]
+              SalesQuota: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Bonus: Option<decimal>
+              [<ProviderDbType("SmallMoney")>]
+              CommissionPct: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesLastYear: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesPerson (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesPerson (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesPerson (base)`` =
+                        { BusinessEntityID = value
+                          TerritoryID = this.TerritoryID
+                          SalesQuota = this.SalesQuota
+                          Bonus = this.Bonus.Value
+                          CommissionPct = this.CommissionPct.Value
+                          SalesYTD = this.SalesYTD.Value
+                          SalesLastYear = this.SalesLastYear.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesPerson = leftTable<``SalesPerson (base)``, SalesPerson>
+
+        type private ``SalesPersonQuotaHistory (base)`` = SalesPersonQuotaHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesPersonQuotaHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              QuotaDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              SalesQuota: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesPersonQuotaHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesPersonQuotaHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesPersonQuotaHistory (base)`` =
+                        { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesPersonQuotaHistory =
+            leftTable<``SalesPersonQuotaHistory (base)``, SalesPersonQuotaHistory>
+
+        type private ``SalesReason (base)`` = SalesReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesReason =
+            { [<ProviderDbType("Int")>]
+              SalesReasonID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              ReasonType: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesReason (base)`` option =
+                match this.SalesReasonID with
+                | Some value ->
+                    let record: ``SalesReason (base)`` =
+                        { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesReason = leftTable<``SalesReason (base)``, SalesReason>
+
+        type private ``SalesTaxRate (base)`` = SalesTaxRate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTaxRate =
+            { [<ProviderDbType("Int")>]
+              SalesTaxRateID: Option<int>
+              [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              TaxType: Option<byte>
+              [<ProviderDbType("SmallMoney")>]
+              TaxRate: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTaxRate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTaxRate (base)`` option =
+                match this.SalesTaxRateID with
+                | Some value ->
+                    let record: ``SalesTaxRate (base)`` =
+                        { SalesTaxRateID = value
+                          StateProvinceID = this.StateProvinceID.Value
+                          TaxType = this.TaxType.Value
+                          TaxRate = this.TaxRate.Value
+                          Name = this.Name.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTaxRate = leftTable<``SalesTaxRate (base)``, SalesTaxRate>
+
+        type private ``SalesTerritory (base)`` = SalesTerritory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTerritory =
+            { [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Group: Option<string>
+              [<ProviderDbType("Money")>]
+              SalesYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesLastYear: Option<decimal>
+              [<ProviderDbType("Money")>]
+              CostYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              CostLastYear: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTerritory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTerritory (base)`` option =
+                match this.TerritoryID with
+                | Some value ->
+                    let record: ``SalesTerritory (base)`` =
+                        { TerritoryID = value
+                          Name = this.Name.Value
+                          CountryRegionCode = this.CountryRegionCode.Value
+                          Group = this.Group.Value
+                          SalesYTD = this.SalesYTD.Value
+                          SalesLastYear = this.SalesLastYear.Value
+                          CostYTD = this.CostYTD.Value
+                          CostLastYear = this.CostLastYear.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTerritory = leftTable<``SalesTerritory (base)``, SalesTerritory>
+
+        type private ``SalesTerritoryHistory (base)`` = SalesTerritoryHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTerritoryHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTerritoryHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTerritoryHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesTerritoryHistory (base)`` =
+                        { BusinessEntityID = value
+                          TerritoryID = this.TerritoryID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTerritoryHistory =
+            leftTable<``SalesTerritoryHistory (base)``, SalesTerritoryHistory>
+
+        type private ``ShoppingCartItem (base)`` = ShoppingCartItem
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ShoppingCartItem =
+            { [<ProviderDbType("Int")>]
+              ShoppingCartItemID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ShoppingCartID: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              DateCreated: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ShoppingCartItem (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ShoppingCartItem (base)`` option =
+                match this.ShoppingCartItemID with
+                | Some value ->
+                    let record: ``ShoppingCartItem (base)`` =
+                        { ShoppingCartItemID = value
+                          ShoppingCartID = this.ShoppingCartID.Value
+                          Quantity = this.Quantity.Value
+                          ProductID = this.ProductID.Value
+                          DateCreated = this.DateCreated.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ShoppingCartItem = leftTable<``ShoppingCartItem (base)``, ShoppingCartItem>
+
+        type private ``SpecialOffer (base)`` = SpecialOffer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SpecialOffer =
+            { [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Description: Option<string>
+              [<ProviderDbType("SmallMoney")>]
+              DiscountPct: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Type: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Category: Option<string>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Int")>]
+              MinQty: Option<int>
+              [<ProviderDbType("Int")>]
+              MaxQty: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SpecialOffer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SpecialOffer (base)`` option =
+                match this.SpecialOfferID with
+                | Some value ->
+                    let record: ``SpecialOffer (base)`` =
+                        { SpecialOfferID = value
+                          Description = this.Description.Value
+                          DiscountPct = this.DiscountPct.Value
+                          Type = this.Type.Value
+                          Category = this.Category.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate.Value
+                          MinQty = this.MinQty.Value
+                          MaxQty = this.MaxQty
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SpecialOffer = leftTable<``SpecialOffer (base)``, SpecialOffer>
+
+        type private ``SpecialOfferProduct (base)`` = SpecialOfferProduct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SpecialOfferProduct =
+            { [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SpecialOfferProduct (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SpecialOfferProduct (base)`` option =
+                match this.SpecialOfferID with
+                | Some value ->
+                    let record: ``SpecialOfferProduct (base)`` =
+                        { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SpecialOfferProduct =
+            leftTable<``SpecialOfferProduct (base)``, SpecialOfferProduct>
+
+        type private ``Store (base)`` = Store
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Store =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Int")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Store (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Store (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Store (base)`` =
+                        { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Store = leftTable<``Store (base)``, Store>
+
+
 module dbo =
 
     [<CLIMutable>]
@@ -2021,6 +4621,124 @@ module dbo =
 
     let ErrorLog = table<ErrorLog>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``AWBuildVersion (base)`` = AWBuildVersion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type AWBuildVersion =
+            { [<ProviderDbType("TinyInt")>]
+              SystemInformationID: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              ``Database Version``: Option<string>
+              [<ProviderDbType("DateTime")>]
+              VersionDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``AWBuildVersion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``AWBuildVersion (base)`` option =
+                match this.SystemInformationID with
+                | Some value ->
+                    let record: ``AWBuildVersion (base)`` =
+                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let AWBuildVersion = leftTable<``AWBuildVersion (base)``, AWBuildVersion>
+
+        type private ``DatabaseLog (base)`` = DatabaseLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type DatabaseLog =
+            { [<ProviderDbType("Int")>]
+              DatabaseLogID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              PostTime: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              DatabaseUser: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Event: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Schema: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Object: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              TSQL: Option<string> }
+
+            interface ILeftViewOf<``DatabaseLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``DatabaseLog (base)`` option =
+                match this.DatabaseLogID with
+                | Some value ->
+                    let record: ``DatabaseLog (base)`` =
+                        { DatabaseLogID = value
+                          PostTime = this.PostTime.Value
+                          DatabaseUser = this.DatabaseUser.Value
+                          Event = this.Event.Value
+                          Schema = this.Schema
+                          Object = this.Object
+                          TSQL = this.TSQL.Value }
+
+                    Some record
+                | None -> None
+
+        let DatabaseLog = leftTable<``DatabaseLog (base)``, DatabaseLog>
+
+        type private ``ErrorLog (base)`` = ErrorLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ErrorLog =
+            { [<ProviderDbType("Int")>]
+              ErrorLogID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ErrorTime: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              UserName: Option<string>
+              [<ProviderDbType("Int")>]
+              ErrorNumber: Option<int>
+              [<ProviderDbType("Int")>]
+              ErrorSeverity: Option<int>
+              [<ProviderDbType("Int")>]
+              ErrorState: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ErrorProcedure: Option<string>
+              [<ProviderDbType("Int")>]
+              ErrorLine: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ErrorMessage: Option<string> }
+
+            interface ILeftViewOf<``ErrorLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ErrorLog (base)`` option =
+                match this.ErrorLogID with
+                | Some value ->
+                    let record: ``ErrorLog (base)`` =
+                        { ErrorLogID = value
+                          ErrorTime = this.ErrorTime.Value
+                          UserName = this.UserName.Value
+                          ErrorNumber = this.ErrorNumber.Value
+                          ErrorSeverity = this.ErrorSeverity
+                          ErrorState = this.ErrorState
+                          ErrorProcedure = this.ErrorProcedure
+                          ErrorLine = this.ErrorLine
+                          ErrorMessage = this.ErrorMessage.Value }
+
+                    Some record
+                | None -> None
+
+        let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
+
+
 module ext =
 
     [<CLIMutable>]
@@ -2084,6 +4802,111 @@ module ext =
                   { WriteColumn.Name = "Value"; Value = box this.Value; ProviderDbType = Some "NVarChar" } ]
 
     let NullableKeyUpsert = table<NullableKeyUpsert>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``DateTime2Support (base)`` = DateTime2Support
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type DateTime2Support =
+            { [<ProviderDbType("Int")>]
+              ID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              LessPrecision: Option<System.DateTime>
+              [<ProviderDbType("DateTime2")>]
+              MorePrecision: Option<System.DateTime> }
+
+            interface ILeftViewOf<``DateTime2Support (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``DateTime2Support (base)`` option =
+                match this.ID with
+                | Some value ->
+                    let record: ``DateTime2Support (base)`` =
+                        { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
+
+                    Some record
+                | None -> None
+
+        let DateTime2Support = leftTable<``DateTime2Support (base)``, DateTime2Support>
+
+        type private ``GetIdGuidRepro (base)`` = GetIdGuidRepro
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type GetIdGuidRepro =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Id: Option<System.Guid>
+              [<ProviderDbType("NChar")>]
+              EmailAddress: Option<string> }
+
+            interface ILeftViewOf<``GetIdGuidRepro (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``GetIdGuidRepro (base)`` option =
+                match this.Id with
+                | Some value ->
+                    let record: ``GetIdGuidRepro (base)`` =
+                        { Id = value; EmailAddress = this.EmailAddress.Value }
+
+                    Some record
+                | None -> None
+
+        let GetIdGuidRepro = leftTable<``GetIdGuidRepro (base)``, GetIdGuidRepro>
+
+        type private ``HierarchyIdSupport (base)`` = HierarchyIdSupport
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type HierarchyIdSupport =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Id: Option<System.Guid>
+              [<ProviderDbType("SqlHierarchyId")>]
+              Hierarchy: Option<Microsoft.SqlServer.Types.SqlHierarchyId> }
+
+            interface ILeftViewOf<``HierarchyIdSupport (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``HierarchyIdSupport (base)`` option =
+                match this.Id with
+                | Some value ->
+                    let record: ``HierarchyIdSupport (base)`` =
+                        { Id = value; Hierarchy = this.Hierarchy.Value }
+
+                    Some record
+                | None -> None
+
+        let HierarchyIdSupport =
+            leftTable<``HierarchyIdSupport (base)``, HierarchyIdSupport>
+
+        type private ``NullableKeyUpsert (base)`` = NullableKeyUpsert
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type NullableKeyUpsert =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Key1: Option<System.Guid>
+              [<ProviderDbType("NVarChar")>]
+              Key2: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Value: Option<string> }
+
+            interface ILeftViewOf<``NullableKeyUpsert (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``NullableKeyUpsert (base)`` option =
+                match this.Key1 with
+                | Some value ->
+                    let record: ``NullableKeyUpsert (base)`` =
+                        { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
+
+                    Some record
+                | None -> None
+
+        let NullableKeyUpsert = leftTable<``NullableKeyUpsert (base)``, NullableKeyUpsert>
+
 
 
 

--- a/src/Tests/SqlServer/AdventureWorksNet10.fs
+++ b/src/Tests/SqlServer/AdventureWorksNet10.fs
@@ -194,17 +194,6 @@ module HumanResources =
 
             interface ILeftViewOf<``Department (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Department (base)`` option =
-                match this.DepartmentID with
-                | Some value ->
-                    let record: ``Department (base)`` =
-                        { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Department = leftTable<``Department (base)``, Department>
 
         type private ``Employee (base)`` = Employee
@@ -246,32 +235,6 @@ module HumanResources =
 
             interface ILeftViewOf<``Employee (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Employee (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Employee (base)`` =
-                        { BusinessEntityID = value
-                          NationalIDNumber = this.NationalIDNumber.Value
-                          LoginID = this.LoginID.Value
-                          OrganizationNode = this.OrganizationNode
-                          OrganizationLevel = this.OrganizationLevel
-                          JobTitle = this.JobTitle.Value
-                          BirthDate = this.BirthDate.Value
-                          MaritalStatus = this.MaritalStatus.Value
-                          Gender = this.Gender.Value
-                          HireDate = this.HireDate.Value
-                          SalariedFlag = this.SalariedFlag.Value
-                          VacationHours = this.VacationHours.Value
-                          SickLeaveHours = this.SickLeaveHours.Value
-                          CurrentFlag = this.CurrentFlag.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Employee = leftTable<``Employee (base)``, Employee>
 
         type private ``EmployeeDepartmentHistory (base)`` = EmployeeDepartmentHistory
@@ -293,22 +256,6 @@ module HumanResources =
 
             interface ILeftViewOf<``EmployeeDepartmentHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmployeeDepartmentHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmployeeDepartmentHistory (base)`` =
-                        { BusinessEntityID = value
-                          DepartmentID = this.DepartmentID.Value
-                          ShiftID = this.ShiftID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmployeeDepartmentHistory =
             leftTable<``EmployeeDepartmentHistory (base)``, EmployeeDepartmentHistory>
 
@@ -329,17 +276,6 @@ module HumanResources =
 
             interface ILeftViewOf<``EmployeePayHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmployeePayHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmployeePayHistory (base)`` =
-                        { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmployeePayHistory =
             leftTable<``EmployeePayHistory (base)``, EmployeePayHistory>
 
@@ -355,17 +291,6 @@ module HumanResources =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``JobCandidate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``JobCandidate (base)`` option =
-                match this.JobCandidateID with
-                | Some value ->
-                    let record: ``JobCandidate (base)`` =
-                        { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let JobCandidate = leftTable<``JobCandidate (base)``, JobCandidate>
 
@@ -385,17 +310,6 @@ module HumanResources =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Shift (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Shift (base)`` option =
-                match this.ShiftID with
-                | Some value ->
-                    let record: ``Shift (base)`` =
-                        { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Shift = leftTable<``Shift (base)``, Shift>
 
@@ -733,24 +647,6 @@ module Person =
 
             interface ILeftViewOf<``Address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Address (base)`` option =
-                match this.AddressID with
-                | Some value ->
-                    let record: ``Address (base)`` =
-                        { AddressID = value
-                          AddressLine1 = this.AddressLine1.Value
-                          AddressLine2 = this.AddressLine2
-                          City = this.City.Value
-                          StateProvinceID = this.StateProvinceID.Value
-                          PostalCode = this.PostalCode.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Address = leftTable<``Address (base)``, Address>
 
         type private ``AddressType (base)`` = AddressType
@@ -768,17 +664,6 @@ module Person =
 
             interface ILeftViewOf<``AddressType (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``AddressType (base)`` option =
-                match this.AddressTypeID with
-                | Some value ->
-                    let record: ``AddressType (base)`` =
-                        { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let AddressType = leftTable<``AddressType (base)``, AddressType>
 
         type private ``BusinessEntity (base)`` = BusinessEntity
@@ -793,17 +678,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BusinessEntity (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntity (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntity (base)`` =
-                        { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BusinessEntity = leftTable<``BusinessEntity (base)``, BusinessEntity>
 
@@ -823,17 +697,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BusinessEntityAddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntityAddress (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntityAddress (base)`` =
-                        { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BusinessEntityAddress =
             leftTable<``BusinessEntityAddress (base)``, BusinessEntityAddress>
@@ -855,17 +718,6 @@ module Person =
 
             interface ILeftViewOf<``BusinessEntityContact (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntityContact (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntityContact (base)`` =
-                        { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let BusinessEntityContact =
             leftTable<``BusinessEntityContact (base)``, BusinessEntityContact>
 
@@ -882,17 +734,6 @@ module Person =
 
             interface ILeftViewOf<``ContactType (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ContactType (base)`` option =
-                match this.ContactTypeID with
-                | Some value ->
-                    let record: ``ContactType (base)`` =
-                        { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ContactType = leftTable<``ContactType (base)``, ContactType>
 
         type private ``CountryRegion (base)`` = CountryRegion
@@ -907,17 +748,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``CountryRegion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CountryRegion (base)`` option =
-                match this.CountryRegionCode with
-                | Some value ->
-                    let record: ``CountryRegion (base)`` =
-                        { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let CountryRegion = leftTable<``CountryRegion (base)``, CountryRegion>
 
@@ -938,17 +768,6 @@ module Person =
 
             interface ILeftViewOf<``EmailAddress (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmailAddress (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmailAddress (base)`` =
-                        { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmailAddress = leftTable<``EmailAddress (base)``, EmailAddress>
 
         type private ``Password (base)`` = Password
@@ -967,21 +786,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Password (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Password (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Password (base)`` =
-                        { BusinessEntityID = value
-                          PasswordHash = this.PasswordHash.Value
-                          PasswordSalt = this.PasswordSalt.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Password = leftTable<``Password (base)``, Password>
 
@@ -1014,27 +818,6 @@ module Person =
 
             interface ILeftViewOf<``Person (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Person (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Person (base)`` =
-                        { BusinessEntityID = value
-                          PersonType = this.PersonType.Value
-                          NameStyle = this.NameStyle.Value
-                          Title = this.Title
-                          FirstName = this.FirstName.Value
-                          MiddleName = this.MiddleName
-                          LastName = this.LastName.Value
-                          Suffix = this.Suffix
-                          EmailPromotion = this.EmailPromotion.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Person = leftTable<``Person (base)``, Person>
 
         type private ``PersonPhone (base)`` = PersonPhone
@@ -1052,17 +835,6 @@ module Person =
 
             interface ILeftViewOf<``PersonPhone (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PersonPhone (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``PersonPhone (base)`` =
-                        { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let PersonPhone = leftTable<``PersonPhone (base)``, PersonPhone>
 
         type private ``PhoneNumberType (base)`` = PhoneNumberType
@@ -1077,17 +849,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PhoneNumberType (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PhoneNumberType (base)`` option =
-                match this.PhoneNumberTypeID with
-                | Some value ->
-                    let record: ``PhoneNumberType (base)`` =
-                        { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PhoneNumberType = leftTable<``PhoneNumberType (base)``, PhoneNumberType>
 
@@ -1113,24 +874,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``StateProvince (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``StateProvince (base)`` option =
-                match this.StateProvinceID with
-                | Some value ->
-                    let record: ``StateProvince (base)`` =
-                        { StateProvinceID = value
-                          StateProvinceCode = this.StateProvinceCode.Value
-                          CountryRegionCode = this.CountryRegionCode.Value
-                          IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
-                          Name = this.Name.Value
-                          TerritoryID = this.TerritoryID.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let StateProvince = leftTable<``StateProvince (base)``, StateProvince>
 
@@ -1864,25 +1607,6 @@ module Production =
 
             interface ILeftViewOf<``BillOfMaterials (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BillOfMaterials (base)`` option =
-                match this.BillOfMaterialsID with
-                | Some value ->
-                    let record: ``BillOfMaterials (base)`` =
-                        { BillOfMaterialsID = value
-                          ProductAssemblyID = this.ProductAssemblyID
-                          ComponentID = this.ComponentID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          UnitMeasureCode = this.UnitMeasureCode.Value
-                          BOMLevel = this.BOMLevel.Value
-                          PerAssemblyQty = this.PerAssemblyQty.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let BillOfMaterials = leftTable<``BillOfMaterials (base)``, BillOfMaterials>
 
         type private ``Culture (base)`` = Culture
@@ -1897,17 +1621,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Culture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Culture (base)`` option =
-                match this.CultureID with
-                | Some value ->
-                    let record: ``Culture (base)`` =
-                        { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Culture = leftTable<``Culture (base)``, Culture>
 
@@ -1946,30 +1659,6 @@ module Production =
 
             interface ILeftViewOf<``Document (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Document (base)`` option =
-                match this.DocumentNode with
-                | Some value ->
-                    let record: ``Document (base)`` =
-                        { DocumentNode = value
-                          DocumentLevel = this.DocumentLevel
-                          Title = this.Title.Value
-                          Owner = this.Owner.Value
-                          FolderFlag = this.FolderFlag.Value
-                          FileName = this.FileName.Value
-                          FileExtension = this.FileExtension.Value
-                          Revision = this.Revision.Value
-                          ChangeNumber = this.ChangeNumber.Value
-                          Status = this.Status.Value
-                          DocumentSummary = this.DocumentSummary
-                          Document = this.Document
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Document = leftTable<``Document (base)``, Document>
 
         type private ``Illustration (base)`` = Illustration
@@ -1982,17 +1671,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Illustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Illustration (base)`` option =
-                match this.IllustrationID with
-                | Some value ->
-                    let record: ``Illustration (base)`` =
-                        { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Illustration = leftTable<``Illustration (base)``, Illustration>
 
@@ -2012,17 +1690,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Location (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Location (base)`` option =
-                match this.LocationID with
-                | Some value ->
-                    let record: ``Location (base)`` =
-                        { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Location = leftTable<``Location (base)``, Location>
 
@@ -2083,41 +1750,6 @@ module Production =
 
             interface ILeftViewOf<``Product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Product (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``Product (base)`` =
-                        { ProductID = value
-                          Name = this.Name.Value
-                          ProductNumber = this.ProductNumber.Value
-                          MakeFlag = this.MakeFlag.Value
-                          FinishedGoodsFlag = this.FinishedGoodsFlag.Value
-                          Color = this.Color
-                          SafetyStockLevel = this.SafetyStockLevel.Value
-                          ReorderPoint = this.ReorderPoint.Value
-                          StandardCost = this.StandardCost.Value
-                          ListPrice = this.ListPrice.Value
-                          Size = this.Size
-                          SizeUnitMeasureCode = this.SizeUnitMeasureCode
-                          WeightUnitMeasureCode = this.WeightUnitMeasureCode
-                          Weight = this.Weight
-                          DaysToManufacture = this.DaysToManufacture.Value
-                          ProductLine = this.ProductLine
-                          Class = this.Class
-                          Style = this.Style
-                          ProductSubcategoryID = this.ProductSubcategoryID
-                          ProductModelID = this.ProductModelID
-                          SellStartDate = this.SellStartDate.Value
-                          SellEndDate = this.SellEndDate
-                          DiscontinuedDate = this.DiscontinuedDate
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Product = leftTable<``Product (base)``, Product>
 
         type private ``ProductCategory (base)`` = ProductCategory
@@ -2134,17 +1766,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductCategory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCategory (base)`` option =
-                match this.ProductCategoryID with
-                | Some value ->
-                    let record: ``ProductCategory (base)`` =
-                        { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
 
@@ -2165,17 +1786,6 @@ module Production =
 
             interface ILeftViewOf<``ProductCostHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCostHistory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductCostHistory (base)`` =
-                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductCostHistory =
             leftTable<``ProductCostHistory (base)``, ProductCostHistory>
 
@@ -2194,17 +1804,6 @@ module Production =
 
             interface ILeftViewOf<``ProductDescription (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDescription (base)`` option =
-                match this.ProductDescriptionID with
-                | Some value ->
-                    let record: ``ProductDescription (base)`` =
-                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductDescription =
             leftTable<``ProductDescription (base)``, ProductDescription>
 
@@ -2220,17 +1819,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductDocument (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDocument (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductDocument (base)`` =
-                        { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductDocument = leftTable<``ProductDocument (base)``, ProductDocument>
 
@@ -2255,23 +1843,6 @@ module Production =
 
             interface ILeftViewOf<``ProductInventory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductInventory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductInventory (base)`` =
-                        { ProductID = value
-                          LocationID = this.LocationID.Value
-                          Shelf = this.Shelf.Value
-                          Bin = this.Bin.Value
-                          Quantity = this.Quantity.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductInventory = leftTable<``ProductInventory (base)``, ProductInventory>
 
         type private ``ProductListPriceHistory (base)`` = ProductListPriceHistory
@@ -2291,17 +1862,6 @@ module Production =
 
             interface ILeftViewOf<``ProductListPriceHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductListPriceHistory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductListPriceHistory (base)`` =
-                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductListPriceHistory =
             leftTable<``ProductListPriceHistory (base)``, ProductListPriceHistory>
 
@@ -2320,17 +1880,6 @@ module Production =
 
             interface ILeftViewOf<``ProductModel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModel (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModel (base)`` =
-                        { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
 
         type private ``ProductModelIllustration (base)`` = ProductModelIllustration
@@ -2345,17 +1894,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelIllustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelIllustration (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelIllustration (base)`` =
-                        { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelIllustration =
             leftTable<``ProductModelIllustration (base)``, ProductModelIllustration>
@@ -2374,17 +1912,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelProductDescriptionCulture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelProductDescriptionCulture (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelProductDescriptionCulture (base)`` =
-                        { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelProductDescriptionCulture =
             leftTable<``ProductModelProductDescriptionCulture (base)``, ProductModelProductDescriptionCulture>
@@ -2408,22 +1935,6 @@ module Production =
 
             interface ILeftViewOf<``ProductPhoto (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductPhoto (base)`` option =
-                match this.ProductPhotoID with
-                | Some value ->
-                    let record: ``ProductPhoto (base)`` =
-                        { ProductPhotoID = value
-                          ThumbNailPhoto = this.ThumbNailPhoto
-                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
-                          LargePhoto = this.LargePhoto
-                          LargePhotoFileName = this.LargePhotoFileName
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductPhoto = leftTable<``ProductPhoto (base)``, ProductPhoto>
 
         type private ``ProductProductPhoto (base)`` = ProductProductPhoto
@@ -2440,17 +1951,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductProductPhoto (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductProductPhoto (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductProductPhoto (base)`` =
-                        { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductProductPhoto =
             leftTable<``ProductProductPhoto (base)``, ProductProductPhoto>
@@ -2478,24 +1978,6 @@ module Production =
 
             interface ILeftViewOf<``ProductReview (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductReview (base)`` option =
-                match this.ProductReviewID with
-                | Some value ->
-                    let record: ``ProductReview (base)`` =
-                        { ProductReviewID = value
-                          ProductID = this.ProductID.Value
-                          ReviewerName = this.ReviewerName.Value
-                          ReviewDate = this.ReviewDate.Value
-                          EmailAddress = this.EmailAddress.Value
-                          Rating = this.Rating.Value
-                          Comments = this.Comments
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductReview = leftTable<``ProductReview (base)``, ProductReview>
 
         type private ``ProductSubcategory (base)`` = ProductSubcategory
@@ -2515,17 +1997,6 @@ module Production =
 
             interface ILeftViewOf<``ProductSubcategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductSubcategory (base)`` option =
-                match this.ProductSubcategoryID with
-                | Some value ->
-                    let record: ``ProductSubcategory (base)`` =
-                        { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductSubcategory =
             leftTable<``ProductSubcategory (base)``, ProductSubcategory>
 
@@ -2541,17 +2012,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ScrapReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ScrapReason (base)`` option =
-                match this.ScrapReasonID with
-                | Some value ->
-                    let record: ``ScrapReason (base)`` =
-                        { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ScrapReason = leftTable<``ScrapReason (base)``, ScrapReason>
 
@@ -2579,25 +2039,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``TransactionHistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``TransactionHistory (base)`` option =
-                match this.TransactionID with
-                | Some value ->
-                    let record: ``TransactionHistory (base)`` =
-                        { TransactionID = value
-                          ProductID = this.ProductID.Value
-                          ReferenceOrderID = this.ReferenceOrderID.Value
-                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
-                          TransactionDate = this.TransactionDate.Value
-                          TransactionType = this.TransactionType.Value
-                          Quantity = this.Quantity.Value
-                          ActualCost = this.ActualCost.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let TransactionHistory =
             leftTable<``TransactionHistory (base)``, TransactionHistory>
@@ -2627,25 +2068,6 @@ module Production =
 
             interface ILeftViewOf<``TransactionHistoryArchive (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``TransactionHistoryArchive (base)`` option =
-                match this.TransactionID with
-                | Some value ->
-                    let record: ``TransactionHistoryArchive (base)`` =
-                        { TransactionID = value
-                          ProductID = this.ProductID.Value
-                          ReferenceOrderID = this.ReferenceOrderID.Value
-                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
-                          TransactionDate = this.TransactionDate.Value
-                          TransactionType = this.TransactionType.Value
-                          Quantity = this.Quantity.Value
-                          ActualCost = this.ActualCost.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let TransactionHistoryArchive =
             leftTable<``TransactionHistoryArchive (base)``, TransactionHistoryArchive>
 
@@ -2661,17 +2083,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``UnitMeasure (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``UnitMeasure (base)`` option =
-                match this.UnitMeasureCode with
-                | Some value ->
-                    let record: ``UnitMeasure (base)`` =
-                        { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let UnitMeasure = leftTable<``UnitMeasure (base)``, UnitMeasure>
 
@@ -2701,26 +2112,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``WorkOrder (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WorkOrder (base)`` option =
-                match this.WorkOrderID with
-                | Some value ->
-                    let record: ``WorkOrder (base)`` =
-                        { WorkOrderID = value
-                          ProductID = this.ProductID.Value
-                          OrderQty = this.OrderQty.Value
-                          StockedQty = this.StockedQty.Value
-                          ScrappedQty = this.ScrappedQty.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          DueDate = this.DueDate.Value
-                          ScrapReasonID = this.ScrapReasonID
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let WorkOrder = leftTable<``WorkOrder (base)``, WorkOrder>
 
@@ -2754,28 +2145,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``WorkOrderRouting (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WorkOrderRouting (base)`` option =
-                match this.WorkOrderID with
-                | Some value ->
-                    let record: ``WorkOrderRouting (base)`` =
-                        { WorkOrderID = value
-                          ProductID = this.ProductID.Value
-                          OperationSequence = this.OperationSequence.Value
-                          LocationID = this.LocationID.Value
-                          ScheduledStartDate = this.ScheduledStartDate.Value
-                          ScheduledEndDate = this.ScheduledEndDate.Value
-                          ActualStartDate = this.ActualStartDate
-                          ActualEndDate = this.ActualEndDate
-                          ActualResourceHrs = this.ActualResourceHrs
-                          PlannedCost = this.PlannedCost.Value
-                          ActualCost = this.ActualCost
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let WorkOrderRouting = leftTable<``WorkOrderRouting (base)``, WorkOrderRouting>
 
@@ -3001,27 +2370,6 @@ module Purchasing =
 
             interface ILeftViewOf<``ProductVendor (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductVendor (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductVendor (base)`` =
-                        { ProductID = value
-                          BusinessEntityID = this.BusinessEntityID.Value
-                          AverageLeadTime = this.AverageLeadTime.Value
-                          StandardPrice = this.StandardPrice.Value
-                          LastReceiptCost = this.LastReceiptCost
-                          LastReceiptDate = this.LastReceiptDate
-                          MinOrderQty = this.MinOrderQty.Value
-                          MaxOrderQty = this.MaxOrderQty.Value
-                          OnOrderQty = this.OnOrderQty
-                          UnitMeasureCode = this.UnitMeasureCode.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductVendor = leftTable<``ProductVendor (base)``, ProductVendor>
 
         type private ``PurchaseOrderDetail (base)`` = PurchaseOrderDetail
@@ -3052,27 +2400,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PurchaseOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PurchaseOrderDetail (base)`` option =
-                match this.PurchaseOrderID with
-                | Some value ->
-                    let record: ``PurchaseOrderDetail (base)`` =
-                        { PurchaseOrderID = value
-                          PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
-                          DueDate = this.DueDate.Value
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          LineTotal = this.LineTotal.Value
-                          ReceivedQty = this.ReceivedQty.Value
-                          RejectedQty = this.RejectedQty.Value
-                          StockedQty = this.StockedQty.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PurchaseOrderDetail =
             leftTable<``PurchaseOrderDetail (base)``, PurchaseOrderDetail>
@@ -3110,29 +2437,6 @@ module Purchasing =
 
             interface ILeftViewOf<``PurchaseOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PurchaseOrderHeader (base)`` option =
-                match this.PurchaseOrderID with
-                | Some value ->
-                    let record: ``PurchaseOrderHeader (base)`` =
-                        { PurchaseOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          Status = this.Status.Value
-                          EmployeeID = this.EmployeeID.Value
-                          VendorID = this.VendorID.Value
-                          ShipMethodID = this.ShipMethodID.Value
-                          OrderDate = this.OrderDate.Value
-                          ShipDate = this.ShipDate
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let PurchaseOrderHeader =
             leftTable<``PurchaseOrderHeader (base)``, PurchaseOrderHeader>
 
@@ -3154,22 +2458,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ShipMethod (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ShipMethod (base)`` option =
-                match this.ShipMethodID with
-                | Some value ->
-                    let record: ``ShipMethod (base)`` =
-                        { ShipMethodID = value
-                          Name = this.Name.Value
-                          ShipBase = this.ShipBase.Value
-                          ShipRate = this.ShipRate.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ShipMethod = leftTable<``ShipMethod (base)``, ShipMethod>
 
@@ -3195,24 +2483,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Vendor (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Vendor (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Vendor (base)`` =
-                        { BusinessEntityID = value
-                          AccountNumber = this.AccountNumber.Value
-                          Name = this.Name.Value
-                          CreditRating = this.CreditRating.Value
-                          PreferredVendorStatus = this.PreferredVendorStatus.Value
-                          ActiveFlag = this.ActiveFlag.Value
-                          PurchasingWebServiceURL = this.PurchasingWebServiceURL
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Vendor = leftTable<``Vendor (base)``, Vendor>
 
@@ -3795,17 +3065,6 @@ module Sales =
 
             interface ILeftViewOf<``CountryRegionCurrency (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CountryRegionCurrency (base)`` option =
-                match this.CountryRegionCode with
-                | Some value ->
-                    let record: ``CountryRegionCurrency (base)`` =
-                        { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CountryRegionCurrency =
             leftTable<``CountryRegionCurrency (base)``, CountryRegionCurrency>
 
@@ -3828,22 +3087,6 @@ module Sales =
 
             interface ILeftViewOf<``CreditCard (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CreditCard (base)`` option =
-                match this.CreditCardID with
-                | Some value ->
-                    let record: ``CreditCard (base)`` =
-                        { CreditCardID = value
-                          CardType = this.CardType.Value
-                          CardNumber = this.CardNumber.Value
-                          ExpMonth = this.ExpMonth.Value
-                          ExpYear = this.ExpYear.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CreditCard = leftTable<``CreditCard (base)``, CreditCard>
 
         type private ``Currency (base)`` = Currency
@@ -3858,17 +3101,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Currency (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Currency (base)`` option =
-                match this.CurrencyCode with
-                | Some value ->
-                    let record: ``Currency (base)`` =
-                        { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Currency = leftTable<``Currency (base)``, Currency>
 
@@ -3893,23 +3125,6 @@ module Sales =
 
             interface ILeftViewOf<``CurrencyRate (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CurrencyRate (base)`` option =
-                match this.CurrencyRateID with
-                | Some value ->
-                    let record: ``CurrencyRate (base)`` =
-                        { CurrencyRateID = value
-                          CurrencyRateDate = this.CurrencyRateDate.Value
-                          FromCurrencyCode = this.FromCurrencyCode.Value
-                          ToCurrencyCode = this.ToCurrencyCode.Value
-                          AverageRate = this.AverageRate.Value
-                          EndOfDayRate = this.EndOfDayRate.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CurrencyRate = leftTable<``CurrencyRate (base)``, CurrencyRate>
 
         type private ``Customer (base)`` = Customer
@@ -3933,23 +3148,6 @@ module Sales =
 
             interface ILeftViewOf<``Customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Customer (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``Customer (base)`` =
-                        { CustomerID = value
-                          PersonID = this.PersonID
-                          StoreID = this.StoreID
-                          TerritoryID = this.TerritoryID
-                          AccountNumber = this.AccountNumber.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Customer = leftTable<``Customer (base)``, Customer>
 
         type private ``PersonCreditCard (base)`` = PersonCreditCard
@@ -3964,17 +3162,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PersonCreditCard (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PersonCreditCard (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``PersonCreditCard (base)`` =
-                        { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PersonCreditCard = leftTable<``PersonCreditCard (base)``, PersonCreditCard>
 
@@ -4006,27 +3193,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderDetail (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderDetail (base)`` =
-                        { SalesOrderID = value
-                          SalesOrderDetailID = this.SalesOrderDetailID.Value
-                          CarrierTrackingNumber = this.CarrierTrackingNumber
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          SpecialOfferID = this.SpecialOfferID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          UnitPriceDiscount = this.UnitPriceDiscount.Value
-                          LineTotal = this.LineTotal.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
 
@@ -4089,42 +3255,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeader (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeader (base)`` =
-                        { SalesOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          OrderDate = this.OrderDate.Value
-                          DueDate = this.DueDate.Value
-                          ShipDate = this.ShipDate
-                          Status = this.Status.Value
-                          OnlineOrderFlag = this.OnlineOrderFlag.Value
-                          SalesOrderNumber = this.SalesOrderNumber.Value
-                          PurchaseOrderNumber = this.PurchaseOrderNumber
-                          AccountNumber = this.AccountNumber
-                          CustomerID = this.CustomerID.Value
-                          SalesPersonID = this.SalesPersonID
-                          TerritoryID = this.TerritoryID
-                          BillToAddressID = this.BillToAddressID.Value
-                          ShipToAddressID = this.ShipToAddressID.Value
-                          ShipMethodID = this.ShipMethodID.Value
-                          CreditCardID = this.CreditCardID
-                          CreditCardApprovalCode = this.CreditCardApprovalCode
-                          CurrencyRateID = this.CurrencyRateID
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          Comment = this.Comment
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
 
         type private ``SalesOrderHeaderSalesReason (base)`` = SalesOrderHeaderSalesReason
@@ -4139,17 +3269,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderHeaderSalesReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeaderSalesReason (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeaderSalesReason (base)`` =
-                        { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderHeaderSalesReason =
             leftTable<``SalesOrderHeaderSalesReason (base)``, SalesOrderHeaderSalesReason>
@@ -4179,25 +3298,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesPerson (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesPerson (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesPerson (base)`` =
-                        { BusinessEntityID = value
-                          TerritoryID = this.TerritoryID
-                          SalesQuota = this.SalesQuota
-                          Bonus = this.Bonus.Value
-                          CommissionPct = this.CommissionPct.Value
-                          SalesYTD = this.SalesYTD.Value
-                          SalesLastYear = this.SalesLastYear.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesPerson = leftTable<``SalesPerson (base)``, SalesPerson>
 
         type private ``SalesPersonQuotaHistory (base)`` = SalesPersonQuotaHistory
@@ -4217,17 +3317,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesPersonQuotaHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesPersonQuotaHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesPersonQuotaHistory (base)`` =
-                        { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesPersonQuotaHistory =
             leftTable<``SalesPersonQuotaHistory (base)``, SalesPersonQuotaHistory>
 
@@ -4245,17 +3334,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesReason (base)`` option =
-                match this.SalesReasonID with
-                | Some value ->
-                    let record: ``SalesReason (base)`` =
-                        { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesReason = leftTable<``SalesReason (base)``, SalesReason>
 
@@ -4279,23 +3357,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesTaxRate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTaxRate (base)`` option =
-                match this.SalesTaxRateID with
-                | Some value ->
-                    let record: ``SalesTaxRate (base)`` =
-                        { SalesTaxRateID = value
-                          StateProvinceID = this.StateProvinceID.Value
-                          TaxType = this.TaxType.Value
-                          TaxRate = this.TaxRate.Value
-                          Name = this.Name.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesTaxRate = leftTable<``SalesTaxRate (base)``, SalesTaxRate>
 
@@ -4326,26 +3387,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesTerritory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTerritory (base)`` option =
-                match this.TerritoryID with
-                | Some value ->
-                    let record: ``SalesTerritory (base)`` =
-                        { TerritoryID = value
-                          Name = this.Name.Value
-                          CountryRegionCode = this.CountryRegionCode.Value
-                          Group = this.Group.Value
-                          SalesYTD = this.SalesYTD.Value
-                          SalesLastYear = this.SalesLastYear.Value
-                          CostYTD = this.CostYTD.Value
-                          CostLastYear = this.CostLastYear.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesTerritory = leftTable<``SalesTerritory (base)``, SalesTerritory>
 
         type private ``SalesTerritoryHistory (base)`` = SalesTerritoryHistory
@@ -4366,22 +3407,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesTerritoryHistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTerritoryHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesTerritoryHistory (base)`` =
-                        { BusinessEntityID = value
-                          TerritoryID = this.TerritoryID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesTerritoryHistory =
             leftTable<``SalesTerritoryHistory (base)``, SalesTerritoryHistory>
@@ -4404,22 +3429,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ShoppingCartItem (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ShoppingCartItem (base)`` option =
-                match this.ShoppingCartItemID with
-                | Some value ->
-                    let record: ``ShoppingCartItem (base)`` =
-                        { ShoppingCartItemID = value
-                          ShoppingCartID = this.ShoppingCartID.Value
-                          Quantity = this.Quantity.Value
-                          ProductID = this.ProductID.Value
-                          DateCreated = this.DateCreated.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ShoppingCartItem = leftTable<``ShoppingCartItem (base)``, ShoppingCartItem>
 
@@ -4452,27 +3461,6 @@ module Sales =
 
             interface ILeftViewOf<``SpecialOffer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SpecialOffer (base)`` option =
-                match this.SpecialOfferID with
-                | Some value ->
-                    let record: ``SpecialOffer (base)`` =
-                        { SpecialOfferID = value
-                          Description = this.Description.Value
-                          DiscountPct = this.DiscountPct.Value
-                          Type = this.Type.Value
-                          Category = this.Category.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate.Value
-                          MinQty = this.MinQty.Value
-                          MaxQty = this.MaxQty
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SpecialOffer = leftTable<``SpecialOffer (base)``, SpecialOffer>
 
         type private ``SpecialOfferProduct (base)`` = SpecialOfferProduct
@@ -4489,17 +3477,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SpecialOfferProduct (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SpecialOfferProduct (base)`` option =
-                match this.SpecialOfferID with
-                | Some value ->
-                    let record: ``SpecialOfferProduct (base)`` =
-                        { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SpecialOfferProduct =
             leftTable<``SpecialOfferProduct (base)``, SpecialOfferProduct>
@@ -4520,17 +3497,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Store (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Store (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Store (base)`` =
-                        { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Store = leftTable<``Store (base)``, Store>
 
@@ -4639,17 +3605,6 @@ module dbo =
 
             interface ILeftViewOf<``AWBuildVersion (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``AWBuildVersion (base)`` option =
-                match this.SystemInformationID with
-                | Some value ->
-                    let record: ``AWBuildVersion (base)`` =
-                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let AWBuildVersion = leftTable<``AWBuildVersion (base)``, AWBuildVersion>
 
         type private ``DatabaseLog (base)`` = DatabaseLog
@@ -4672,23 +3627,6 @@ module dbo =
               TSQL: Option<string> }
 
             interface ILeftViewOf<``DatabaseLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``DatabaseLog (base)`` option =
-                match this.DatabaseLogID with
-                | Some value ->
-                    let record: ``DatabaseLog (base)`` =
-                        { DatabaseLogID = value
-                          PostTime = this.PostTime.Value
-                          DatabaseUser = this.DatabaseUser.Value
-                          Event = this.Event.Value
-                          Schema = this.Schema
-                          Object = this.Object
-                          TSQL = this.TSQL.Value }
-
-                    Some record
-                | None -> None
 
         let DatabaseLog = leftTable<``DatabaseLog (base)``, DatabaseLog>
 
@@ -4716,25 +3654,6 @@ module dbo =
               ErrorMessage: Option<string> }
 
             interface ILeftViewOf<``ErrorLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ErrorLog (base)`` option =
-                match this.ErrorLogID with
-                | Some value ->
-                    let record: ``ErrorLog (base)`` =
-                        { ErrorLogID = value
-                          ErrorTime = this.ErrorTime.Value
-                          UserName = this.UserName.Value
-                          ErrorNumber = this.ErrorNumber.Value
-                          ErrorSeverity = this.ErrorSeverity
-                          ErrorState = this.ErrorState
-                          ErrorProcedure = this.ErrorProcedure
-                          ErrorLine = this.ErrorLine
-                          ErrorMessage = this.ErrorMessage.Value }
-
-                    Some record
-                | None -> None
 
         let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
 
@@ -4819,17 +3738,6 @@ module ext =
 
             interface ILeftViewOf<``DateTime2Support (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``DateTime2Support (base)`` option =
-                match this.ID with
-                | Some value ->
-                    let record: ``DateTime2Support (base)`` =
-                        { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
-
-                    Some record
-                | None -> None
-
         let DateTime2Support = leftTable<``DateTime2Support (base)``, DateTime2Support>
 
         type private ``GetIdGuidRepro (base)`` = GetIdGuidRepro
@@ -4843,17 +3751,6 @@ module ext =
 
             interface ILeftViewOf<``GetIdGuidRepro (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``GetIdGuidRepro (base)`` option =
-                match this.Id with
-                | Some value ->
-                    let record: ``GetIdGuidRepro (base)`` =
-                        { Id = value; EmailAddress = this.EmailAddress.Value }
-
-                    Some record
-                | None -> None
-
         let GetIdGuidRepro = leftTable<``GetIdGuidRepro (base)``, GetIdGuidRepro>
 
         type private ``HierarchyIdSupport (base)`` = HierarchyIdSupport
@@ -4866,17 +3763,6 @@ module ext =
               Hierarchy: Option<Microsoft.SqlServer.Types.SqlHierarchyId> }
 
             interface ILeftViewOf<``HierarchyIdSupport (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``HierarchyIdSupport (base)`` option =
-                match this.Id with
-                | Some value ->
-                    let record: ``HierarchyIdSupport (base)`` =
-                        { Id = value; Hierarchy = this.Hierarchy.Value }
-
-                    Some record
-                | None -> None
 
         let HierarchyIdSupport =
             leftTable<``HierarchyIdSupport (base)``, HierarchyIdSupport>
@@ -4894,18 +3780,1206 @@ module ext =
 
             interface ILeftViewOf<``NullableKeyUpsert (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``NullableKeyUpsert (base)`` option =
-                match this.Key1 with
-                | Some value ->
-                    let record: ``NullableKeyUpsert (base)`` =
-                        { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
-
-                    Some record
-                | None -> None
-
         let NullableKeyUpsert = leftTable<``NullableKeyUpsert (base)``, NullableKeyUpsert>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type HumanResources.LeftJoined.Department with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Department option =
+            match this.DepartmentID with
+            | Some value ->
+                let record: HumanResources.Department =
+                    { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.Employee with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Employee option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.Employee =
+                    { BusinessEntityID = value
+                      NationalIDNumber = this.NationalIDNumber.Value
+                      LoginID = this.LoginID.Value
+                      OrganizationNode = this.OrganizationNode
+                      OrganizationLevel = this.OrganizationLevel
+                      JobTitle = this.JobTitle.Value
+                      BirthDate = this.BirthDate.Value
+                      MaritalStatus = this.MaritalStatus.Value
+                      Gender = this.Gender.Value
+                      HireDate = this.HireDate.Value
+                      SalariedFlag = this.SalariedFlag.Value
+                      VacationHours = this.VacationHours.Value
+                      SickLeaveHours = this.SickLeaveHours.Value
+                      CurrentFlag = this.CurrentFlag.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.EmployeeDepartmentHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.EmployeeDepartmentHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.EmployeeDepartmentHistory =
+                    { BusinessEntityID = value
+                      DepartmentID = this.DepartmentID.Value
+                      ShiftID = this.ShiftID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.EmployeePayHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.EmployeePayHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.EmployeePayHistory =
+                    { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.JobCandidate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.JobCandidate option =
+            match this.JobCandidateID with
+            | Some value ->
+                let record: HumanResources.JobCandidate =
+                    { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.Shift with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Shift option =
+            match this.ShiftID with
+            | Some value ->
+                let record: HumanResources.Shift =
+                    { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Address option =
+            match this.AddressID with
+            | Some value ->
+                let record: Person.Address =
+                    { AddressID = value
+                      AddressLine1 = this.AddressLine1.Value
+                      AddressLine2 = this.AddressLine2
+                      City = this.City.Value
+                      StateProvinceID = this.StateProvinceID.Value
+                      PostalCode = this.PostalCode.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.AddressType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.AddressType option =
+            match this.AddressTypeID with
+            | Some value ->
+                let record: Person.AddressType =
+                    { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntity with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntity option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntity =
+                    { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntityAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntityAddress option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntityAddress =
+                    { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntityContact with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntityContact option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntityContact =
+                    { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.ContactType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.ContactType option =
+            match this.ContactTypeID with
+            | Some value ->
+                let record: Person.ContactType =
+                    { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.CountryRegion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.CountryRegion option =
+            match this.CountryRegionCode with
+            | Some value ->
+                let record: Person.CountryRegion =
+                    { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.EmailAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.EmailAddress option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.EmailAddress =
+                    { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Password with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Password option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.Password =
+                    { BusinessEntityID = value; PasswordHash = this.PasswordHash.Value; PasswordSalt = this.PasswordSalt.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Person option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.Person =
+                    { BusinessEntityID = value
+                      PersonType = this.PersonType.Value
+                      NameStyle = this.NameStyle.Value
+                      Title = this.Title
+                      FirstName = this.FirstName.Value
+                      MiddleName = this.MiddleName
+                      LastName = this.LastName.Value
+                      Suffix = this.Suffix
+                      EmailPromotion = this.EmailPromotion.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.PersonPhone with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.PersonPhone option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.PersonPhone =
+                    { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.PhoneNumberType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.PhoneNumberType option =
+            match this.PhoneNumberTypeID with
+            | Some value ->
+                let record: Person.PhoneNumberType =
+                    { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.StateProvince with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.StateProvince option =
+            match this.StateProvinceID with
+            | Some value ->
+                let record: Person.StateProvince =
+                    { StateProvinceID = value
+                      StateProvinceCode = this.StateProvinceCode.Value
+                      CountryRegionCode = this.CountryRegionCode.Value
+                      IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
+                      Name = this.Name.Value
+                      TerritoryID = this.TerritoryID.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.BillOfMaterials with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.BillOfMaterials option =
+            match this.BillOfMaterialsID with
+            | Some value ->
+                let record: Production.BillOfMaterials =
+                    { BillOfMaterialsID = value
+                      ProductAssemblyID = this.ProductAssemblyID
+                      ComponentID = this.ComponentID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      UnitMeasureCode = this.UnitMeasureCode.Value
+                      BOMLevel = this.BOMLevel.Value
+                      PerAssemblyQty = this.PerAssemblyQty.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Culture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Culture option =
+            match this.CultureID with
+            | Some value ->
+                let record: Production.Culture =
+                    { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Document with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Document option =
+            match this.DocumentNode with
+            | Some value ->
+                let record: Production.Document =
+                    { DocumentNode = value
+                      DocumentLevel = this.DocumentLevel
+                      Title = this.Title.Value
+                      Owner = this.Owner.Value
+                      FolderFlag = this.FolderFlag.Value
+                      FileName = this.FileName.Value
+                      FileExtension = this.FileExtension.Value
+                      Revision = this.Revision.Value
+                      ChangeNumber = this.ChangeNumber.Value
+                      Status = this.Status.Value
+                      DocumentSummary = this.DocumentSummary
+                      Document = this.Document
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Illustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Illustration option =
+            match this.IllustrationID with
+            | Some value ->
+                let record: Production.Illustration =
+                    { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Location with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Location option =
+            match this.LocationID with
+            | Some value ->
+                let record: Production.Location =
+                    { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Product option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.Product =
+                    { ProductID = value
+                      Name = this.Name.Value
+                      ProductNumber = this.ProductNumber.Value
+                      MakeFlag = this.MakeFlag.Value
+                      FinishedGoodsFlag = this.FinishedGoodsFlag.Value
+                      Color = this.Color
+                      SafetyStockLevel = this.SafetyStockLevel.Value
+                      ReorderPoint = this.ReorderPoint.Value
+                      StandardCost = this.StandardCost.Value
+                      ListPrice = this.ListPrice.Value
+                      Size = this.Size
+                      SizeUnitMeasureCode = this.SizeUnitMeasureCode
+                      WeightUnitMeasureCode = this.WeightUnitMeasureCode
+                      Weight = this.Weight
+                      DaysToManufacture = this.DaysToManufacture.Value
+                      ProductLine = this.ProductLine
+                      Class = this.Class
+                      Style = this.Style
+                      ProductSubcategoryID = this.ProductSubcategoryID
+                      ProductModelID = this.ProductModelID
+                      SellStartDate = this.SellStartDate.Value
+                      SellEndDate = this.SellEndDate
+                      DiscontinuedDate = this.DiscontinuedDate
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductCategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductCategory option =
+            match this.ProductCategoryID with
+            | Some value ->
+                let record: Production.ProductCategory =
+                    { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductCostHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductCostHistory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductCostHistory =
+                    { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductDescription option =
+            match this.ProductDescriptionID with
+            | Some value ->
+                let record: Production.ProductDescription =
+                    { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductDocument with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductDocument option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductDocument =
+                    { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductInventory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductInventory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductInventory =
+                    { ProductID = value
+                      LocationID = this.LocationID.Value
+                      Shelf = this.Shelf.Value
+                      Bin = this.Bin.Value
+                      Quantity = this.Quantity.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductListPriceHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductListPriceHistory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductListPriceHistory =
+                    { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModel option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModel =
+                    { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModelIllustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModelIllustration option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModelIllustration =
+                    { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModelProductDescriptionCulture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModelProductDescriptionCulture option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModelProductDescriptionCulture =
+                    { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductPhoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductPhoto option =
+            match this.ProductPhotoID with
+            | Some value ->
+                let record: Production.ProductPhoto =
+                    { ProductPhotoID = value
+                      ThumbNailPhoto = this.ThumbNailPhoto
+                      ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                      LargePhoto = this.LargePhoto
+                      LargePhotoFileName = this.LargePhotoFileName
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductProductPhoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductProductPhoto option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductProductPhoto =
+                    { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductReview with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductReview option =
+            match this.ProductReviewID with
+            | Some value ->
+                let record: Production.ProductReview =
+                    { ProductReviewID = value
+                      ProductID = this.ProductID.Value
+                      ReviewerName = this.ReviewerName.Value
+                      ReviewDate = this.ReviewDate.Value
+                      EmailAddress = this.EmailAddress.Value
+                      Rating = this.Rating.Value
+                      Comments = this.Comments
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductSubcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductSubcategory option =
+            match this.ProductSubcategoryID with
+            | Some value ->
+                let record: Production.ProductSubcategory =
+                    { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ScrapReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ScrapReason option =
+            match this.ScrapReasonID with
+            | Some value ->
+                let record: Production.ScrapReason =
+                    { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.TransactionHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.TransactionHistory option =
+            match this.TransactionID with
+            | Some value ->
+                let record: Production.TransactionHistory =
+                    { TransactionID = value
+                      ProductID = this.ProductID.Value
+                      ReferenceOrderID = this.ReferenceOrderID.Value
+                      ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                      TransactionDate = this.TransactionDate.Value
+                      TransactionType = this.TransactionType.Value
+                      Quantity = this.Quantity.Value
+                      ActualCost = this.ActualCost.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.TransactionHistoryArchive with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.TransactionHistoryArchive option =
+            match this.TransactionID with
+            | Some value ->
+                let record: Production.TransactionHistoryArchive =
+                    { TransactionID = value
+                      ProductID = this.ProductID.Value
+                      ReferenceOrderID = this.ReferenceOrderID.Value
+                      ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                      TransactionDate = this.TransactionDate.Value
+                      TransactionType = this.TransactionType.Value
+                      Quantity = this.Quantity.Value
+                      ActualCost = this.ActualCost.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.UnitMeasure with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.UnitMeasure option =
+            match this.UnitMeasureCode with
+            | Some value ->
+                let record: Production.UnitMeasure =
+                    { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.WorkOrder with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.WorkOrder option =
+            match this.WorkOrderID with
+            | Some value ->
+                let record: Production.WorkOrder =
+                    { WorkOrderID = value
+                      ProductID = this.ProductID.Value
+                      OrderQty = this.OrderQty.Value
+                      StockedQty = this.StockedQty.Value
+                      ScrappedQty = this.ScrappedQty.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      DueDate = this.DueDate.Value
+                      ScrapReasonID = this.ScrapReasonID
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.WorkOrderRouting with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.WorkOrderRouting option =
+            match this.WorkOrderID with
+            | Some value ->
+                let record: Production.WorkOrderRouting =
+                    { WorkOrderID = value
+                      ProductID = this.ProductID.Value
+                      OperationSequence = this.OperationSequence.Value
+                      LocationID = this.LocationID.Value
+                      ScheduledStartDate = this.ScheduledStartDate.Value
+                      ScheduledEndDate = this.ScheduledEndDate.Value
+                      ActualStartDate = this.ActualStartDate
+                      ActualEndDate = this.ActualEndDate
+                      ActualResourceHrs = this.ActualResourceHrs
+                      PlannedCost = this.PlannedCost.Value
+                      ActualCost = this.ActualCost
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.ProductVendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.ProductVendor option =
+            match this.ProductID with
+            | Some value ->
+                let record: Purchasing.ProductVendor =
+                    { ProductID = value
+                      BusinessEntityID = this.BusinessEntityID.Value
+                      AverageLeadTime = this.AverageLeadTime.Value
+                      StandardPrice = this.StandardPrice.Value
+                      LastReceiptCost = this.LastReceiptCost
+                      LastReceiptDate = this.LastReceiptDate
+                      MinOrderQty = this.MinOrderQty.Value
+                      MaxOrderQty = this.MaxOrderQty.Value
+                      OnOrderQty = this.OnOrderQty
+                      UnitMeasureCode = this.UnitMeasureCode.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.PurchaseOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.PurchaseOrderDetail option =
+            match this.PurchaseOrderID with
+            | Some value ->
+                let record: Purchasing.PurchaseOrderDetail =
+                    { PurchaseOrderID = value
+                      PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
+                      DueDate = this.DueDate.Value
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      LineTotal = this.LineTotal.Value
+                      ReceivedQty = this.ReceivedQty.Value
+                      RejectedQty = this.RejectedQty.Value
+                      StockedQty = this.StockedQty.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.PurchaseOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.PurchaseOrderHeader option =
+            match this.PurchaseOrderID with
+            | Some value ->
+                let record: Purchasing.PurchaseOrderHeader =
+                    { PurchaseOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      Status = this.Status.Value
+                      EmployeeID = this.EmployeeID.Value
+                      VendorID = this.VendorID.Value
+                      ShipMethodID = this.ShipMethodID.Value
+                      OrderDate = this.OrderDate.Value
+                      ShipDate = this.ShipDate
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.ShipMethod with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.ShipMethod option =
+            match this.ShipMethodID with
+            | Some value ->
+                let record: Purchasing.ShipMethod =
+                    { ShipMethodID = value
+                      Name = this.Name.Value
+                      ShipBase = this.ShipBase.Value
+                      ShipRate = this.ShipRate.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.Vendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.Vendor option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Purchasing.Vendor =
+                    { BusinessEntityID = value
+                      AccountNumber = this.AccountNumber.Value
+                      Name = this.Name.Value
+                      CreditRating = this.CreditRating.Value
+                      PreferredVendorStatus = this.PreferredVendorStatus.Value
+                      ActiveFlag = this.ActiveFlag.Value
+                      PurchasingWebServiceURL = this.PurchasingWebServiceURL
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CountryRegionCurrency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CountryRegionCurrency option =
+            match this.CountryRegionCode with
+            | Some value ->
+                let record: Sales.CountryRegionCurrency =
+                    { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CreditCard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CreditCard option =
+            match this.CreditCardID with
+            | Some value ->
+                let record: Sales.CreditCard =
+                    { CreditCardID = value
+                      CardType = this.CardType.Value
+                      CardNumber = this.CardNumber.Value
+                      ExpMonth = this.ExpMonth.Value
+                      ExpYear = this.ExpYear.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Currency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Currency option =
+            match this.CurrencyCode with
+            | Some value ->
+                let record: Sales.Currency =
+                    { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CurrencyRate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CurrencyRate option =
+            match this.CurrencyRateID with
+            | Some value ->
+                let record: Sales.CurrencyRate =
+                    { CurrencyRateID = value
+                      CurrencyRateDate = this.CurrencyRateDate.Value
+                      FromCurrencyCode = this.FromCurrencyCode.Value
+                      ToCurrencyCode = this.ToCurrencyCode.Value
+                      AverageRate = this.AverageRate.Value
+                      EndOfDayRate = this.EndOfDayRate.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Customer option =
+            match this.CustomerID with
+            | Some value ->
+                let record: Sales.Customer =
+                    { CustomerID = value
+                      PersonID = this.PersonID
+                      StoreID = this.StoreID
+                      TerritoryID = this.TerritoryID
+                      AccountNumber = this.AccountNumber.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.PersonCreditCard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.PersonCreditCard option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.PersonCreditCard =
+                    { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderDetail option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderDetail =
+                    { SalesOrderID = value
+                      SalesOrderDetailID = this.SalesOrderDetailID.Value
+                      CarrierTrackingNumber = this.CarrierTrackingNumber
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      SpecialOfferID = this.SpecialOfferID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      UnitPriceDiscount = this.UnitPriceDiscount.Value
+                      LineTotal = this.LineTotal.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderHeader option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderHeader =
+                    { SalesOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      OrderDate = this.OrderDate.Value
+                      DueDate = this.DueDate.Value
+                      ShipDate = this.ShipDate
+                      Status = this.Status.Value
+                      OnlineOrderFlag = this.OnlineOrderFlag.Value
+                      SalesOrderNumber = this.SalesOrderNumber.Value
+                      PurchaseOrderNumber = this.PurchaseOrderNumber
+                      AccountNumber = this.AccountNumber
+                      CustomerID = this.CustomerID.Value
+                      SalesPersonID = this.SalesPersonID
+                      TerritoryID = this.TerritoryID
+                      BillToAddressID = this.BillToAddressID.Value
+                      ShipToAddressID = this.ShipToAddressID.Value
+                      ShipMethodID = this.ShipMethodID.Value
+                      CreditCardID = this.CreditCardID
+                      CreditCardApprovalCode = this.CreditCardApprovalCode
+                      CurrencyRateID = this.CurrencyRateID
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      Comment = this.Comment
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderHeaderSalesReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderHeaderSalesReason option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderHeaderSalesReason =
+                    { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesPerson with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesPerson option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesPerson =
+                    { BusinessEntityID = value
+                      TerritoryID = this.TerritoryID
+                      SalesQuota = this.SalesQuota
+                      Bonus = this.Bonus.Value
+                      CommissionPct = this.CommissionPct.Value
+                      SalesYTD = this.SalesYTD.Value
+                      SalesLastYear = this.SalesLastYear.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesPersonQuotaHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesPersonQuotaHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesPersonQuotaHistory =
+                    { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesReason option =
+            match this.SalesReasonID with
+            | Some value ->
+                let record: Sales.SalesReason =
+                    { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTaxRate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTaxRate option =
+            match this.SalesTaxRateID with
+            | Some value ->
+                let record: Sales.SalesTaxRate =
+                    { SalesTaxRateID = value
+                      StateProvinceID = this.StateProvinceID.Value
+                      TaxType = this.TaxType.Value
+                      TaxRate = this.TaxRate.Value
+                      Name = this.Name.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTerritory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTerritory option =
+            match this.TerritoryID with
+            | Some value ->
+                let record: Sales.SalesTerritory =
+                    { TerritoryID = value
+                      Name = this.Name.Value
+                      CountryRegionCode = this.CountryRegionCode.Value
+                      Group = this.Group.Value
+                      SalesYTD = this.SalesYTD.Value
+                      SalesLastYear = this.SalesLastYear.Value
+                      CostYTD = this.CostYTD.Value
+                      CostLastYear = this.CostLastYear.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTerritoryHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTerritoryHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesTerritoryHistory =
+                    { BusinessEntityID = value
+                      TerritoryID = this.TerritoryID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.ShoppingCartItem with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.ShoppingCartItem option =
+            match this.ShoppingCartItemID with
+            | Some value ->
+                let record: Sales.ShoppingCartItem =
+                    { ShoppingCartItemID = value
+                      ShoppingCartID = this.ShoppingCartID.Value
+                      Quantity = this.Quantity.Value
+                      ProductID = this.ProductID.Value
+                      DateCreated = this.DateCreated.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SpecialOffer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SpecialOffer option =
+            match this.SpecialOfferID with
+            | Some value ->
+                let record: Sales.SpecialOffer =
+                    { SpecialOfferID = value
+                      Description = this.Description.Value
+                      DiscountPct = this.DiscountPct.Value
+                      Type = this.Type.Value
+                      Category = this.Category.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate.Value
+                      MinQty = this.MinQty.Value
+                      MaxQty = this.MaxQty
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SpecialOfferProduct with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SpecialOfferProduct option =
+            match this.SpecialOfferID with
+            | Some value ->
+                let record: Sales.SpecialOfferProduct =
+                    { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Store with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Store option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.Store =
+                    { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.AWBuildVersion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.AWBuildVersion option =
+            match this.SystemInformationID with
+            | Some value ->
+                let record: dbo.AWBuildVersion =
+                    { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.DatabaseLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.DatabaseLog option =
+            match this.DatabaseLogID with
+            | Some value ->
+                let record: dbo.DatabaseLog =
+                    { DatabaseLogID = value
+                      PostTime = this.PostTime.Value
+                      DatabaseUser = this.DatabaseUser.Value
+                      Event = this.Event.Value
+                      Schema = this.Schema
+                      Object = this.Object
+                      TSQL = this.TSQL.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.ErrorLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.ErrorLog option =
+            match this.ErrorLogID with
+            | Some value ->
+                let record: dbo.ErrorLog =
+                    { ErrorLogID = value
+                      ErrorTime = this.ErrorTime.Value
+                      UserName = this.UserName.Value
+                      ErrorNumber = this.ErrorNumber.Value
+                      ErrorSeverity = this.ErrorSeverity
+                      ErrorState = this.ErrorState
+                      ErrorProcedure = this.ErrorProcedure
+                      ErrorLine = this.ErrorLine
+                      ErrorMessage = this.ErrorMessage.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.DateTime2Support with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.DateTime2Support option =
+            match this.ID with
+            | Some value ->
+                let record: ext.DateTime2Support =
+                    { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.GetIdGuidRepro with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.GetIdGuidRepro option =
+            match this.Id with
+            | Some value ->
+                let record: ext.GetIdGuidRepro =
+                    { Id = value; EmailAddress = this.EmailAddress.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.HierarchyIdSupport with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.HierarchyIdSupport option =
+            match this.Id with
+            | Some value ->
+                let record: ext.HierarchyIdSupport =
+                    { Id = value; Hierarchy = this.Hierarchy.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.NullableKeyUpsert with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.NullableKeyUpsert option =
+            match this.Key1 with
+            | Some value ->
+                let record: ext.NullableKeyUpsert =
+                    { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/SqlServer/AdventureWorksNet8.fs
+++ b/src/Tests/SqlServer/AdventureWorksNet8.fs
@@ -176,6 +176,230 @@ module HumanResources =
 
     let Shift = table<Shift>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Department (base)`` = Department
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Department =
+            { [<ProviderDbType("SmallInt")>]
+              DepartmentID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              GroupName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Department (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Department (base)`` option =
+                match this.DepartmentID with
+                | Some value ->
+                    let record: ``Department (base)`` =
+                        { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Department = leftTable<``Department (base)``, Department>
+
+        type private ``Employee (base)`` = Employee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Employee =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              NationalIDNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              LoginID: Option<string>
+              [<ProviderDbType("SqlHierarchyId")>]
+              OrganizationNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("SmallInt")>]
+              OrganizationLevel: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              JobTitle: Option<string>
+              [<ProviderDbType("Date")>]
+              BirthDate: Option<System.DateOnly>
+              [<ProviderDbType("NChar")>]
+              MaritalStatus: Option<string>
+              [<ProviderDbType("NChar")>]
+              Gender: Option<string>
+              [<ProviderDbType("Date")>]
+              HireDate: Option<System.DateOnly>
+              [<ProviderDbType("Bit")>]
+              SalariedFlag: Option<bool>
+              [<ProviderDbType("SmallInt")>]
+              VacationHours: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              SickLeaveHours: Option<int16>
+              [<ProviderDbType("Bit")>]
+              CurrentFlag: Option<bool>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Employee (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Employee (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Employee (base)`` =
+                        { BusinessEntityID = value
+                          NationalIDNumber = this.NationalIDNumber.Value
+                          LoginID = this.LoginID.Value
+                          OrganizationNode = this.OrganizationNode
+                          OrganizationLevel = this.OrganizationLevel
+                          JobTitle = this.JobTitle.Value
+                          BirthDate = this.BirthDate.Value
+                          MaritalStatus = this.MaritalStatus.Value
+                          Gender = this.Gender.Value
+                          HireDate = this.HireDate.Value
+                          SalariedFlag = this.SalariedFlag.Value
+                          VacationHours = this.VacationHours.Value
+                          SickLeaveHours = this.SickLeaveHours.Value
+                          CurrentFlag = this.CurrentFlag.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Employee = leftTable<``Employee (base)``, Employee>
+
+        type private ``EmployeeDepartmentHistory (base)`` = EmployeeDepartmentHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmployeeDepartmentHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              DepartmentID: Option<int16>
+              [<ProviderDbType("TinyInt")>]
+              ShiftID: Option<byte>
+              [<ProviderDbType("Date")>]
+              StartDate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              EndDate: Option<System.DateOnly>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmployeeDepartmentHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmployeeDepartmentHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmployeeDepartmentHistory (base)`` =
+                        { BusinessEntityID = value
+                          DepartmentID = this.DepartmentID.Value
+                          ShiftID = this.ShiftID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmployeeDepartmentHistory =
+            leftTable<``EmployeeDepartmentHistory (base)``, EmployeeDepartmentHistory>
+
+        type private ``EmployeePayHistory (base)`` = EmployeePayHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmployeePayHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              RateChangeDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              Rate: Option<decimal>
+              [<ProviderDbType("TinyInt")>]
+              PayFrequency: Option<byte>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmployeePayHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmployeePayHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmployeePayHistory (base)`` =
+                        { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmployeePayHistory =
+            leftTable<``EmployeePayHistory (base)``, EmployeePayHistory>
+
+        type private ``JobCandidate (base)`` = JobCandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type JobCandidate =
+            { [<ProviderDbType("Int")>]
+              JobCandidateID: Option<int>
+              [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``JobCandidate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``JobCandidate (base)`` option =
+                match this.JobCandidateID with
+                | Some value ->
+                    let record: ``JobCandidate (base)`` =
+                        { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let JobCandidate = leftTable<``JobCandidate (base)``, JobCandidate>
+
+        type private ``Shift (base)`` = Shift
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Shift =
+            { [<ProviderDbType("TinyInt")>]
+              ShiftID: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Time")>]
+              StartTime: Option<System.TimeOnly>
+              [<ProviderDbType("Time")>]
+              EndTime: Option<System.TimeOnly>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Shift (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Shift (base)`` option =
+                match this.ShiftID with
+                | Some value ->
+                    let record: ``Shift (base)`` =
+                        { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Shift = leftTable<``Shift (base)``, Shift>
+
+
 module Person =
 
     [<CLIMutable>]
@@ -482,6 +706,434 @@ module Person =
                   { WriteColumn.Name = "ModifiedDate"; Value = box this.ModifiedDate; ProviderDbType = Some "DateTime" } ]
 
     let StateProvince = table<StateProvince>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Address (base)`` = Address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Address =
+            { [<ProviderDbType("Int")>]
+              AddressID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              AddressLine1: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              AddressLine2: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              City: Option<string>
+              [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              PostalCode: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Address (base)`` option =
+                match this.AddressID with
+                | Some value ->
+                    let record: ``Address (base)`` =
+                        { AddressID = value
+                          AddressLine1 = this.AddressLine1.Value
+                          AddressLine2 = this.AddressLine2
+                          City = this.City.Value
+                          StateProvinceID = this.StateProvinceID.Value
+                          PostalCode = this.PostalCode.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Address = leftTable<``Address (base)``, Address>
+
+        type private ``AddressType (base)`` = AddressType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type AddressType =
+            { [<ProviderDbType("Int")>]
+              AddressTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``AddressType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``AddressType (base)`` option =
+                match this.AddressTypeID with
+                | Some value ->
+                    let record: ``AddressType (base)`` =
+                        { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let AddressType = leftTable<``AddressType (base)``, AddressType>
+
+        type private ``BusinessEntity (base)`` = BusinessEntity
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntity =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntity (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntity (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntity (base)`` =
+                        { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntity = leftTable<``BusinessEntity (base)``, BusinessEntity>
+
+        type private ``BusinessEntityAddress (base)`` = BusinessEntityAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntityAddress =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              AddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              AddressTypeID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntityAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntityAddress (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntityAddress (base)`` =
+                        { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntityAddress =
+            leftTable<``BusinessEntityAddress (base)``, BusinessEntityAddress>
+
+        type private ``BusinessEntityContact (base)`` = BusinessEntityContact
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntityContact =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              PersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              ContactTypeID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntityContact (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntityContact (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntityContact (base)`` =
+                        { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntityContact =
+            leftTable<``BusinessEntityContact (base)``, BusinessEntityContact>
+
+        type private ``ContactType (base)`` = ContactType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ContactType =
+            { [<ProviderDbType("Int")>]
+              ContactTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ContactType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ContactType (base)`` option =
+                match this.ContactTypeID with
+                | Some value ->
+                    let record: ``ContactType (base)`` =
+                        { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ContactType = leftTable<``ContactType (base)``, ContactType>
+
+        type private ``CountryRegion (base)`` = CountryRegion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CountryRegion =
+            { [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CountryRegion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CountryRegion (base)`` option =
+                match this.CountryRegionCode with
+                | Some value ->
+                    let record: ``CountryRegion (base)`` =
+                        { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CountryRegion = leftTable<``CountryRegion (base)``, CountryRegion>
+
+        type private ``EmailAddress (base)`` = EmailAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmailAddress =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              EmailAddressID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              EmailAddress: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmailAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmailAddress (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmailAddress (base)`` =
+                        { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmailAddress = leftTable<``EmailAddress (base)``, EmailAddress>
+
+        type private ``Password (base)`` = Password
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Password =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              PasswordHash: Option<string>
+              [<ProviderDbType("VarChar")>]
+              PasswordSalt: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Password (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Password (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Password (base)`` =
+                        { BusinessEntityID = value
+                          PasswordHash = this.PasswordHash.Value
+                          PasswordSalt = this.PasswordSalt.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Password = leftTable<``Password (base)``, Password>
+
+        type private ``Person (base)`` = Person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Person =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NChar")>]
+              PersonType: Option<string>
+              [<ProviderDbType("Bit")>]
+              NameStyle: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Title: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              FirstName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              MiddleName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              LastName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Suffix: Option<string>
+              [<ProviderDbType("Int")>]
+              EmailPromotion: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Person (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Person (base)`` =
+                        { BusinessEntityID = value
+                          PersonType = this.PersonType.Value
+                          NameStyle = this.NameStyle.Value
+                          Title = this.Title
+                          FirstName = this.FirstName.Value
+                          MiddleName = this.MiddleName
+                          LastName = this.LastName.Value
+                          Suffix = this.Suffix
+                          EmailPromotion = this.EmailPromotion.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Person = leftTable<``Person (base)``, Person>
+
+        type private ``PersonPhone (base)`` = PersonPhone
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PersonPhone =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              PhoneNumber: Option<string>
+              [<ProviderDbType("Int")>]
+              PhoneNumberTypeID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PersonPhone (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PersonPhone (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``PersonPhone (base)`` =
+                        { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PersonPhone = leftTable<``PersonPhone (base)``, PersonPhone>
+
+        type private ``PhoneNumberType (base)`` = PhoneNumberType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PhoneNumberType =
+            { [<ProviderDbType("Int")>]
+              PhoneNumberTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PhoneNumberType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PhoneNumberType (base)`` option =
+                match this.PhoneNumberTypeID with
+                | Some value ->
+                    let record: ``PhoneNumberType (base)`` =
+                        { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PhoneNumberType = leftTable<``PhoneNumberType (base)``, PhoneNumberType>
+
+        type private ``StateProvince (base)`` = StateProvince
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type StateProvince =
+            { [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("NChar")>]
+              StateProvinceCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("Bit")>]
+              IsOnlyStateProvinceFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``StateProvince (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``StateProvince (base)`` option =
+                match this.StateProvinceID with
+                | Some value ->
+                    let record: ``StateProvince (base)`` =
+                        { StateProvinceID = value
+                          StateProvinceCode = this.StateProvinceCode.Value
+                          CountryRegionCode = this.CountryRegionCode.Value
+                          IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
+                          Name = this.Name.Value
+                          TerritoryID = this.TerritoryID.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let StateProvince = leftTable<``StateProvince (base)``, StateProvince>
+
 
 module Production =
 
@@ -1184,6 +1836,950 @@ module Production =
 
     let WorkOrderRouting = table<WorkOrderRouting>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``BillOfMaterials (base)`` = BillOfMaterials
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BillOfMaterials =
+            { [<ProviderDbType("Int")>]
+              BillOfMaterialsID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductAssemblyID: Option<int>
+              [<ProviderDbType("Int")>]
+              ComponentID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              BOMLevel: Option<int16>
+              [<ProviderDbType("Decimal")>]
+              PerAssemblyQty: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BillOfMaterials (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BillOfMaterials (base)`` option =
+                match this.BillOfMaterialsID with
+                | Some value ->
+                    let record: ``BillOfMaterials (base)`` =
+                        { BillOfMaterialsID = value
+                          ProductAssemblyID = this.ProductAssemblyID
+                          ComponentID = this.ComponentID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          UnitMeasureCode = this.UnitMeasureCode.Value
+                          BOMLevel = this.BOMLevel.Value
+                          PerAssemblyQty = this.PerAssemblyQty.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BillOfMaterials = leftTable<``BillOfMaterials (base)``, BillOfMaterials>
+
+        type private ``Culture (base)`` = Culture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Culture =
+            { [<ProviderDbType("NChar")>]
+              CultureID: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Culture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Culture (base)`` option =
+                match this.CultureID with
+                | Some value ->
+                    let record: ``Culture (base)`` =
+                        { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Culture = leftTable<``Culture (base)``, Culture>
+
+        type private ``Document (base)`` = Document
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Document =
+            { [<ProviderDbType("SqlHierarchyId")>]
+              DocumentNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("SmallInt")>]
+              DocumentLevel: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Title: Option<string>
+              [<ProviderDbType("Int")>]
+              Owner: Option<int>
+              [<ProviderDbType("Bit")>]
+              FolderFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              FileName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              FileExtension: Option<string>
+              [<ProviderDbType("NChar")>]
+              Revision: Option<string>
+              [<ProviderDbType("Int")>]
+              ChangeNumber: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              DocumentSummary: Option<string>
+              [<ProviderDbType("VarBinary")>]
+              Document: Option<byte[]>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Document (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Document (base)`` option =
+                match this.DocumentNode with
+                | Some value ->
+                    let record: ``Document (base)`` =
+                        { DocumentNode = value
+                          DocumentLevel = this.DocumentLevel
+                          Title = this.Title.Value
+                          Owner = this.Owner.Value
+                          FolderFlag = this.FolderFlag.Value
+                          FileName = this.FileName.Value
+                          FileExtension = this.FileExtension.Value
+                          Revision = this.Revision.Value
+                          ChangeNumber = this.ChangeNumber.Value
+                          Status = this.Status.Value
+                          DocumentSummary = this.DocumentSummary
+                          Document = this.Document
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Document = leftTable<``Document (base)``, Document>
+
+        type private ``Illustration (base)`` = Illustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Illustration =
+            { [<ProviderDbType("Int")>]
+              IllustrationID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Illustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Illustration (base)`` option =
+                match this.IllustrationID with
+                | Some value ->
+                    let record: ``Illustration (base)`` =
+                        { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Illustration = leftTable<``Illustration (base)``, Illustration>
+
+        type private ``Location (base)`` = Location
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Location =
+            { [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("SmallMoney")>]
+              CostRate: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              Availability: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Location (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Location (base)`` option =
+                match this.LocationID with
+                | Some value ->
+                    let record: ``Location (base)`` =
+                        { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Location = leftTable<``Location (base)``, Location>
+
+        type private ``Product (base)`` = Product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Product =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              ProductNumber: Option<string>
+              [<ProviderDbType("Bit")>]
+              MakeFlag: Option<bool>
+              [<ProviderDbType("Bit")>]
+              FinishedGoodsFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Color: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              SafetyStockLevel: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              ReorderPoint: Option<int16>
+              [<ProviderDbType("Money")>]
+              StandardCost: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ListPrice: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Size: Option<string>
+              [<ProviderDbType("NChar")>]
+              SizeUnitMeasureCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              WeightUnitMeasureCode: Option<string>
+              [<ProviderDbType("Decimal")>]
+              Weight: Option<decimal>
+              [<ProviderDbType("Int")>]
+              DaysToManufacture: Option<int>
+              [<ProviderDbType("NChar")>]
+              ProductLine: Option<string>
+              [<ProviderDbType("NChar")>]
+              Class: Option<string>
+              [<ProviderDbType("NChar")>]
+              Style: Option<string>
+              [<ProviderDbType("Int")>]
+              ProductSubcategoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              SellStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              SellEndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DiscontinuedDate: Option<System.DateTime>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Product (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``Product (base)`` =
+                        { ProductID = value
+                          Name = this.Name.Value
+                          ProductNumber = this.ProductNumber.Value
+                          MakeFlag = this.MakeFlag.Value
+                          FinishedGoodsFlag = this.FinishedGoodsFlag.Value
+                          Color = this.Color
+                          SafetyStockLevel = this.SafetyStockLevel.Value
+                          ReorderPoint = this.ReorderPoint.Value
+                          StandardCost = this.StandardCost.Value
+                          ListPrice = this.ListPrice.Value
+                          Size = this.Size
+                          SizeUnitMeasureCode = this.SizeUnitMeasureCode
+                          WeightUnitMeasureCode = this.WeightUnitMeasureCode
+                          Weight = this.Weight
+                          DaysToManufacture = this.DaysToManufacture.Value
+                          ProductLine = this.ProductLine
+                          Class = this.Class
+                          Style = this.Style
+                          ProductSubcategoryID = this.ProductSubcategoryID
+                          ProductModelID = this.ProductModelID
+                          SellStartDate = this.SellStartDate.Value
+                          SellEndDate = this.SellEndDate
+                          DiscontinuedDate = this.DiscontinuedDate
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Product = leftTable<``Product (base)``, Product>
+
+        type private ``ProductCategory (base)`` = ProductCategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCategory =
+            { [<ProviderDbType("Int")>]
+              ProductCategoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCategory (base)`` option =
+                match this.ProductCategoryID with
+                | Some value ->
+                    let record: ``ProductCategory (base)`` =
+                        { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
+
+        type private ``ProductCostHistory (base)`` = ProductCostHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCostHistory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              StandardCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCostHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCostHistory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductCostHistory (base)`` =
+                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCostHistory =
+            leftTable<``ProductCostHistory (base)``, ProductCostHistory>
+
+        type private ``ProductDescription (base)`` = ProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDescription =
+            { [<ProviderDbType("Int")>]
+              ProductDescriptionID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Description: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDescription (base)`` option =
+                match this.ProductDescriptionID with
+                | Some value ->
+                    let record: ``ProductDescription (base)`` =
+                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDescription =
+            leftTable<``ProductDescription (base)``, ProductDescription>
+
+        type private ``ProductDocument (base)`` = ProductDocument
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDocument =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SqlHierarchyId")>]
+              DocumentNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDocument (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDocument (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductDocument (base)`` =
+                        { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDocument = leftTable<``ProductDocument (base)``, ProductDocument>
+
+        type private ``ProductInventory (base)`` = ProductInventory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductInventory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Shelf: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              Bin: Option<byte>
+              [<ProviderDbType("SmallInt")>]
+              Quantity: Option<int16>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductInventory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductInventory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductInventory (base)`` =
+                        { ProductID = value
+                          LocationID = this.LocationID.Value
+                          Shelf = this.Shelf.Value
+                          Bin = this.Bin.Value
+                          Quantity = this.Quantity.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductInventory = leftTable<``ProductInventory (base)``, ProductInventory>
+
+        type private ``ProductListPriceHistory (base)`` = ProductListPriceHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductListPriceHistory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              ListPrice: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductListPriceHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductListPriceHistory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductListPriceHistory (base)`` =
+                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductListPriceHistory =
+            leftTable<``ProductListPriceHistory (base)``, ProductListPriceHistory>
+
+        type private ``ProductModel (base)`` = ProductModel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModel =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModel (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModel (base)`` =
+                        { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
+
+        type private ``ProductModelIllustration (base)`` = ProductModelIllustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelIllustration =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("Int")>]
+              IllustrationID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelIllustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelIllustration (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelIllustration (base)`` =
+                        { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelIllustration =
+            leftTable<``ProductModelIllustration (base)``, ProductModelIllustration>
+
+        type private ``ProductModelProductDescriptionCulture (base)`` = ProductModelProductDescriptionCulture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelProductDescriptionCulture =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductDescriptionID: Option<int>
+              [<ProviderDbType("NChar")>]
+              CultureID: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelProductDescriptionCulture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelProductDescriptionCulture (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelProductDescriptionCulture (base)`` =
+                        { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelProductDescriptionCulture =
+            leftTable<``ProductModelProductDescriptionCulture (base)``, ProductModelProductDescriptionCulture>
+
+        type private ``ProductPhoto (base)`` = ProductPhoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductPhoto =
+            { [<ProviderDbType("Int")>]
+              ProductPhotoID: Option<int>
+              [<ProviderDbType("VarBinary")>]
+              ThumbNailPhoto: Option<byte[]>
+              [<ProviderDbType("NVarChar")>]
+              ThumbnailPhotoFileName: Option<string>
+              [<ProviderDbType("VarBinary")>]
+              LargePhoto: Option<byte[]>
+              [<ProviderDbType("NVarChar")>]
+              LargePhotoFileName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductPhoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductPhoto (base)`` option =
+                match this.ProductPhotoID with
+                | Some value ->
+                    let record: ``ProductPhoto (base)`` =
+                        { ProductPhotoID = value
+                          ThumbNailPhoto = this.ThumbNailPhoto
+                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                          LargePhoto = this.LargePhoto
+                          LargePhotoFileName = this.LargePhotoFileName
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductPhoto = leftTable<``ProductPhoto (base)``, ProductPhoto>
+
+        type private ``ProductProductPhoto (base)`` = ProductProductPhoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductProductPhoto =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductPhotoID: Option<int>
+              [<ProviderDbType("Bit")>]
+              Primary: Option<bool>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductProductPhoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductProductPhoto (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductProductPhoto (base)`` =
+                        { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductProductPhoto =
+            leftTable<``ProductProductPhoto (base)``, ProductProductPhoto>
+
+        type private ``ProductReview (base)`` = ProductReview
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductReview =
+            { [<ProviderDbType("Int")>]
+              ProductReviewID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ReviewerName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ReviewDate: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              EmailAddress: Option<string>
+              [<ProviderDbType("Int")>]
+              Rating: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Comments: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductReview (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductReview (base)`` option =
+                match this.ProductReviewID with
+                | Some value ->
+                    let record: ``ProductReview (base)`` =
+                        { ProductReviewID = value
+                          ProductID = this.ProductID.Value
+                          ReviewerName = this.ReviewerName.Value
+                          ReviewDate = this.ReviewDate.Value
+                          EmailAddress = this.EmailAddress.Value
+                          Rating = this.Rating.Value
+                          Comments = this.Comments
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductReview = leftTable<``ProductReview (base)``, ProductReview>
+
+        type private ``ProductSubcategory (base)`` = ProductSubcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductSubcategory =
+            { [<ProviderDbType("Int")>]
+              ProductSubcategoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductCategoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductSubcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductSubcategory (base)`` option =
+                match this.ProductSubcategoryID with
+                | Some value ->
+                    let record: ``ProductSubcategory (base)`` =
+                        { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductSubcategory =
+            leftTable<``ProductSubcategory (base)``, ProductSubcategory>
+
+        type private ``ScrapReason (base)`` = ScrapReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ScrapReason =
+            { [<ProviderDbType("SmallInt")>]
+              ScrapReasonID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ScrapReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ScrapReason (base)`` option =
+                match this.ScrapReasonID with
+                | Some value ->
+                    let record: ``ScrapReason (base)`` =
+                        { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ScrapReason = leftTable<``ScrapReason (base)``, ScrapReason>
+
+        type private ``TransactionHistory (base)`` = TransactionHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type TransactionHistory =
+            { [<ProviderDbType("Int")>]
+              TransactionID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderLineID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              TransactionDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              TransactionType: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``TransactionHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``TransactionHistory (base)`` option =
+                match this.TransactionID with
+                | Some value ->
+                    let record: ``TransactionHistory (base)`` =
+                        { TransactionID = value
+                          ProductID = this.ProductID.Value
+                          ReferenceOrderID = this.ReferenceOrderID.Value
+                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                          TransactionDate = this.TransactionDate.Value
+                          TransactionType = this.TransactionType.Value
+                          Quantity = this.Quantity.Value
+                          ActualCost = this.ActualCost.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let TransactionHistory =
+            leftTable<``TransactionHistory (base)``, TransactionHistory>
+
+        type private ``TransactionHistoryArchive (base)`` = TransactionHistoryArchive
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type TransactionHistoryArchive =
+            { [<ProviderDbType("Int")>]
+              TransactionID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderLineID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              TransactionDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              TransactionType: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``TransactionHistoryArchive (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``TransactionHistoryArchive (base)`` option =
+                match this.TransactionID with
+                | Some value ->
+                    let record: ``TransactionHistoryArchive (base)`` =
+                        { TransactionID = value
+                          ProductID = this.ProductID.Value
+                          ReferenceOrderID = this.ReferenceOrderID.Value
+                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                          TransactionDate = this.TransactionDate.Value
+                          TransactionType = this.TransactionType.Value
+                          Quantity = this.Quantity.Value
+                          ActualCost = this.ActualCost.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let TransactionHistoryArchive =
+            leftTable<``TransactionHistoryArchive (base)``, TransactionHistoryArchive>
+
+        type private ``UnitMeasure (base)`` = UnitMeasure
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type UnitMeasure =
+            { [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``UnitMeasure (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``UnitMeasure (base)`` option =
+                match this.UnitMeasureCode with
+                | Some value ->
+                    let record: ``UnitMeasure (base)`` =
+                        { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let UnitMeasure = leftTable<``UnitMeasure (base)``, UnitMeasure>
+
+        type private ``WorkOrder (base)`` = WorkOrder
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WorkOrder =
+            { [<ProviderDbType("Int")>]
+              WorkOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              OrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              StockedQty: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              ScrappedQty: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("SmallInt")>]
+              ScrapReasonID: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``WorkOrder (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WorkOrder (base)`` option =
+                match this.WorkOrderID with
+                | Some value ->
+                    let record: ``WorkOrder (base)`` =
+                        { WorkOrderID = value
+                          ProductID = this.ProductID.Value
+                          OrderQty = this.OrderQty.Value
+                          StockedQty = this.StockedQty.Value
+                          ScrappedQty = this.ScrappedQty.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          DueDate = this.DueDate.Value
+                          ScrapReasonID = this.ScrapReasonID
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let WorkOrder = leftTable<``WorkOrder (base)``, WorkOrder>
+
+        type private ``WorkOrderRouting (base)`` = WorkOrderRouting
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WorkOrderRouting =
+            { [<ProviderDbType("Int")>]
+              WorkOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              OperationSequence: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ScheduledStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ScheduledEndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ActualStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ActualEndDate: Option<System.DateTime>
+              [<ProviderDbType("Decimal")>]
+              ActualResourceHrs: Option<decimal>
+              [<ProviderDbType("Money")>]
+              PlannedCost: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``WorkOrderRouting (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WorkOrderRouting (base)`` option =
+                match this.WorkOrderID with
+                | Some value ->
+                    let record: ``WorkOrderRouting (base)`` =
+                        { WorkOrderID = value
+                          ProductID = this.ProductID.Value
+                          OperationSequence = this.OperationSequence.Value
+                          LocationID = this.LocationID.Value
+                          ScheduledStartDate = this.ScheduledStartDate.Value
+                          ScheduledEndDate = this.ScheduledEndDate.Value
+                          ActualStartDate = this.ActualStartDate
+                          ActualEndDate = this.ActualEndDate
+                          ActualResourceHrs = this.ActualResourceHrs
+                          PlannedCost = this.PlannedCost.Value
+                          ActualCost = this.ActualCost
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let WorkOrderRouting = leftTable<``WorkOrderRouting (base)``, WorkOrderRouting>
+
+
 module Purchasing =
 
     [<CLIMutable>]
@@ -1372,6 +2968,254 @@ module Purchasing =
                   { WriteColumn.Name = "ModifiedDate"; Value = box this.ModifiedDate; ProviderDbType = Some "DateTime" } ]
 
     let Vendor = table<Vendor>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``ProductVendor (base)`` = ProductVendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductVendor =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              AverageLeadTime: Option<int>
+              [<ProviderDbType("Money")>]
+              StandardPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              LastReceiptCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              LastReceiptDate: Option<System.DateTime>
+              [<ProviderDbType("Int")>]
+              MinOrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              MaxOrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              OnOrderQty: Option<int>
+              [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductVendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductVendor (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductVendor (base)`` =
+                        { ProductID = value
+                          BusinessEntityID = this.BusinessEntityID.Value
+                          AverageLeadTime = this.AverageLeadTime.Value
+                          StandardPrice = this.StandardPrice.Value
+                          LastReceiptCost = this.LastReceiptCost
+                          LastReceiptDate = this.LastReceiptDate
+                          MinOrderQty = this.MinOrderQty.Value
+                          MaxOrderQty = this.MaxOrderQty.Value
+                          OnOrderQty = this.OnOrderQty
+                          UnitMeasureCode = this.UnitMeasureCode.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductVendor = leftTable<``ProductVendor (base)``, ProductVendor>
+
+        type private ``PurchaseOrderDetail (base)`` = PurchaseOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PurchaseOrderDetail =
+            { [<ProviderDbType("Int")>]
+              PurchaseOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              PurchaseOrderDetailID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("SmallInt")>]
+              OrderQty: Option<int16>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Money")>]
+              UnitPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              LineTotal: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              ReceivedQty: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              RejectedQty: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              StockedQty: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PurchaseOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PurchaseOrderDetail (base)`` option =
+                match this.PurchaseOrderID with
+                | Some value ->
+                    let record: ``PurchaseOrderDetail (base)`` =
+                        { PurchaseOrderID = value
+                          PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
+                          DueDate = this.DueDate.Value
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          LineTotal = this.LineTotal.Value
+                          ReceivedQty = this.ReceivedQty.Value
+                          RejectedQty = this.RejectedQty.Value
+                          StockedQty = this.StockedQty.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PurchaseOrderDetail =
+            leftTable<``PurchaseOrderDetail (base)``, PurchaseOrderDetail>
+
+        type private ``PurchaseOrderHeader (base)`` = PurchaseOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PurchaseOrderHeader =
+            { [<ProviderDbType("Int")>]
+              PurchaseOrderID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              RevisionNumber: Option<byte>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("Int")>]
+              EmployeeID: Option<int>
+              [<ProviderDbType("Int")>]
+              VendorID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              OrderDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ShipDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              SubTotal: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TaxAmt: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Freight: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TotalDue: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PurchaseOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PurchaseOrderHeader (base)`` option =
+                match this.PurchaseOrderID with
+                | Some value ->
+                    let record: ``PurchaseOrderHeader (base)`` =
+                        { PurchaseOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          Status = this.Status.Value
+                          EmployeeID = this.EmployeeID.Value
+                          VendorID = this.VendorID.Value
+                          ShipMethodID = this.ShipMethodID.Value
+                          OrderDate = this.OrderDate.Value
+                          ShipDate = this.ShipDate
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PurchaseOrderHeader =
+            leftTable<``PurchaseOrderHeader (base)``, PurchaseOrderHeader>
+
+        type private ``ShipMethod (base)`` = ShipMethod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ShipMethod =
+            { [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Money")>]
+              ShipBase: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ShipRate: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ShipMethod (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ShipMethod (base)`` option =
+                match this.ShipMethodID with
+                | Some value ->
+                    let record: ``ShipMethod (base)`` =
+                        { ShipMethodID = value
+                          Name = this.Name.Value
+                          ShipBase = this.ShipBase.Value
+                          ShipRate = this.ShipRate.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ShipMethod = leftTable<``ShipMethod (base)``, ShipMethod>
+
+        type private ``Vendor (base)`` = Vendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Vendor =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              CreditRating: Option<byte>
+              [<ProviderDbType("Bit")>]
+              PreferredVendorStatus: Option<bool>
+              [<ProviderDbType("Bit")>]
+              ActiveFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              PurchasingWebServiceURL: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Vendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Vendor (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Vendor (base)`` =
+                        { BusinessEntityID = value
+                          AccountNumber = this.AccountNumber.Value
+                          Name = this.Name.Value
+                          CreditRating = this.CreditRating.Value
+                          PreferredVendorStatus = this.PreferredVendorStatus.Value
+                          ActiveFlag = this.ActiveFlag.Value
+                          PurchasingWebServiceURL = this.PurchasingWebServiceURL
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Vendor = leftTable<``Vendor (base)``, Vendor>
+
 
 module Sales =
 
@@ -1935,6 +3779,762 @@ module Sales =
 
     let Store = table<Store>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``CountryRegionCurrency (base)`` = CountryRegionCurrency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CountryRegionCurrency =
+            { [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              CurrencyCode: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CountryRegionCurrency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CountryRegionCurrency (base)`` option =
+                match this.CountryRegionCode with
+                | Some value ->
+                    let record: ``CountryRegionCurrency (base)`` =
+                        { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CountryRegionCurrency =
+            leftTable<``CountryRegionCurrency (base)``, CountryRegionCurrency>
+
+        type private ``CreditCard (base)`` = CreditCard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CreditCard =
+            { [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              CardType: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CardNumber: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              ExpMonth: Option<byte>
+              [<ProviderDbType("SmallInt")>]
+              ExpYear: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CreditCard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CreditCard (base)`` option =
+                match this.CreditCardID with
+                | Some value ->
+                    let record: ``CreditCard (base)`` =
+                        { CreditCardID = value
+                          CardType = this.CardType.Value
+                          CardNumber = this.CardNumber.Value
+                          ExpMonth = this.ExpMonth.Value
+                          ExpYear = this.ExpYear.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CreditCard = leftTable<``CreditCard (base)``, CreditCard>
+
+        type private ``Currency (base)`` = Currency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Currency =
+            { [<ProviderDbType("NChar")>]
+              CurrencyCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Currency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Currency (base)`` option =
+                match this.CurrencyCode with
+                | Some value ->
+                    let record: ``Currency (base)`` =
+                        { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Currency = leftTable<``Currency (base)``, Currency>
+
+        type private ``CurrencyRate (base)`` = CurrencyRate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CurrencyRate =
+            { [<ProviderDbType("Int")>]
+              CurrencyRateID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              CurrencyRateDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              FromCurrencyCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              ToCurrencyCode: Option<string>
+              [<ProviderDbType("Money")>]
+              AverageRate: Option<decimal>
+              [<ProviderDbType("Money")>]
+              EndOfDayRate: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CurrencyRate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CurrencyRate (base)`` option =
+                match this.CurrencyRateID with
+                | Some value ->
+                    let record: ``CurrencyRate (base)`` =
+                        { CurrencyRateID = value
+                          CurrencyRateDate = this.CurrencyRateDate.Value
+                          FromCurrencyCode = this.FromCurrencyCode.Value
+                          ToCurrencyCode = this.ToCurrencyCode.Value
+                          AverageRate = this.AverageRate.Value
+                          EndOfDayRate = this.EndOfDayRate.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CurrencyRate = leftTable<``CurrencyRate (base)``, CurrencyRate>
+
+        type private ``Customer (base)`` = Customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Customer =
+            { [<ProviderDbType("Int")>]
+              CustomerID: Option<int>
+              [<ProviderDbType("Int")>]
+              PersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              StoreID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Customer (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``Customer (base)`` =
+                        { CustomerID = value
+                          PersonID = this.PersonID
+                          StoreID = this.StoreID
+                          TerritoryID = this.TerritoryID
+                          AccountNumber = this.AccountNumber.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Customer = leftTable<``Customer (base)``, Customer>
+
+        type private ``PersonCreditCard (base)`` = PersonCreditCard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PersonCreditCard =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PersonCreditCard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PersonCreditCard (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``PersonCreditCard (base)`` =
+                        { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PersonCreditCard = leftTable<``PersonCreditCard (base)``, PersonCreditCard>
+
+        type private ``SalesOrderDetail (base)`` = SalesOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderDetail =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesOrderDetailID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              CarrierTrackingNumber: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              OrderQty: Option<int16>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("Money")>]
+              UnitPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              UnitPriceDiscount: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              LineTotal: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderDetail (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderDetail (base)`` =
+                        { SalesOrderID = value
+                          SalesOrderDetailID = this.SalesOrderDetailID.Value
+                          CarrierTrackingNumber = this.CarrierTrackingNumber
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          SpecialOfferID = this.SpecialOfferID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          UnitPriceDiscount = this.UnitPriceDiscount.Value
+                          LineTotal = this.LineTotal.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
+
+        type private ``SalesOrderHeader (base)`` = SalesOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeader =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              RevisionNumber: Option<byte>
+              [<ProviderDbType("DateTime")>]
+              OrderDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ShipDate: Option<System.DateTime>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("Bit")>]
+              OnlineOrderFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              SalesOrderNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              PurchaseOrderNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("Int")>]
+              CustomerID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              BillToAddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipToAddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              CreditCardApprovalCode: Option<string>
+              [<ProviderDbType("Int")>]
+              CurrencyRateID: Option<int>
+              [<ProviderDbType("Money")>]
+              SubTotal: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TaxAmt: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Freight: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TotalDue: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Comment: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeader (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeader (base)`` =
+                        { SalesOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          OrderDate = this.OrderDate.Value
+                          DueDate = this.DueDate.Value
+                          ShipDate = this.ShipDate
+                          Status = this.Status.Value
+                          OnlineOrderFlag = this.OnlineOrderFlag.Value
+                          SalesOrderNumber = this.SalesOrderNumber.Value
+                          PurchaseOrderNumber = this.PurchaseOrderNumber
+                          AccountNumber = this.AccountNumber
+                          CustomerID = this.CustomerID.Value
+                          SalesPersonID = this.SalesPersonID
+                          TerritoryID = this.TerritoryID
+                          BillToAddressID = this.BillToAddressID.Value
+                          ShipToAddressID = this.ShipToAddressID.Value
+                          ShipMethodID = this.ShipMethodID.Value
+                          CreditCardID = this.CreditCardID
+                          CreditCardApprovalCode = this.CreditCardApprovalCode
+                          CurrencyRateID = this.CurrencyRateID
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          Comment = this.Comment
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+        type private ``SalesOrderHeaderSalesReason (base)`` = SalesOrderHeaderSalesReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeaderSalesReason =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesReasonID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeaderSalesReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeaderSalesReason (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeaderSalesReason (base)`` =
+                        { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeaderSalesReason =
+            leftTable<``SalesOrderHeaderSalesReason (base)``, SalesOrderHeaderSalesReason>
+
+        type private ``SalesPerson (base)`` = SalesPerson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesPerson =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("Money")>]
+              SalesQuota: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Bonus: Option<decimal>
+              [<ProviderDbType("SmallMoney")>]
+              CommissionPct: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesLastYear: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesPerson (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesPerson (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesPerson (base)`` =
+                        { BusinessEntityID = value
+                          TerritoryID = this.TerritoryID
+                          SalesQuota = this.SalesQuota
+                          Bonus = this.Bonus.Value
+                          CommissionPct = this.CommissionPct.Value
+                          SalesYTD = this.SalesYTD.Value
+                          SalesLastYear = this.SalesLastYear.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesPerson = leftTable<``SalesPerson (base)``, SalesPerson>
+
+        type private ``SalesPersonQuotaHistory (base)`` = SalesPersonQuotaHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesPersonQuotaHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              QuotaDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              SalesQuota: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesPersonQuotaHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesPersonQuotaHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesPersonQuotaHistory (base)`` =
+                        { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesPersonQuotaHistory =
+            leftTable<``SalesPersonQuotaHistory (base)``, SalesPersonQuotaHistory>
+
+        type private ``SalesReason (base)`` = SalesReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesReason =
+            { [<ProviderDbType("Int")>]
+              SalesReasonID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              ReasonType: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesReason (base)`` option =
+                match this.SalesReasonID with
+                | Some value ->
+                    let record: ``SalesReason (base)`` =
+                        { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesReason = leftTable<``SalesReason (base)``, SalesReason>
+
+        type private ``SalesTaxRate (base)`` = SalesTaxRate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTaxRate =
+            { [<ProviderDbType("Int")>]
+              SalesTaxRateID: Option<int>
+              [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              TaxType: Option<byte>
+              [<ProviderDbType("SmallMoney")>]
+              TaxRate: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTaxRate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTaxRate (base)`` option =
+                match this.SalesTaxRateID with
+                | Some value ->
+                    let record: ``SalesTaxRate (base)`` =
+                        { SalesTaxRateID = value
+                          StateProvinceID = this.StateProvinceID.Value
+                          TaxType = this.TaxType.Value
+                          TaxRate = this.TaxRate.Value
+                          Name = this.Name.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTaxRate = leftTable<``SalesTaxRate (base)``, SalesTaxRate>
+
+        type private ``SalesTerritory (base)`` = SalesTerritory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTerritory =
+            { [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Group: Option<string>
+              [<ProviderDbType("Money")>]
+              SalesYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesLastYear: Option<decimal>
+              [<ProviderDbType("Money")>]
+              CostYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              CostLastYear: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTerritory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTerritory (base)`` option =
+                match this.TerritoryID with
+                | Some value ->
+                    let record: ``SalesTerritory (base)`` =
+                        { TerritoryID = value
+                          Name = this.Name.Value
+                          CountryRegionCode = this.CountryRegionCode.Value
+                          Group = this.Group.Value
+                          SalesYTD = this.SalesYTD.Value
+                          SalesLastYear = this.SalesLastYear.Value
+                          CostYTD = this.CostYTD.Value
+                          CostLastYear = this.CostLastYear.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTerritory = leftTable<``SalesTerritory (base)``, SalesTerritory>
+
+        type private ``SalesTerritoryHistory (base)`` = SalesTerritoryHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTerritoryHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTerritoryHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTerritoryHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesTerritoryHistory (base)`` =
+                        { BusinessEntityID = value
+                          TerritoryID = this.TerritoryID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTerritoryHistory =
+            leftTable<``SalesTerritoryHistory (base)``, SalesTerritoryHistory>
+
+        type private ``ShoppingCartItem (base)`` = ShoppingCartItem
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ShoppingCartItem =
+            { [<ProviderDbType("Int")>]
+              ShoppingCartItemID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ShoppingCartID: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              DateCreated: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ShoppingCartItem (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ShoppingCartItem (base)`` option =
+                match this.ShoppingCartItemID with
+                | Some value ->
+                    let record: ``ShoppingCartItem (base)`` =
+                        { ShoppingCartItemID = value
+                          ShoppingCartID = this.ShoppingCartID.Value
+                          Quantity = this.Quantity.Value
+                          ProductID = this.ProductID.Value
+                          DateCreated = this.DateCreated.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ShoppingCartItem = leftTable<``ShoppingCartItem (base)``, ShoppingCartItem>
+
+        type private ``SpecialOffer (base)`` = SpecialOffer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SpecialOffer =
+            { [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Description: Option<string>
+              [<ProviderDbType("SmallMoney")>]
+              DiscountPct: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Type: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Category: Option<string>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Int")>]
+              MinQty: Option<int>
+              [<ProviderDbType("Int")>]
+              MaxQty: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SpecialOffer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SpecialOffer (base)`` option =
+                match this.SpecialOfferID with
+                | Some value ->
+                    let record: ``SpecialOffer (base)`` =
+                        { SpecialOfferID = value
+                          Description = this.Description.Value
+                          DiscountPct = this.DiscountPct.Value
+                          Type = this.Type.Value
+                          Category = this.Category.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate.Value
+                          MinQty = this.MinQty.Value
+                          MaxQty = this.MaxQty
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SpecialOffer = leftTable<``SpecialOffer (base)``, SpecialOffer>
+
+        type private ``SpecialOfferProduct (base)`` = SpecialOfferProduct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SpecialOfferProduct =
+            { [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SpecialOfferProduct (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SpecialOfferProduct (base)`` option =
+                match this.SpecialOfferID with
+                | Some value ->
+                    let record: ``SpecialOfferProduct (base)`` =
+                        { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SpecialOfferProduct =
+            leftTable<``SpecialOfferProduct (base)``, SpecialOfferProduct>
+
+        type private ``Store (base)`` = Store
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Store =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Int")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Store (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Store (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Store (base)`` =
+                        { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Store = leftTable<``Store (base)``, Store>
+
+
 module dbo =
 
     [<CLIMutable>]
@@ -2021,6 +4621,124 @@ module dbo =
 
     let ErrorLog = table<ErrorLog>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``AWBuildVersion (base)`` = AWBuildVersion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type AWBuildVersion =
+            { [<ProviderDbType("TinyInt")>]
+              SystemInformationID: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              ``Database Version``: Option<string>
+              [<ProviderDbType("DateTime")>]
+              VersionDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``AWBuildVersion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``AWBuildVersion (base)`` option =
+                match this.SystemInformationID with
+                | Some value ->
+                    let record: ``AWBuildVersion (base)`` =
+                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let AWBuildVersion = leftTable<``AWBuildVersion (base)``, AWBuildVersion>
+
+        type private ``DatabaseLog (base)`` = DatabaseLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type DatabaseLog =
+            { [<ProviderDbType("Int")>]
+              DatabaseLogID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              PostTime: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              DatabaseUser: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Event: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Schema: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Object: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              TSQL: Option<string> }
+
+            interface ILeftViewOf<``DatabaseLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``DatabaseLog (base)`` option =
+                match this.DatabaseLogID with
+                | Some value ->
+                    let record: ``DatabaseLog (base)`` =
+                        { DatabaseLogID = value
+                          PostTime = this.PostTime.Value
+                          DatabaseUser = this.DatabaseUser.Value
+                          Event = this.Event.Value
+                          Schema = this.Schema
+                          Object = this.Object
+                          TSQL = this.TSQL.Value }
+
+                    Some record
+                | None -> None
+
+        let DatabaseLog = leftTable<``DatabaseLog (base)``, DatabaseLog>
+
+        type private ``ErrorLog (base)`` = ErrorLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ErrorLog =
+            { [<ProviderDbType("Int")>]
+              ErrorLogID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ErrorTime: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              UserName: Option<string>
+              [<ProviderDbType("Int")>]
+              ErrorNumber: Option<int>
+              [<ProviderDbType("Int")>]
+              ErrorSeverity: Option<int>
+              [<ProviderDbType("Int")>]
+              ErrorState: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ErrorProcedure: Option<string>
+              [<ProviderDbType("Int")>]
+              ErrorLine: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ErrorMessage: Option<string> }
+
+            interface ILeftViewOf<``ErrorLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ErrorLog (base)`` option =
+                match this.ErrorLogID with
+                | Some value ->
+                    let record: ``ErrorLog (base)`` =
+                        { ErrorLogID = value
+                          ErrorTime = this.ErrorTime.Value
+                          UserName = this.UserName.Value
+                          ErrorNumber = this.ErrorNumber.Value
+                          ErrorSeverity = this.ErrorSeverity
+                          ErrorState = this.ErrorState
+                          ErrorProcedure = this.ErrorProcedure
+                          ErrorLine = this.ErrorLine
+                          ErrorMessage = this.ErrorMessage.Value }
+
+                    Some record
+                | None -> None
+
+        let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
+
+
 module ext =
 
     [<CLIMutable>]
@@ -2084,6 +4802,111 @@ module ext =
                   { WriteColumn.Name = "Value"; Value = box this.Value; ProviderDbType = Some "NVarChar" } ]
 
     let NullableKeyUpsert = table<NullableKeyUpsert>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``DateTime2Support (base)`` = DateTime2Support
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type DateTime2Support =
+            { [<ProviderDbType("Int")>]
+              ID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              LessPrecision: Option<System.DateTime>
+              [<ProviderDbType("DateTime2")>]
+              MorePrecision: Option<System.DateTime> }
+
+            interface ILeftViewOf<``DateTime2Support (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``DateTime2Support (base)`` option =
+                match this.ID with
+                | Some value ->
+                    let record: ``DateTime2Support (base)`` =
+                        { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
+
+                    Some record
+                | None -> None
+
+        let DateTime2Support = leftTable<``DateTime2Support (base)``, DateTime2Support>
+
+        type private ``GetIdGuidRepro (base)`` = GetIdGuidRepro
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type GetIdGuidRepro =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Id: Option<System.Guid>
+              [<ProviderDbType("NChar")>]
+              EmailAddress: Option<string> }
+
+            interface ILeftViewOf<``GetIdGuidRepro (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``GetIdGuidRepro (base)`` option =
+                match this.Id with
+                | Some value ->
+                    let record: ``GetIdGuidRepro (base)`` =
+                        { Id = value; EmailAddress = this.EmailAddress.Value }
+
+                    Some record
+                | None -> None
+
+        let GetIdGuidRepro = leftTable<``GetIdGuidRepro (base)``, GetIdGuidRepro>
+
+        type private ``HierarchyIdSupport (base)`` = HierarchyIdSupport
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type HierarchyIdSupport =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Id: Option<System.Guid>
+              [<ProviderDbType("SqlHierarchyId")>]
+              Hierarchy: Option<Microsoft.SqlServer.Types.SqlHierarchyId> }
+
+            interface ILeftViewOf<``HierarchyIdSupport (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``HierarchyIdSupport (base)`` option =
+                match this.Id with
+                | Some value ->
+                    let record: ``HierarchyIdSupport (base)`` =
+                        { Id = value; Hierarchy = this.Hierarchy.Value }
+
+                    Some record
+                | None -> None
+
+        let HierarchyIdSupport =
+            leftTable<``HierarchyIdSupport (base)``, HierarchyIdSupport>
+
+        type private ``NullableKeyUpsert (base)`` = NullableKeyUpsert
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type NullableKeyUpsert =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Key1: Option<System.Guid>
+              [<ProviderDbType("NVarChar")>]
+              Key2: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Value: Option<string> }
+
+            interface ILeftViewOf<``NullableKeyUpsert (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``NullableKeyUpsert (base)`` option =
+                match this.Key1 with
+                | Some value ->
+                    let record: ``NullableKeyUpsert (base)`` =
+                        { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
+
+                    Some record
+                | None -> None
+
+        let NullableKeyUpsert = leftTable<``NullableKeyUpsert (base)``, NullableKeyUpsert>
+
 
 
 

--- a/src/Tests/SqlServer/AdventureWorksNet8.fs
+++ b/src/Tests/SqlServer/AdventureWorksNet8.fs
@@ -194,17 +194,6 @@ module HumanResources =
 
             interface ILeftViewOf<``Department (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Department (base)`` option =
-                match this.DepartmentID with
-                | Some value ->
-                    let record: ``Department (base)`` =
-                        { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Department = leftTable<``Department (base)``, Department>
 
         type private ``Employee (base)`` = Employee
@@ -246,32 +235,6 @@ module HumanResources =
 
             interface ILeftViewOf<``Employee (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Employee (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Employee (base)`` =
-                        { BusinessEntityID = value
-                          NationalIDNumber = this.NationalIDNumber.Value
-                          LoginID = this.LoginID.Value
-                          OrganizationNode = this.OrganizationNode
-                          OrganizationLevel = this.OrganizationLevel
-                          JobTitle = this.JobTitle.Value
-                          BirthDate = this.BirthDate.Value
-                          MaritalStatus = this.MaritalStatus.Value
-                          Gender = this.Gender.Value
-                          HireDate = this.HireDate.Value
-                          SalariedFlag = this.SalariedFlag.Value
-                          VacationHours = this.VacationHours.Value
-                          SickLeaveHours = this.SickLeaveHours.Value
-                          CurrentFlag = this.CurrentFlag.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Employee = leftTable<``Employee (base)``, Employee>
 
         type private ``EmployeeDepartmentHistory (base)`` = EmployeeDepartmentHistory
@@ -293,22 +256,6 @@ module HumanResources =
 
             interface ILeftViewOf<``EmployeeDepartmentHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmployeeDepartmentHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmployeeDepartmentHistory (base)`` =
-                        { BusinessEntityID = value
-                          DepartmentID = this.DepartmentID.Value
-                          ShiftID = this.ShiftID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmployeeDepartmentHistory =
             leftTable<``EmployeeDepartmentHistory (base)``, EmployeeDepartmentHistory>
 
@@ -329,17 +276,6 @@ module HumanResources =
 
             interface ILeftViewOf<``EmployeePayHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmployeePayHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmployeePayHistory (base)`` =
-                        { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmployeePayHistory =
             leftTable<``EmployeePayHistory (base)``, EmployeePayHistory>
 
@@ -355,17 +291,6 @@ module HumanResources =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``JobCandidate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``JobCandidate (base)`` option =
-                match this.JobCandidateID with
-                | Some value ->
-                    let record: ``JobCandidate (base)`` =
-                        { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let JobCandidate = leftTable<``JobCandidate (base)``, JobCandidate>
 
@@ -385,17 +310,6 @@ module HumanResources =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Shift (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Shift (base)`` option =
-                match this.ShiftID with
-                | Some value ->
-                    let record: ``Shift (base)`` =
-                        { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Shift = leftTable<``Shift (base)``, Shift>
 
@@ -733,24 +647,6 @@ module Person =
 
             interface ILeftViewOf<``Address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Address (base)`` option =
-                match this.AddressID with
-                | Some value ->
-                    let record: ``Address (base)`` =
-                        { AddressID = value
-                          AddressLine1 = this.AddressLine1.Value
-                          AddressLine2 = this.AddressLine2
-                          City = this.City.Value
-                          StateProvinceID = this.StateProvinceID.Value
-                          PostalCode = this.PostalCode.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Address = leftTable<``Address (base)``, Address>
 
         type private ``AddressType (base)`` = AddressType
@@ -768,17 +664,6 @@ module Person =
 
             interface ILeftViewOf<``AddressType (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``AddressType (base)`` option =
-                match this.AddressTypeID with
-                | Some value ->
-                    let record: ``AddressType (base)`` =
-                        { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let AddressType = leftTable<``AddressType (base)``, AddressType>
 
         type private ``BusinessEntity (base)`` = BusinessEntity
@@ -793,17 +678,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BusinessEntity (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntity (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntity (base)`` =
-                        { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BusinessEntity = leftTable<``BusinessEntity (base)``, BusinessEntity>
 
@@ -823,17 +697,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BusinessEntityAddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntityAddress (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntityAddress (base)`` =
-                        { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BusinessEntityAddress =
             leftTable<``BusinessEntityAddress (base)``, BusinessEntityAddress>
@@ -855,17 +718,6 @@ module Person =
 
             interface ILeftViewOf<``BusinessEntityContact (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntityContact (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntityContact (base)`` =
-                        { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let BusinessEntityContact =
             leftTable<``BusinessEntityContact (base)``, BusinessEntityContact>
 
@@ -882,17 +734,6 @@ module Person =
 
             interface ILeftViewOf<``ContactType (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ContactType (base)`` option =
-                match this.ContactTypeID with
-                | Some value ->
-                    let record: ``ContactType (base)`` =
-                        { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ContactType = leftTable<``ContactType (base)``, ContactType>
 
         type private ``CountryRegion (base)`` = CountryRegion
@@ -907,17 +748,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``CountryRegion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CountryRegion (base)`` option =
-                match this.CountryRegionCode with
-                | Some value ->
-                    let record: ``CountryRegion (base)`` =
-                        { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let CountryRegion = leftTable<``CountryRegion (base)``, CountryRegion>
 
@@ -938,17 +768,6 @@ module Person =
 
             interface ILeftViewOf<``EmailAddress (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmailAddress (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmailAddress (base)`` =
-                        { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmailAddress = leftTable<``EmailAddress (base)``, EmailAddress>
 
         type private ``Password (base)`` = Password
@@ -967,21 +786,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Password (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Password (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Password (base)`` =
-                        { BusinessEntityID = value
-                          PasswordHash = this.PasswordHash.Value
-                          PasswordSalt = this.PasswordSalt.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Password = leftTable<``Password (base)``, Password>
 
@@ -1014,27 +818,6 @@ module Person =
 
             interface ILeftViewOf<``Person (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Person (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Person (base)`` =
-                        { BusinessEntityID = value
-                          PersonType = this.PersonType.Value
-                          NameStyle = this.NameStyle.Value
-                          Title = this.Title
-                          FirstName = this.FirstName.Value
-                          MiddleName = this.MiddleName
-                          LastName = this.LastName.Value
-                          Suffix = this.Suffix
-                          EmailPromotion = this.EmailPromotion.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Person = leftTable<``Person (base)``, Person>
 
         type private ``PersonPhone (base)`` = PersonPhone
@@ -1052,17 +835,6 @@ module Person =
 
             interface ILeftViewOf<``PersonPhone (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PersonPhone (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``PersonPhone (base)`` =
-                        { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let PersonPhone = leftTable<``PersonPhone (base)``, PersonPhone>
 
         type private ``PhoneNumberType (base)`` = PhoneNumberType
@@ -1077,17 +849,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PhoneNumberType (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PhoneNumberType (base)`` option =
-                match this.PhoneNumberTypeID with
-                | Some value ->
-                    let record: ``PhoneNumberType (base)`` =
-                        { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PhoneNumberType = leftTable<``PhoneNumberType (base)``, PhoneNumberType>
 
@@ -1113,24 +874,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``StateProvince (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``StateProvince (base)`` option =
-                match this.StateProvinceID with
-                | Some value ->
-                    let record: ``StateProvince (base)`` =
-                        { StateProvinceID = value
-                          StateProvinceCode = this.StateProvinceCode.Value
-                          CountryRegionCode = this.CountryRegionCode.Value
-                          IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
-                          Name = this.Name.Value
-                          TerritoryID = this.TerritoryID.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let StateProvince = leftTable<``StateProvince (base)``, StateProvince>
 
@@ -1864,25 +1607,6 @@ module Production =
 
             interface ILeftViewOf<``BillOfMaterials (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BillOfMaterials (base)`` option =
-                match this.BillOfMaterialsID with
-                | Some value ->
-                    let record: ``BillOfMaterials (base)`` =
-                        { BillOfMaterialsID = value
-                          ProductAssemblyID = this.ProductAssemblyID
-                          ComponentID = this.ComponentID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          UnitMeasureCode = this.UnitMeasureCode.Value
-                          BOMLevel = this.BOMLevel.Value
-                          PerAssemblyQty = this.PerAssemblyQty.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let BillOfMaterials = leftTable<``BillOfMaterials (base)``, BillOfMaterials>
 
         type private ``Culture (base)`` = Culture
@@ -1897,17 +1621,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Culture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Culture (base)`` option =
-                match this.CultureID with
-                | Some value ->
-                    let record: ``Culture (base)`` =
-                        { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Culture = leftTable<``Culture (base)``, Culture>
 
@@ -1946,30 +1659,6 @@ module Production =
 
             interface ILeftViewOf<``Document (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Document (base)`` option =
-                match this.DocumentNode with
-                | Some value ->
-                    let record: ``Document (base)`` =
-                        { DocumentNode = value
-                          DocumentLevel = this.DocumentLevel
-                          Title = this.Title.Value
-                          Owner = this.Owner.Value
-                          FolderFlag = this.FolderFlag.Value
-                          FileName = this.FileName.Value
-                          FileExtension = this.FileExtension.Value
-                          Revision = this.Revision.Value
-                          ChangeNumber = this.ChangeNumber.Value
-                          Status = this.Status.Value
-                          DocumentSummary = this.DocumentSummary
-                          Document = this.Document
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Document = leftTable<``Document (base)``, Document>
 
         type private ``Illustration (base)`` = Illustration
@@ -1982,17 +1671,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Illustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Illustration (base)`` option =
-                match this.IllustrationID with
-                | Some value ->
-                    let record: ``Illustration (base)`` =
-                        { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Illustration = leftTable<``Illustration (base)``, Illustration>
 
@@ -2012,17 +1690,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Location (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Location (base)`` option =
-                match this.LocationID with
-                | Some value ->
-                    let record: ``Location (base)`` =
-                        { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Location = leftTable<``Location (base)``, Location>
 
@@ -2083,41 +1750,6 @@ module Production =
 
             interface ILeftViewOf<``Product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Product (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``Product (base)`` =
-                        { ProductID = value
-                          Name = this.Name.Value
-                          ProductNumber = this.ProductNumber.Value
-                          MakeFlag = this.MakeFlag.Value
-                          FinishedGoodsFlag = this.FinishedGoodsFlag.Value
-                          Color = this.Color
-                          SafetyStockLevel = this.SafetyStockLevel.Value
-                          ReorderPoint = this.ReorderPoint.Value
-                          StandardCost = this.StandardCost.Value
-                          ListPrice = this.ListPrice.Value
-                          Size = this.Size
-                          SizeUnitMeasureCode = this.SizeUnitMeasureCode
-                          WeightUnitMeasureCode = this.WeightUnitMeasureCode
-                          Weight = this.Weight
-                          DaysToManufacture = this.DaysToManufacture.Value
-                          ProductLine = this.ProductLine
-                          Class = this.Class
-                          Style = this.Style
-                          ProductSubcategoryID = this.ProductSubcategoryID
-                          ProductModelID = this.ProductModelID
-                          SellStartDate = this.SellStartDate.Value
-                          SellEndDate = this.SellEndDate
-                          DiscontinuedDate = this.DiscontinuedDate
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Product = leftTable<``Product (base)``, Product>
 
         type private ``ProductCategory (base)`` = ProductCategory
@@ -2134,17 +1766,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductCategory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCategory (base)`` option =
-                match this.ProductCategoryID with
-                | Some value ->
-                    let record: ``ProductCategory (base)`` =
-                        { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
 
@@ -2165,17 +1786,6 @@ module Production =
 
             interface ILeftViewOf<``ProductCostHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCostHistory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductCostHistory (base)`` =
-                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductCostHistory =
             leftTable<``ProductCostHistory (base)``, ProductCostHistory>
 
@@ -2194,17 +1804,6 @@ module Production =
 
             interface ILeftViewOf<``ProductDescription (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDescription (base)`` option =
-                match this.ProductDescriptionID with
-                | Some value ->
-                    let record: ``ProductDescription (base)`` =
-                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductDescription =
             leftTable<``ProductDescription (base)``, ProductDescription>
 
@@ -2220,17 +1819,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductDocument (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDocument (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductDocument (base)`` =
-                        { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductDocument = leftTable<``ProductDocument (base)``, ProductDocument>
 
@@ -2255,23 +1843,6 @@ module Production =
 
             interface ILeftViewOf<``ProductInventory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductInventory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductInventory (base)`` =
-                        { ProductID = value
-                          LocationID = this.LocationID.Value
-                          Shelf = this.Shelf.Value
-                          Bin = this.Bin.Value
-                          Quantity = this.Quantity.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductInventory = leftTable<``ProductInventory (base)``, ProductInventory>
 
         type private ``ProductListPriceHistory (base)`` = ProductListPriceHistory
@@ -2291,17 +1862,6 @@ module Production =
 
             interface ILeftViewOf<``ProductListPriceHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductListPriceHistory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductListPriceHistory (base)`` =
-                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductListPriceHistory =
             leftTable<``ProductListPriceHistory (base)``, ProductListPriceHistory>
 
@@ -2320,17 +1880,6 @@ module Production =
 
             interface ILeftViewOf<``ProductModel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModel (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModel (base)`` =
-                        { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
 
         type private ``ProductModelIllustration (base)`` = ProductModelIllustration
@@ -2345,17 +1894,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelIllustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelIllustration (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelIllustration (base)`` =
-                        { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelIllustration =
             leftTable<``ProductModelIllustration (base)``, ProductModelIllustration>
@@ -2374,17 +1912,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelProductDescriptionCulture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelProductDescriptionCulture (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelProductDescriptionCulture (base)`` =
-                        { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelProductDescriptionCulture =
             leftTable<``ProductModelProductDescriptionCulture (base)``, ProductModelProductDescriptionCulture>
@@ -2408,22 +1935,6 @@ module Production =
 
             interface ILeftViewOf<``ProductPhoto (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductPhoto (base)`` option =
-                match this.ProductPhotoID with
-                | Some value ->
-                    let record: ``ProductPhoto (base)`` =
-                        { ProductPhotoID = value
-                          ThumbNailPhoto = this.ThumbNailPhoto
-                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
-                          LargePhoto = this.LargePhoto
-                          LargePhotoFileName = this.LargePhotoFileName
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductPhoto = leftTable<``ProductPhoto (base)``, ProductPhoto>
 
         type private ``ProductProductPhoto (base)`` = ProductProductPhoto
@@ -2440,17 +1951,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductProductPhoto (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductProductPhoto (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductProductPhoto (base)`` =
-                        { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductProductPhoto =
             leftTable<``ProductProductPhoto (base)``, ProductProductPhoto>
@@ -2478,24 +1978,6 @@ module Production =
 
             interface ILeftViewOf<``ProductReview (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductReview (base)`` option =
-                match this.ProductReviewID with
-                | Some value ->
-                    let record: ``ProductReview (base)`` =
-                        { ProductReviewID = value
-                          ProductID = this.ProductID.Value
-                          ReviewerName = this.ReviewerName.Value
-                          ReviewDate = this.ReviewDate.Value
-                          EmailAddress = this.EmailAddress.Value
-                          Rating = this.Rating.Value
-                          Comments = this.Comments
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductReview = leftTable<``ProductReview (base)``, ProductReview>
 
         type private ``ProductSubcategory (base)`` = ProductSubcategory
@@ -2515,17 +1997,6 @@ module Production =
 
             interface ILeftViewOf<``ProductSubcategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductSubcategory (base)`` option =
-                match this.ProductSubcategoryID with
-                | Some value ->
-                    let record: ``ProductSubcategory (base)`` =
-                        { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductSubcategory =
             leftTable<``ProductSubcategory (base)``, ProductSubcategory>
 
@@ -2541,17 +2012,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ScrapReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ScrapReason (base)`` option =
-                match this.ScrapReasonID with
-                | Some value ->
-                    let record: ``ScrapReason (base)`` =
-                        { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ScrapReason = leftTable<``ScrapReason (base)``, ScrapReason>
 
@@ -2579,25 +2039,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``TransactionHistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``TransactionHistory (base)`` option =
-                match this.TransactionID with
-                | Some value ->
-                    let record: ``TransactionHistory (base)`` =
-                        { TransactionID = value
-                          ProductID = this.ProductID.Value
-                          ReferenceOrderID = this.ReferenceOrderID.Value
-                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
-                          TransactionDate = this.TransactionDate.Value
-                          TransactionType = this.TransactionType.Value
-                          Quantity = this.Quantity.Value
-                          ActualCost = this.ActualCost.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let TransactionHistory =
             leftTable<``TransactionHistory (base)``, TransactionHistory>
@@ -2627,25 +2068,6 @@ module Production =
 
             interface ILeftViewOf<``TransactionHistoryArchive (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``TransactionHistoryArchive (base)`` option =
-                match this.TransactionID with
-                | Some value ->
-                    let record: ``TransactionHistoryArchive (base)`` =
-                        { TransactionID = value
-                          ProductID = this.ProductID.Value
-                          ReferenceOrderID = this.ReferenceOrderID.Value
-                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
-                          TransactionDate = this.TransactionDate.Value
-                          TransactionType = this.TransactionType.Value
-                          Quantity = this.Quantity.Value
-                          ActualCost = this.ActualCost.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let TransactionHistoryArchive =
             leftTable<``TransactionHistoryArchive (base)``, TransactionHistoryArchive>
 
@@ -2661,17 +2083,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``UnitMeasure (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``UnitMeasure (base)`` option =
-                match this.UnitMeasureCode with
-                | Some value ->
-                    let record: ``UnitMeasure (base)`` =
-                        { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let UnitMeasure = leftTable<``UnitMeasure (base)``, UnitMeasure>
 
@@ -2701,26 +2112,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``WorkOrder (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WorkOrder (base)`` option =
-                match this.WorkOrderID with
-                | Some value ->
-                    let record: ``WorkOrder (base)`` =
-                        { WorkOrderID = value
-                          ProductID = this.ProductID.Value
-                          OrderQty = this.OrderQty.Value
-                          StockedQty = this.StockedQty.Value
-                          ScrappedQty = this.ScrappedQty.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          DueDate = this.DueDate.Value
-                          ScrapReasonID = this.ScrapReasonID
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let WorkOrder = leftTable<``WorkOrder (base)``, WorkOrder>
 
@@ -2754,28 +2145,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``WorkOrderRouting (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WorkOrderRouting (base)`` option =
-                match this.WorkOrderID with
-                | Some value ->
-                    let record: ``WorkOrderRouting (base)`` =
-                        { WorkOrderID = value
-                          ProductID = this.ProductID.Value
-                          OperationSequence = this.OperationSequence.Value
-                          LocationID = this.LocationID.Value
-                          ScheduledStartDate = this.ScheduledStartDate.Value
-                          ScheduledEndDate = this.ScheduledEndDate.Value
-                          ActualStartDate = this.ActualStartDate
-                          ActualEndDate = this.ActualEndDate
-                          ActualResourceHrs = this.ActualResourceHrs
-                          PlannedCost = this.PlannedCost.Value
-                          ActualCost = this.ActualCost
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let WorkOrderRouting = leftTable<``WorkOrderRouting (base)``, WorkOrderRouting>
 
@@ -3001,27 +2370,6 @@ module Purchasing =
 
             interface ILeftViewOf<``ProductVendor (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductVendor (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductVendor (base)`` =
-                        { ProductID = value
-                          BusinessEntityID = this.BusinessEntityID.Value
-                          AverageLeadTime = this.AverageLeadTime.Value
-                          StandardPrice = this.StandardPrice.Value
-                          LastReceiptCost = this.LastReceiptCost
-                          LastReceiptDate = this.LastReceiptDate
-                          MinOrderQty = this.MinOrderQty.Value
-                          MaxOrderQty = this.MaxOrderQty.Value
-                          OnOrderQty = this.OnOrderQty
-                          UnitMeasureCode = this.UnitMeasureCode.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductVendor = leftTable<``ProductVendor (base)``, ProductVendor>
 
         type private ``PurchaseOrderDetail (base)`` = PurchaseOrderDetail
@@ -3052,27 +2400,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PurchaseOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PurchaseOrderDetail (base)`` option =
-                match this.PurchaseOrderID with
-                | Some value ->
-                    let record: ``PurchaseOrderDetail (base)`` =
-                        { PurchaseOrderID = value
-                          PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
-                          DueDate = this.DueDate.Value
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          LineTotal = this.LineTotal.Value
-                          ReceivedQty = this.ReceivedQty.Value
-                          RejectedQty = this.RejectedQty.Value
-                          StockedQty = this.StockedQty.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PurchaseOrderDetail =
             leftTable<``PurchaseOrderDetail (base)``, PurchaseOrderDetail>
@@ -3110,29 +2437,6 @@ module Purchasing =
 
             interface ILeftViewOf<``PurchaseOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PurchaseOrderHeader (base)`` option =
-                match this.PurchaseOrderID with
-                | Some value ->
-                    let record: ``PurchaseOrderHeader (base)`` =
-                        { PurchaseOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          Status = this.Status.Value
-                          EmployeeID = this.EmployeeID.Value
-                          VendorID = this.VendorID.Value
-                          ShipMethodID = this.ShipMethodID.Value
-                          OrderDate = this.OrderDate.Value
-                          ShipDate = this.ShipDate
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let PurchaseOrderHeader =
             leftTable<``PurchaseOrderHeader (base)``, PurchaseOrderHeader>
 
@@ -3154,22 +2458,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ShipMethod (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ShipMethod (base)`` option =
-                match this.ShipMethodID with
-                | Some value ->
-                    let record: ``ShipMethod (base)`` =
-                        { ShipMethodID = value
-                          Name = this.Name.Value
-                          ShipBase = this.ShipBase.Value
-                          ShipRate = this.ShipRate.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ShipMethod = leftTable<``ShipMethod (base)``, ShipMethod>
 
@@ -3195,24 +2483,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Vendor (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Vendor (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Vendor (base)`` =
-                        { BusinessEntityID = value
-                          AccountNumber = this.AccountNumber.Value
-                          Name = this.Name.Value
-                          CreditRating = this.CreditRating.Value
-                          PreferredVendorStatus = this.PreferredVendorStatus.Value
-                          ActiveFlag = this.ActiveFlag.Value
-                          PurchasingWebServiceURL = this.PurchasingWebServiceURL
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Vendor = leftTable<``Vendor (base)``, Vendor>
 
@@ -3795,17 +3065,6 @@ module Sales =
 
             interface ILeftViewOf<``CountryRegionCurrency (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CountryRegionCurrency (base)`` option =
-                match this.CountryRegionCode with
-                | Some value ->
-                    let record: ``CountryRegionCurrency (base)`` =
-                        { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CountryRegionCurrency =
             leftTable<``CountryRegionCurrency (base)``, CountryRegionCurrency>
 
@@ -3828,22 +3087,6 @@ module Sales =
 
             interface ILeftViewOf<``CreditCard (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CreditCard (base)`` option =
-                match this.CreditCardID with
-                | Some value ->
-                    let record: ``CreditCard (base)`` =
-                        { CreditCardID = value
-                          CardType = this.CardType.Value
-                          CardNumber = this.CardNumber.Value
-                          ExpMonth = this.ExpMonth.Value
-                          ExpYear = this.ExpYear.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CreditCard = leftTable<``CreditCard (base)``, CreditCard>
 
         type private ``Currency (base)`` = Currency
@@ -3858,17 +3101,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Currency (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Currency (base)`` option =
-                match this.CurrencyCode with
-                | Some value ->
-                    let record: ``Currency (base)`` =
-                        { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Currency = leftTable<``Currency (base)``, Currency>
 
@@ -3893,23 +3125,6 @@ module Sales =
 
             interface ILeftViewOf<``CurrencyRate (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CurrencyRate (base)`` option =
-                match this.CurrencyRateID with
-                | Some value ->
-                    let record: ``CurrencyRate (base)`` =
-                        { CurrencyRateID = value
-                          CurrencyRateDate = this.CurrencyRateDate.Value
-                          FromCurrencyCode = this.FromCurrencyCode.Value
-                          ToCurrencyCode = this.ToCurrencyCode.Value
-                          AverageRate = this.AverageRate.Value
-                          EndOfDayRate = this.EndOfDayRate.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CurrencyRate = leftTable<``CurrencyRate (base)``, CurrencyRate>
 
         type private ``Customer (base)`` = Customer
@@ -3933,23 +3148,6 @@ module Sales =
 
             interface ILeftViewOf<``Customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Customer (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``Customer (base)`` =
-                        { CustomerID = value
-                          PersonID = this.PersonID
-                          StoreID = this.StoreID
-                          TerritoryID = this.TerritoryID
-                          AccountNumber = this.AccountNumber.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Customer = leftTable<``Customer (base)``, Customer>
 
         type private ``PersonCreditCard (base)`` = PersonCreditCard
@@ -3964,17 +3162,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PersonCreditCard (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PersonCreditCard (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``PersonCreditCard (base)`` =
-                        { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PersonCreditCard = leftTable<``PersonCreditCard (base)``, PersonCreditCard>
 
@@ -4006,27 +3193,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderDetail (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderDetail (base)`` =
-                        { SalesOrderID = value
-                          SalesOrderDetailID = this.SalesOrderDetailID.Value
-                          CarrierTrackingNumber = this.CarrierTrackingNumber
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          SpecialOfferID = this.SpecialOfferID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          UnitPriceDiscount = this.UnitPriceDiscount.Value
-                          LineTotal = this.LineTotal.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
 
@@ -4089,42 +3255,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeader (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeader (base)`` =
-                        { SalesOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          OrderDate = this.OrderDate.Value
-                          DueDate = this.DueDate.Value
-                          ShipDate = this.ShipDate
-                          Status = this.Status.Value
-                          OnlineOrderFlag = this.OnlineOrderFlag.Value
-                          SalesOrderNumber = this.SalesOrderNumber.Value
-                          PurchaseOrderNumber = this.PurchaseOrderNumber
-                          AccountNumber = this.AccountNumber
-                          CustomerID = this.CustomerID.Value
-                          SalesPersonID = this.SalesPersonID
-                          TerritoryID = this.TerritoryID
-                          BillToAddressID = this.BillToAddressID.Value
-                          ShipToAddressID = this.ShipToAddressID.Value
-                          ShipMethodID = this.ShipMethodID.Value
-                          CreditCardID = this.CreditCardID
-                          CreditCardApprovalCode = this.CreditCardApprovalCode
-                          CurrencyRateID = this.CurrencyRateID
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          Comment = this.Comment
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
 
         type private ``SalesOrderHeaderSalesReason (base)`` = SalesOrderHeaderSalesReason
@@ -4139,17 +3269,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderHeaderSalesReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeaderSalesReason (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeaderSalesReason (base)`` =
-                        { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderHeaderSalesReason =
             leftTable<``SalesOrderHeaderSalesReason (base)``, SalesOrderHeaderSalesReason>
@@ -4179,25 +3298,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesPerson (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesPerson (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesPerson (base)`` =
-                        { BusinessEntityID = value
-                          TerritoryID = this.TerritoryID
-                          SalesQuota = this.SalesQuota
-                          Bonus = this.Bonus.Value
-                          CommissionPct = this.CommissionPct.Value
-                          SalesYTD = this.SalesYTD.Value
-                          SalesLastYear = this.SalesLastYear.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesPerson = leftTable<``SalesPerson (base)``, SalesPerson>
 
         type private ``SalesPersonQuotaHistory (base)`` = SalesPersonQuotaHistory
@@ -4217,17 +3317,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesPersonQuotaHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesPersonQuotaHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesPersonQuotaHistory (base)`` =
-                        { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesPersonQuotaHistory =
             leftTable<``SalesPersonQuotaHistory (base)``, SalesPersonQuotaHistory>
 
@@ -4245,17 +3334,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesReason (base)`` option =
-                match this.SalesReasonID with
-                | Some value ->
-                    let record: ``SalesReason (base)`` =
-                        { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesReason = leftTable<``SalesReason (base)``, SalesReason>
 
@@ -4279,23 +3357,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesTaxRate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTaxRate (base)`` option =
-                match this.SalesTaxRateID with
-                | Some value ->
-                    let record: ``SalesTaxRate (base)`` =
-                        { SalesTaxRateID = value
-                          StateProvinceID = this.StateProvinceID.Value
-                          TaxType = this.TaxType.Value
-                          TaxRate = this.TaxRate.Value
-                          Name = this.Name.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesTaxRate = leftTable<``SalesTaxRate (base)``, SalesTaxRate>
 
@@ -4326,26 +3387,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesTerritory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTerritory (base)`` option =
-                match this.TerritoryID with
-                | Some value ->
-                    let record: ``SalesTerritory (base)`` =
-                        { TerritoryID = value
-                          Name = this.Name.Value
-                          CountryRegionCode = this.CountryRegionCode.Value
-                          Group = this.Group.Value
-                          SalesYTD = this.SalesYTD.Value
-                          SalesLastYear = this.SalesLastYear.Value
-                          CostYTD = this.CostYTD.Value
-                          CostLastYear = this.CostLastYear.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesTerritory = leftTable<``SalesTerritory (base)``, SalesTerritory>
 
         type private ``SalesTerritoryHistory (base)`` = SalesTerritoryHistory
@@ -4366,22 +3407,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesTerritoryHistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTerritoryHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesTerritoryHistory (base)`` =
-                        { BusinessEntityID = value
-                          TerritoryID = this.TerritoryID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesTerritoryHistory =
             leftTable<``SalesTerritoryHistory (base)``, SalesTerritoryHistory>
@@ -4404,22 +3429,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ShoppingCartItem (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ShoppingCartItem (base)`` option =
-                match this.ShoppingCartItemID with
-                | Some value ->
-                    let record: ``ShoppingCartItem (base)`` =
-                        { ShoppingCartItemID = value
-                          ShoppingCartID = this.ShoppingCartID.Value
-                          Quantity = this.Quantity.Value
-                          ProductID = this.ProductID.Value
-                          DateCreated = this.DateCreated.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ShoppingCartItem = leftTable<``ShoppingCartItem (base)``, ShoppingCartItem>
 
@@ -4452,27 +3461,6 @@ module Sales =
 
             interface ILeftViewOf<``SpecialOffer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SpecialOffer (base)`` option =
-                match this.SpecialOfferID with
-                | Some value ->
-                    let record: ``SpecialOffer (base)`` =
-                        { SpecialOfferID = value
-                          Description = this.Description.Value
-                          DiscountPct = this.DiscountPct.Value
-                          Type = this.Type.Value
-                          Category = this.Category.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate.Value
-                          MinQty = this.MinQty.Value
-                          MaxQty = this.MaxQty
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SpecialOffer = leftTable<``SpecialOffer (base)``, SpecialOffer>
 
         type private ``SpecialOfferProduct (base)`` = SpecialOfferProduct
@@ -4489,17 +3477,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SpecialOfferProduct (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SpecialOfferProduct (base)`` option =
-                match this.SpecialOfferID with
-                | Some value ->
-                    let record: ``SpecialOfferProduct (base)`` =
-                        { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SpecialOfferProduct =
             leftTable<``SpecialOfferProduct (base)``, SpecialOfferProduct>
@@ -4520,17 +3497,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Store (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Store (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Store (base)`` =
-                        { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Store = leftTable<``Store (base)``, Store>
 
@@ -4639,17 +3605,6 @@ module dbo =
 
             interface ILeftViewOf<``AWBuildVersion (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``AWBuildVersion (base)`` option =
-                match this.SystemInformationID with
-                | Some value ->
-                    let record: ``AWBuildVersion (base)`` =
-                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let AWBuildVersion = leftTable<``AWBuildVersion (base)``, AWBuildVersion>
 
         type private ``DatabaseLog (base)`` = DatabaseLog
@@ -4672,23 +3627,6 @@ module dbo =
               TSQL: Option<string> }
 
             interface ILeftViewOf<``DatabaseLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``DatabaseLog (base)`` option =
-                match this.DatabaseLogID with
-                | Some value ->
-                    let record: ``DatabaseLog (base)`` =
-                        { DatabaseLogID = value
-                          PostTime = this.PostTime.Value
-                          DatabaseUser = this.DatabaseUser.Value
-                          Event = this.Event.Value
-                          Schema = this.Schema
-                          Object = this.Object
-                          TSQL = this.TSQL.Value }
-
-                    Some record
-                | None -> None
 
         let DatabaseLog = leftTable<``DatabaseLog (base)``, DatabaseLog>
 
@@ -4716,25 +3654,6 @@ module dbo =
               ErrorMessage: Option<string> }
 
             interface ILeftViewOf<``ErrorLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ErrorLog (base)`` option =
-                match this.ErrorLogID with
-                | Some value ->
-                    let record: ``ErrorLog (base)`` =
-                        { ErrorLogID = value
-                          ErrorTime = this.ErrorTime.Value
-                          UserName = this.UserName.Value
-                          ErrorNumber = this.ErrorNumber.Value
-                          ErrorSeverity = this.ErrorSeverity
-                          ErrorState = this.ErrorState
-                          ErrorProcedure = this.ErrorProcedure
-                          ErrorLine = this.ErrorLine
-                          ErrorMessage = this.ErrorMessage.Value }
-
-                    Some record
-                | None -> None
 
         let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
 
@@ -4819,17 +3738,6 @@ module ext =
 
             interface ILeftViewOf<``DateTime2Support (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``DateTime2Support (base)`` option =
-                match this.ID with
-                | Some value ->
-                    let record: ``DateTime2Support (base)`` =
-                        { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
-
-                    Some record
-                | None -> None
-
         let DateTime2Support = leftTable<``DateTime2Support (base)``, DateTime2Support>
 
         type private ``GetIdGuidRepro (base)`` = GetIdGuidRepro
@@ -4843,17 +3751,6 @@ module ext =
 
             interface ILeftViewOf<``GetIdGuidRepro (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``GetIdGuidRepro (base)`` option =
-                match this.Id with
-                | Some value ->
-                    let record: ``GetIdGuidRepro (base)`` =
-                        { Id = value; EmailAddress = this.EmailAddress.Value }
-
-                    Some record
-                | None -> None
-
         let GetIdGuidRepro = leftTable<``GetIdGuidRepro (base)``, GetIdGuidRepro>
 
         type private ``HierarchyIdSupport (base)`` = HierarchyIdSupport
@@ -4866,17 +3763,6 @@ module ext =
               Hierarchy: Option<Microsoft.SqlServer.Types.SqlHierarchyId> }
 
             interface ILeftViewOf<``HierarchyIdSupport (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``HierarchyIdSupport (base)`` option =
-                match this.Id with
-                | Some value ->
-                    let record: ``HierarchyIdSupport (base)`` =
-                        { Id = value; Hierarchy = this.Hierarchy.Value }
-
-                    Some record
-                | None -> None
 
         let HierarchyIdSupport =
             leftTable<``HierarchyIdSupport (base)``, HierarchyIdSupport>
@@ -4894,18 +3780,1206 @@ module ext =
 
             interface ILeftViewOf<``NullableKeyUpsert (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``NullableKeyUpsert (base)`` option =
-                match this.Key1 with
-                | Some value ->
-                    let record: ``NullableKeyUpsert (base)`` =
-                        { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
-
-                    Some record
-                | None -> None
-
         let NullableKeyUpsert = leftTable<``NullableKeyUpsert (base)``, NullableKeyUpsert>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type HumanResources.LeftJoined.Department with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Department option =
+            match this.DepartmentID with
+            | Some value ->
+                let record: HumanResources.Department =
+                    { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.Employee with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Employee option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.Employee =
+                    { BusinessEntityID = value
+                      NationalIDNumber = this.NationalIDNumber.Value
+                      LoginID = this.LoginID.Value
+                      OrganizationNode = this.OrganizationNode
+                      OrganizationLevel = this.OrganizationLevel
+                      JobTitle = this.JobTitle.Value
+                      BirthDate = this.BirthDate.Value
+                      MaritalStatus = this.MaritalStatus.Value
+                      Gender = this.Gender.Value
+                      HireDate = this.HireDate.Value
+                      SalariedFlag = this.SalariedFlag.Value
+                      VacationHours = this.VacationHours.Value
+                      SickLeaveHours = this.SickLeaveHours.Value
+                      CurrentFlag = this.CurrentFlag.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.EmployeeDepartmentHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.EmployeeDepartmentHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.EmployeeDepartmentHistory =
+                    { BusinessEntityID = value
+                      DepartmentID = this.DepartmentID.Value
+                      ShiftID = this.ShiftID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.EmployeePayHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.EmployeePayHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.EmployeePayHistory =
+                    { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.JobCandidate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.JobCandidate option =
+            match this.JobCandidateID with
+            | Some value ->
+                let record: HumanResources.JobCandidate =
+                    { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.Shift with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Shift option =
+            match this.ShiftID with
+            | Some value ->
+                let record: HumanResources.Shift =
+                    { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Address option =
+            match this.AddressID with
+            | Some value ->
+                let record: Person.Address =
+                    { AddressID = value
+                      AddressLine1 = this.AddressLine1.Value
+                      AddressLine2 = this.AddressLine2
+                      City = this.City.Value
+                      StateProvinceID = this.StateProvinceID.Value
+                      PostalCode = this.PostalCode.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.AddressType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.AddressType option =
+            match this.AddressTypeID with
+            | Some value ->
+                let record: Person.AddressType =
+                    { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntity with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntity option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntity =
+                    { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntityAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntityAddress option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntityAddress =
+                    { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntityContact with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntityContact option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntityContact =
+                    { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.ContactType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.ContactType option =
+            match this.ContactTypeID with
+            | Some value ->
+                let record: Person.ContactType =
+                    { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.CountryRegion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.CountryRegion option =
+            match this.CountryRegionCode with
+            | Some value ->
+                let record: Person.CountryRegion =
+                    { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.EmailAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.EmailAddress option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.EmailAddress =
+                    { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Password with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Password option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.Password =
+                    { BusinessEntityID = value; PasswordHash = this.PasswordHash.Value; PasswordSalt = this.PasswordSalt.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Person option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.Person =
+                    { BusinessEntityID = value
+                      PersonType = this.PersonType.Value
+                      NameStyle = this.NameStyle.Value
+                      Title = this.Title
+                      FirstName = this.FirstName.Value
+                      MiddleName = this.MiddleName
+                      LastName = this.LastName.Value
+                      Suffix = this.Suffix
+                      EmailPromotion = this.EmailPromotion.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.PersonPhone with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.PersonPhone option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.PersonPhone =
+                    { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.PhoneNumberType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.PhoneNumberType option =
+            match this.PhoneNumberTypeID with
+            | Some value ->
+                let record: Person.PhoneNumberType =
+                    { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.StateProvince with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.StateProvince option =
+            match this.StateProvinceID with
+            | Some value ->
+                let record: Person.StateProvince =
+                    { StateProvinceID = value
+                      StateProvinceCode = this.StateProvinceCode.Value
+                      CountryRegionCode = this.CountryRegionCode.Value
+                      IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
+                      Name = this.Name.Value
+                      TerritoryID = this.TerritoryID.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.BillOfMaterials with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.BillOfMaterials option =
+            match this.BillOfMaterialsID with
+            | Some value ->
+                let record: Production.BillOfMaterials =
+                    { BillOfMaterialsID = value
+                      ProductAssemblyID = this.ProductAssemblyID
+                      ComponentID = this.ComponentID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      UnitMeasureCode = this.UnitMeasureCode.Value
+                      BOMLevel = this.BOMLevel.Value
+                      PerAssemblyQty = this.PerAssemblyQty.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Culture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Culture option =
+            match this.CultureID with
+            | Some value ->
+                let record: Production.Culture =
+                    { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Document with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Document option =
+            match this.DocumentNode with
+            | Some value ->
+                let record: Production.Document =
+                    { DocumentNode = value
+                      DocumentLevel = this.DocumentLevel
+                      Title = this.Title.Value
+                      Owner = this.Owner.Value
+                      FolderFlag = this.FolderFlag.Value
+                      FileName = this.FileName.Value
+                      FileExtension = this.FileExtension.Value
+                      Revision = this.Revision.Value
+                      ChangeNumber = this.ChangeNumber.Value
+                      Status = this.Status.Value
+                      DocumentSummary = this.DocumentSummary
+                      Document = this.Document
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Illustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Illustration option =
+            match this.IllustrationID with
+            | Some value ->
+                let record: Production.Illustration =
+                    { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Location with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Location option =
+            match this.LocationID with
+            | Some value ->
+                let record: Production.Location =
+                    { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Product option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.Product =
+                    { ProductID = value
+                      Name = this.Name.Value
+                      ProductNumber = this.ProductNumber.Value
+                      MakeFlag = this.MakeFlag.Value
+                      FinishedGoodsFlag = this.FinishedGoodsFlag.Value
+                      Color = this.Color
+                      SafetyStockLevel = this.SafetyStockLevel.Value
+                      ReorderPoint = this.ReorderPoint.Value
+                      StandardCost = this.StandardCost.Value
+                      ListPrice = this.ListPrice.Value
+                      Size = this.Size
+                      SizeUnitMeasureCode = this.SizeUnitMeasureCode
+                      WeightUnitMeasureCode = this.WeightUnitMeasureCode
+                      Weight = this.Weight
+                      DaysToManufacture = this.DaysToManufacture.Value
+                      ProductLine = this.ProductLine
+                      Class = this.Class
+                      Style = this.Style
+                      ProductSubcategoryID = this.ProductSubcategoryID
+                      ProductModelID = this.ProductModelID
+                      SellStartDate = this.SellStartDate.Value
+                      SellEndDate = this.SellEndDate
+                      DiscontinuedDate = this.DiscontinuedDate
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductCategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductCategory option =
+            match this.ProductCategoryID with
+            | Some value ->
+                let record: Production.ProductCategory =
+                    { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductCostHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductCostHistory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductCostHistory =
+                    { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductDescription option =
+            match this.ProductDescriptionID with
+            | Some value ->
+                let record: Production.ProductDescription =
+                    { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductDocument with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductDocument option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductDocument =
+                    { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductInventory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductInventory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductInventory =
+                    { ProductID = value
+                      LocationID = this.LocationID.Value
+                      Shelf = this.Shelf.Value
+                      Bin = this.Bin.Value
+                      Quantity = this.Quantity.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductListPriceHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductListPriceHistory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductListPriceHistory =
+                    { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModel option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModel =
+                    { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModelIllustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModelIllustration option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModelIllustration =
+                    { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModelProductDescriptionCulture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModelProductDescriptionCulture option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModelProductDescriptionCulture =
+                    { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductPhoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductPhoto option =
+            match this.ProductPhotoID with
+            | Some value ->
+                let record: Production.ProductPhoto =
+                    { ProductPhotoID = value
+                      ThumbNailPhoto = this.ThumbNailPhoto
+                      ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                      LargePhoto = this.LargePhoto
+                      LargePhotoFileName = this.LargePhotoFileName
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductProductPhoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductProductPhoto option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductProductPhoto =
+                    { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductReview with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductReview option =
+            match this.ProductReviewID with
+            | Some value ->
+                let record: Production.ProductReview =
+                    { ProductReviewID = value
+                      ProductID = this.ProductID.Value
+                      ReviewerName = this.ReviewerName.Value
+                      ReviewDate = this.ReviewDate.Value
+                      EmailAddress = this.EmailAddress.Value
+                      Rating = this.Rating.Value
+                      Comments = this.Comments
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductSubcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductSubcategory option =
+            match this.ProductSubcategoryID with
+            | Some value ->
+                let record: Production.ProductSubcategory =
+                    { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ScrapReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ScrapReason option =
+            match this.ScrapReasonID with
+            | Some value ->
+                let record: Production.ScrapReason =
+                    { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.TransactionHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.TransactionHistory option =
+            match this.TransactionID with
+            | Some value ->
+                let record: Production.TransactionHistory =
+                    { TransactionID = value
+                      ProductID = this.ProductID.Value
+                      ReferenceOrderID = this.ReferenceOrderID.Value
+                      ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                      TransactionDate = this.TransactionDate.Value
+                      TransactionType = this.TransactionType.Value
+                      Quantity = this.Quantity.Value
+                      ActualCost = this.ActualCost.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.TransactionHistoryArchive with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.TransactionHistoryArchive option =
+            match this.TransactionID with
+            | Some value ->
+                let record: Production.TransactionHistoryArchive =
+                    { TransactionID = value
+                      ProductID = this.ProductID.Value
+                      ReferenceOrderID = this.ReferenceOrderID.Value
+                      ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                      TransactionDate = this.TransactionDate.Value
+                      TransactionType = this.TransactionType.Value
+                      Quantity = this.Quantity.Value
+                      ActualCost = this.ActualCost.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.UnitMeasure with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.UnitMeasure option =
+            match this.UnitMeasureCode with
+            | Some value ->
+                let record: Production.UnitMeasure =
+                    { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.WorkOrder with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.WorkOrder option =
+            match this.WorkOrderID with
+            | Some value ->
+                let record: Production.WorkOrder =
+                    { WorkOrderID = value
+                      ProductID = this.ProductID.Value
+                      OrderQty = this.OrderQty.Value
+                      StockedQty = this.StockedQty.Value
+                      ScrappedQty = this.ScrappedQty.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      DueDate = this.DueDate.Value
+                      ScrapReasonID = this.ScrapReasonID
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.WorkOrderRouting with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.WorkOrderRouting option =
+            match this.WorkOrderID with
+            | Some value ->
+                let record: Production.WorkOrderRouting =
+                    { WorkOrderID = value
+                      ProductID = this.ProductID.Value
+                      OperationSequence = this.OperationSequence.Value
+                      LocationID = this.LocationID.Value
+                      ScheduledStartDate = this.ScheduledStartDate.Value
+                      ScheduledEndDate = this.ScheduledEndDate.Value
+                      ActualStartDate = this.ActualStartDate
+                      ActualEndDate = this.ActualEndDate
+                      ActualResourceHrs = this.ActualResourceHrs
+                      PlannedCost = this.PlannedCost.Value
+                      ActualCost = this.ActualCost
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.ProductVendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.ProductVendor option =
+            match this.ProductID with
+            | Some value ->
+                let record: Purchasing.ProductVendor =
+                    { ProductID = value
+                      BusinessEntityID = this.BusinessEntityID.Value
+                      AverageLeadTime = this.AverageLeadTime.Value
+                      StandardPrice = this.StandardPrice.Value
+                      LastReceiptCost = this.LastReceiptCost
+                      LastReceiptDate = this.LastReceiptDate
+                      MinOrderQty = this.MinOrderQty.Value
+                      MaxOrderQty = this.MaxOrderQty.Value
+                      OnOrderQty = this.OnOrderQty
+                      UnitMeasureCode = this.UnitMeasureCode.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.PurchaseOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.PurchaseOrderDetail option =
+            match this.PurchaseOrderID with
+            | Some value ->
+                let record: Purchasing.PurchaseOrderDetail =
+                    { PurchaseOrderID = value
+                      PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
+                      DueDate = this.DueDate.Value
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      LineTotal = this.LineTotal.Value
+                      ReceivedQty = this.ReceivedQty.Value
+                      RejectedQty = this.RejectedQty.Value
+                      StockedQty = this.StockedQty.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.PurchaseOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.PurchaseOrderHeader option =
+            match this.PurchaseOrderID with
+            | Some value ->
+                let record: Purchasing.PurchaseOrderHeader =
+                    { PurchaseOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      Status = this.Status.Value
+                      EmployeeID = this.EmployeeID.Value
+                      VendorID = this.VendorID.Value
+                      ShipMethodID = this.ShipMethodID.Value
+                      OrderDate = this.OrderDate.Value
+                      ShipDate = this.ShipDate
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.ShipMethod with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.ShipMethod option =
+            match this.ShipMethodID with
+            | Some value ->
+                let record: Purchasing.ShipMethod =
+                    { ShipMethodID = value
+                      Name = this.Name.Value
+                      ShipBase = this.ShipBase.Value
+                      ShipRate = this.ShipRate.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.Vendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.Vendor option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Purchasing.Vendor =
+                    { BusinessEntityID = value
+                      AccountNumber = this.AccountNumber.Value
+                      Name = this.Name.Value
+                      CreditRating = this.CreditRating.Value
+                      PreferredVendorStatus = this.PreferredVendorStatus.Value
+                      ActiveFlag = this.ActiveFlag.Value
+                      PurchasingWebServiceURL = this.PurchasingWebServiceURL
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CountryRegionCurrency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CountryRegionCurrency option =
+            match this.CountryRegionCode with
+            | Some value ->
+                let record: Sales.CountryRegionCurrency =
+                    { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CreditCard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CreditCard option =
+            match this.CreditCardID with
+            | Some value ->
+                let record: Sales.CreditCard =
+                    { CreditCardID = value
+                      CardType = this.CardType.Value
+                      CardNumber = this.CardNumber.Value
+                      ExpMonth = this.ExpMonth.Value
+                      ExpYear = this.ExpYear.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Currency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Currency option =
+            match this.CurrencyCode with
+            | Some value ->
+                let record: Sales.Currency =
+                    { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CurrencyRate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CurrencyRate option =
+            match this.CurrencyRateID with
+            | Some value ->
+                let record: Sales.CurrencyRate =
+                    { CurrencyRateID = value
+                      CurrencyRateDate = this.CurrencyRateDate.Value
+                      FromCurrencyCode = this.FromCurrencyCode.Value
+                      ToCurrencyCode = this.ToCurrencyCode.Value
+                      AverageRate = this.AverageRate.Value
+                      EndOfDayRate = this.EndOfDayRate.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Customer option =
+            match this.CustomerID with
+            | Some value ->
+                let record: Sales.Customer =
+                    { CustomerID = value
+                      PersonID = this.PersonID
+                      StoreID = this.StoreID
+                      TerritoryID = this.TerritoryID
+                      AccountNumber = this.AccountNumber.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.PersonCreditCard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.PersonCreditCard option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.PersonCreditCard =
+                    { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderDetail option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderDetail =
+                    { SalesOrderID = value
+                      SalesOrderDetailID = this.SalesOrderDetailID.Value
+                      CarrierTrackingNumber = this.CarrierTrackingNumber
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      SpecialOfferID = this.SpecialOfferID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      UnitPriceDiscount = this.UnitPriceDiscount.Value
+                      LineTotal = this.LineTotal.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderHeader option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderHeader =
+                    { SalesOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      OrderDate = this.OrderDate.Value
+                      DueDate = this.DueDate.Value
+                      ShipDate = this.ShipDate
+                      Status = this.Status.Value
+                      OnlineOrderFlag = this.OnlineOrderFlag.Value
+                      SalesOrderNumber = this.SalesOrderNumber.Value
+                      PurchaseOrderNumber = this.PurchaseOrderNumber
+                      AccountNumber = this.AccountNumber
+                      CustomerID = this.CustomerID.Value
+                      SalesPersonID = this.SalesPersonID
+                      TerritoryID = this.TerritoryID
+                      BillToAddressID = this.BillToAddressID.Value
+                      ShipToAddressID = this.ShipToAddressID.Value
+                      ShipMethodID = this.ShipMethodID.Value
+                      CreditCardID = this.CreditCardID
+                      CreditCardApprovalCode = this.CreditCardApprovalCode
+                      CurrencyRateID = this.CurrencyRateID
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      Comment = this.Comment
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderHeaderSalesReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderHeaderSalesReason option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderHeaderSalesReason =
+                    { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesPerson with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesPerson option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesPerson =
+                    { BusinessEntityID = value
+                      TerritoryID = this.TerritoryID
+                      SalesQuota = this.SalesQuota
+                      Bonus = this.Bonus.Value
+                      CommissionPct = this.CommissionPct.Value
+                      SalesYTD = this.SalesYTD.Value
+                      SalesLastYear = this.SalesLastYear.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesPersonQuotaHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesPersonQuotaHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesPersonQuotaHistory =
+                    { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesReason option =
+            match this.SalesReasonID with
+            | Some value ->
+                let record: Sales.SalesReason =
+                    { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTaxRate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTaxRate option =
+            match this.SalesTaxRateID with
+            | Some value ->
+                let record: Sales.SalesTaxRate =
+                    { SalesTaxRateID = value
+                      StateProvinceID = this.StateProvinceID.Value
+                      TaxType = this.TaxType.Value
+                      TaxRate = this.TaxRate.Value
+                      Name = this.Name.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTerritory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTerritory option =
+            match this.TerritoryID with
+            | Some value ->
+                let record: Sales.SalesTerritory =
+                    { TerritoryID = value
+                      Name = this.Name.Value
+                      CountryRegionCode = this.CountryRegionCode.Value
+                      Group = this.Group.Value
+                      SalesYTD = this.SalesYTD.Value
+                      SalesLastYear = this.SalesLastYear.Value
+                      CostYTD = this.CostYTD.Value
+                      CostLastYear = this.CostLastYear.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTerritoryHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTerritoryHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesTerritoryHistory =
+                    { BusinessEntityID = value
+                      TerritoryID = this.TerritoryID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.ShoppingCartItem with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.ShoppingCartItem option =
+            match this.ShoppingCartItemID with
+            | Some value ->
+                let record: Sales.ShoppingCartItem =
+                    { ShoppingCartItemID = value
+                      ShoppingCartID = this.ShoppingCartID.Value
+                      Quantity = this.Quantity.Value
+                      ProductID = this.ProductID.Value
+                      DateCreated = this.DateCreated.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SpecialOffer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SpecialOffer option =
+            match this.SpecialOfferID with
+            | Some value ->
+                let record: Sales.SpecialOffer =
+                    { SpecialOfferID = value
+                      Description = this.Description.Value
+                      DiscountPct = this.DiscountPct.Value
+                      Type = this.Type.Value
+                      Category = this.Category.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate.Value
+                      MinQty = this.MinQty.Value
+                      MaxQty = this.MaxQty
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SpecialOfferProduct with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SpecialOfferProduct option =
+            match this.SpecialOfferID with
+            | Some value ->
+                let record: Sales.SpecialOfferProduct =
+                    { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Store with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Store option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.Store =
+                    { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.AWBuildVersion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.AWBuildVersion option =
+            match this.SystemInformationID with
+            | Some value ->
+                let record: dbo.AWBuildVersion =
+                    { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.DatabaseLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.DatabaseLog option =
+            match this.DatabaseLogID with
+            | Some value ->
+                let record: dbo.DatabaseLog =
+                    { DatabaseLogID = value
+                      PostTime = this.PostTime.Value
+                      DatabaseUser = this.DatabaseUser.Value
+                      Event = this.Event.Value
+                      Schema = this.Schema
+                      Object = this.Object
+                      TSQL = this.TSQL.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.ErrorLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.ErrorLog option =
+            match this.ErrorLogID with
+            | Some value ->
+                let record: dbo.ErrorLog =
+                    { ErrorLogID = value
+                      ErrorTime = this.ErrorTime.Value
+                      UserName = this.UserName.Value
+                      ErrorNumber = this.ErrorNumber.Value
+                      ErrorSeverity = this.ErrorSeverity
+                      ErrorState = this.ErrorState
+                      ErrorProcedure = this.ErrorProcedure
+                      ErrorLine = this.ErrorLine
+                      ErrorMessage = this.ErrorMessage.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.DateTime2Support with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.DateTime2Support option =
+            match this.ID with
+            | Some value ->
+                let record: ext.DateTime2Support =
+                    { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.GetIdGuidRepro with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.GetIdGuidRepro option =
+            match this.Id with
+            | Some value ->
+                let record: ext.GetIdGuidRepro =
+                    { Id = value; EmailAddress = this.EmailAddress.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.HierarchyIdSupport with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.HierarchyIdSupport option =
+            match this.Id with
+            | Some value ->
+                let record: ext.HierarchyIdSupport =
+                    { Id = value; Hierarchy = this.Hierarchy.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.NullableKeyUpsert with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.NullableKeyUpsert option =
+            match this.Key1 with
+            | Some value ->
+                let record: ext.NullableKeyUpsert =
+                    { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/SqlServer/AdventureWorksNet9.fs
+++ b/src/Tests/SqlServer/AdventureWorksNet9.fs
@@ -176,6 +176,230 @@ module HumanResources =
 
     let Shift = table<Shift>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Department (base)`` = Department
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Department =
+            { [<ProviderDbType("SmallInt")>]
+              DepartmentID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              GroupName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Department (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Department (base)`` option =
+                match this.DepartmentID with
+                | Some value ->
+                    let record: ``Department (base)`` =
+                        { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Department = leftTable<``Department (base)``, Department>
+
+        type private ``Employee (base)`` = Employee
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Employee =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              NationalIDNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              LoginID: Option<string>
+              [<ProviderDbType("SqlHierarchyId")>]
+              OrganizationNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("SmallInt")>]
+              OrganizationLevel: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              JobTitle: Option<string>
+              [<ProviderDbType("Date")>]
+              BirthDate: Option<System.DateOnly>
+              [<ProviderDbType("NChar")>]
+              MaritalStatus: Option<string>
+              [<ProviderDbType("NChar")>]
+              Gender: Option<string>
+              [<ProviderDbType("Date")>]
+              HireDate: Option<System.DateOnly>
+              [<ProviderDbType("Bit")>]
+              SalariedFlag: Option<bool>
+              [<ProviderDbType("SmallInt")>]
+              VacationHours: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              SickLeaveHours: Option<int16>
+              [<ProviderDbType("Bit")>]
+              CurrentFlag: Option<bool>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Employee (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Employee (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Employee (base)`` =
+                        { BusinessEntityID = value
+                          NationalIDNumber = this.NationalIDNumber.Value
+                          LoginID = this.LoginID.Value
+                          OrganizationNode = this.OrganizationNode
+                          OrganizationLevel = this.OrganizationLevel
+                          JobTitle = this.JobTitle.Value
+                          BirthDate = this.BirthDate.Value
+                          MaritalStatus = this.MaritalStatus.Value
+                          Gender = this.Gender.Value
+                          HireDate = this.HireDate.Value
+                          SalariedFlag = this.SalariedFlag.Value
+                          VacationHours = this.VacationHours.Value
+                          SickLeaveHours = this.SickLeaveHours.Value
+                          CurrentFlag = this.CurrentFlag.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Employee = leftTable<``Employee (base)``, Employee>
+
+        type private ``EmployeeDepartmentHistory (base)`` = EmployeeDepartmentHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmployeeDepartmentHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              DepartmentID: Option<int16>
+              [<ProviderDbType("TinyInt")>]
+              ShiftID: Option<byte>
+              [<ProviderDbType("Date")>]
+              StartDate: Option<System.DateOnly>
+              [<ProviderDbType("Date")>]
+              EndDate: Option<System.DateOnly>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmployeeDepartmentHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmployeeDepartmentHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmployeeDepartmentHistory (base)`` =
+                        { BusinessEntityID = value
+                          DepartmentID = this.DepartmentID.Value
+                          ShiftID = this.ShiftID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmployeeDepartmentHistory =
+            leftTable<``EmployeeDepartmentHistory (base)``, EmployeeDepartmentHistory>
+
+        type private ``EmployeePayHistory (base)`` = EmployeePayHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmployeePayHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              RateChangeDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              Rate: Option<decimal>
+              [<ProviderDbType("TinyInt")>]
+              PayFrequency: Option<byte>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmployeePayHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmployeePayHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmployeePayHistory (base)`` =
+                        { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmployeePayHistory =
+            leftTable<``EmployeePayHistory (base)``, EmployeePayHistory>
+
+        type private ``JobCandidate (base)`` = JobCandidate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type JobCandidate =
+            { [<ProviderDbType("Int")>]
+              JobCandidateID: Option<int>
+              [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``JobCandidate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``JobCandidate (base)`` option =
+                match this.JobCandidateID with
+                | Some value ->
+                    let record: ``JobCandidate (base)`` =
+                        { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let JobCandidate = leftTable<``JobCandidate (base)``, JobCandidate>
+
+        type private ``Shift (base)`` = Shift
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Shift =
+            { [<ProviderDbType("TinyInt")>]
+              ShiftID: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Time")>]
+              StartTime: Option<System.TimeOnly>
+              [<ProviderDbType("Time")>]
+              EndTime: Option<System.TimeOnly>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Shift (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Shift (base)`` option =
+                match this.ShiftID with
+                | Some value ->
+                    let record: ``Shift (base)`` =
+                        { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Shift = leftTable<``Shift (base)``, Shift>
+
+
 module Person =
 
     [<CLIMutable>]
@@ -482,6 +706,434 @@ module Person =
                   { WriteColumn.Name = "ModifiedDate"; Value = box this.ModifiedDate; ProviderDbType = Some "DateTime" } ]
 
     let StateProvince = table<StateProvince>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Address (base)`` = Address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Address =
+            { [<ProviderDbType("Int")>]
+              AddressID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              AddressLine1: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              AddressLine2: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              City: Option<string>
+              [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              PostalCode: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Address (base)`` option =
+                match this.AddressID with
+                | Some value ->
+                    let record: ``Address (base)`` =
+                        { AddressID = value
+                          AddressLine1 = this.AddressLine1.Value
+                          AddressLine2 = this.AddressLine2
+                          City = this.City.Value
+                          StateProvinceID = this.StateProvinceID.Value
+                          PostalCode = this.PostalCode.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Address = leftTable<``Address (base)``, Address>
+
+        type private ``AddressType (base)`` = AddressType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type AddressType =
+            { [<ProviderDbType("Int")>]
+              AddressTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``AddressType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``AddressType (base)`` option =
+                match this.AddressTypeID with
+                | Some value ->
+                    let record: ``AddressType (base)`` =
+                        { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let AddressType = leftTable<``AddressType (base)``, AddressType>
+
+        type private ``BusinessEntity (base)`` = BusinessEntity
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntity =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntity (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntity (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntity (base)`` =
+                        { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntity = leftTable<``BusinessEntity (base)``, BusinessEntity>
+
+        type private ``BusinessEntityAddress (base)`` = BusinessEntityAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntityAddress =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              AddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              AddressTypeID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntityAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntityAddress (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntityAddress (base)`` =
+                        { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntityAddress =
+            leftTable<``BusinessEntityAddress (base)``, BusinessEntityAddress>
+
+        type private ``BusinessEntityContact (base)`` = BusinessEntityContact
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BusinessEntityContact =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              PersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              ContactTypeID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BusinessEntityContact (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BusinessEntityContact (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``BusinessEntityContact (base)`` =
+                        { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BusinessEntityContact =
+            leftTable<``BusinessEntityContact (base)``, BusinessEntityContact>
+
+        type private ``ContactType (base)`` = ContactType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ContactType =
+            { [<ProviderDbType("Int")>]
+              ContactTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ContactType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ContactType (base)`` option =
+                match this.ContactTypeID with
+                | Some value ->
+                    let record: ``ContactType (base)`` =
+                        { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ContactType = leftTable<``ContactType (base)``, ContactType>
+
+        type private ``CountryRegion (base)`` = CountryRegion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CountryRegion =
+            { [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CountryRegion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CountryRegion (base)`` option =
+                match this.CountryRegionCode with
+                | Some value ->
+                    let record: ``CountryRegion (base)`` =
+                        { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CountryRegion = leftTable<``CountryRegion (base)``, CountryRegion>
+
+        type private ``EmailAddress (base)`` = EmailAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type EmailAddress =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              EmailAddressID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              EmailAddress: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``EmailAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``EmailAddress (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``EmailAddress (base)`` =
+                        { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let EmailAddress = leftTable<``EmailAddress (base)``, EmailAddress>
+
+        type private ``Password (base)`` = Password
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Password =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              PasswordHash: Option<string>
+              [<ProviderDbType("VarChar")>]
+              PasswordSalt: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Password (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Password (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Password (base)`` =
+                        { BusinessEntityID = value
+                          PasswordHash = this.PasswordHash.Value
+                          PasswordSalt = this.PasswordSalt.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Password = leftTable<``Password (base)``, Password>
+
+        type private ``Person (base)`` = Person
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Person =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NChar")>]
+              PersonType: Option<string>
+              [<ProviderDbType("Bit")>]
+              NameStyle: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Title: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              FirstName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              MiddleName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              LastName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Suffix: Option<string>
+              [<ProviderDbType("Int")>]
+              EmailPromotion: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Person (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Person (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Person (base)`` =
+                        { BusinessEntityID = value
+                          PersonType = this.PersonType.Value
+                          NameStyle = this.NameStyle.Value
+                          Title = this.Title
+                          FirstName = this.FirstName.Value
+                          MiddleName = this.MiddleName
+                          LastName = this.LastName.Value
+                          Suffix = this.Suffix
+                          EmailPromotion = this.EmailPromotion.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Person = leftTable<``Person (base)``, Person>
+
+        type private ``PersonPhone (base)`` = PersonPhone
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PersonPhone =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              PhoneNumber: Option<string>
+              [<ProviderDbType("Int")>]
+              PhoneNumberTypeID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PersonPhone (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PersonPhone (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``PersonPhone (base)`` =
+                        { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PersonPhone = leftTable<``PersonPhone (base)``, PersonPhone>
+
+        type private ``PhoneNumberType (base)`` = PhoneNumberType
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PhoneNumberType =
+            { [<ProviderDbType("Int")>]
+              PhoneNumberTypeID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PhoneNumberType (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PhoneNumberType (base)`` option =
+                match this.PhoneNumberTypeID with
+                | Some value ->
+                    let record: ``PhoneNumberType (base)`` =
+                        { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PhoneNumberType = leftTable<``PhoneNumberType (base)``, PhoneNumberType>
+
+        type private ``StateProvince (base)`` = StateProvince
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type StateProvince =
+            { [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("NChar")>]
+              StateProvinceCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("Bit")>]
+              IsOnlyStateProvinceFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``StateProvince (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``StateProvince (base)`` option =
+                match this.StateProvinceID with
+                | Some value ->
+                    let record: ``StateProvince (base)`` =
+                        { StateProvinceID = value
+                          StateProvinceCode = this.StateProvinceCode.Value
+                          CountryRegionCode = this.CountryRegionCode.Value
+                          IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
+                          Name = this.Name.Value
+                          TerritoryID = this.TerritoryID.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let StateProvince = leftTable<``StateProvince (base)``, StateProvince>
+
 
 module Production =
 
@@ -1184,6 +1836,950 @@ module Production =
 
     let WorkOrderRouting = table<WorkOrderRouting>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``BillOfMaterials (base)`` = BillOfMaterials
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BillOfMaterials =
+            { [<ProviderDbType("Int")>]
+              BillOfMaterialsID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductAssemblyID: Option<int>
+              [<ProviderDbType("Int")>]
+              ComponentID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              BOMLevel: Option<int16>
+              [<ProviderDbType("Decimal")>]
+              PerAssemblyQty: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BillOfMaterials (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BillOfMaterials (base)`` option =
+                match this.BillOfMaterialsID with
+                | Some value ->
+                    let record: ``BillOfMaterials (base)`` =
+                        { BillOfMaterialsID = value
+                          ProductAssemblyID = this.ProductAssemblyID
+                          ComponentID = this.ComponentID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          UnitMeasureCode = this.UnitMeasureCode.Value
+                          BOMLevel = this.BOMLevel.Value
+                          PerAssemblyQty = this.PerAssemblyQty.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BillOfMaterials = leftTable<``BillOfMaterials (base)``, BillOfMaterials>
+
+        type private ``Culture (base)`` = Culture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Culture =
+            { [<ProviderDbType("NChar")>]
+              CultureID: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Culture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Culture (base)`` option =
+                match this.CultureID with
+                | Some value ->
+                    let record: ``Culture (base)`` =
+                        { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Culture = leftTable<``Culture (base)``, Culture>
+
+        type private ``Document (base)`` = Document
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Document =
+            { [<ProviderDbType("SqlHierarchyId")>]
+              DocumentNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("SmallInt")>]
+              DocumentLevel: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Title: Option<string>
+              [<ProviderDbType("Int")>]
+              Owner: Option<int>
+              [<ProviderDbType("Bit")>]
+              FolderFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              FileName: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              FileExtension: Option<string>
+              [<ProviderDbType("NChar")>]
+              Revision: Option<string>
+              [<ProviderDbType("Int")>]
+              ChangeNumber: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              DocumentSummary: Option<string>
+              [<ProviderDbType("VarBinary")>]
+              Document: Option<byte[]>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Document (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Document (base)`` option =
+                match this.DocumentNode with
+                | Some value ->
+                    let record: ``Document (base)`` =
+                        { DocumentNode = value
+                          DocumentLevel = this.DocumentLevel
+                          Title = this.Title.Value
+                          Owner = this.Owner.Value
+                          FolderFlag = this.FolderFlag.Value
+                          FileName = this.FileName.Value
+                          FileExtension = this.FileExtension.Value
+                          Revision = this.Revision.Value
+                          ChangeNumber = this.ChangeNumber.Value
+                          Status = this.Status.Value
+                          DocumentSummary = this.DocumentSummary
+                          Document = this.Document
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Document = leftTable<``Document (base)``, Document>
+
+        type private ``Illustration (base)`` = Illustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Illustration =
+            { [<ProviderDbType("Int")>]
+              IllustrationID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Illustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Illustration (base)`` option =
+                match this.IllustrationID with
+                | Some value ->
+                    let record: ``Illustration (base)`` =
+                        { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Illustration = leftTable<``Illustration (base)``, Illustration>
+
+        type private ``Location (base)`` = Location
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Location =
+            { [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("SmallMoney")>]
+              CostRate: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              Availability: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Location (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Location (base)`` option =
+                match this.LocationID with
+                | Some value ->
+                    let record: ``Location (base)`` =
+                        { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Location = leftTable<``Location (base)``, Location>
+
+        type private ``Product (base)`` = Product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Product =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              ProductNumber: Option<string>
+              [<ProviderDbType("Bit")>]
+              MakeFlag: Option<bool>
+              [<ProviderDbType("Bit")>]
+              FinishedGoodsFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              Color: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              SafetyStockLevel: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              ReorderPoint: Option<int16>
+              [<ProviderDbType("Money")>]
+              StandardCost: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ListPrice: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Size: Option<string>
+              [<ProviderDbType("NChar")>]
+              SizeUnitMeasureCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              WeightUnitMeasureCode: Option<string>
+              [<ProviderDbType("Decimal")>]
+              Weight: Option<decimal>
+              [<ProviderDbType("Int")>]
+              DaysToManufacture: Option<int>
+              [<ProviderDbType("NChar")>]
+              ProductLine: Option<string>
+              [<ProviderDbType("NChar")>]
+              Class: Option<string>
+              [<ProviderDbType("NChar")>]
+              Style: Option<string>
+              [<ProviderDbType("Int")>]
+              ProductSubcategoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              SellStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              SellEndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DiscontinuedDate: Option<System.DateTime>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Product (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``Product (base)`` =
+                        { ProductID = value
+                          Name = this.Name.Value
+                          ProductNumber = this.ProductNumber.Value
+                          MakeFlag = this.MakeFlag.Value
+                          FinishedGoodsFlag = this.FinishedGoodsFlag.Value
+                          Color = this.Color
+                          SafetyStockLevel = this.SafetyStockLevel.Value
+                          ReorderPoint = this.ReorderPoint.Value
+                          StandardCost = this.StandardCost.Value
+                          ListPrice = this.ListPrice.Value
+                          Size = this.Size
+                          SizeUnitMeasureCode = this.SizeUnitMeasureCode
+                          WeightUnitMeasureCode = this.WeightUnitMeasureCode
+                          Weight = this.Weight
+                          DaysToManufacture = this.DaysToManufacture.Value
+                          ProductLine = this.ProductLine
+                          Class = this.Class
+                          Style = this.Style
+                          ProductSubcategoryID = this.ProductSubcategoryID
+                          ProductModelID = this.ProductModelID
+                          SellStartDate = this.SellStartDate.Value
+                          SellEndDate = this.SellEndDate
+                          DiscontinuedDate = this.DiscontinuedDate
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Product = leftTable<``Product (base)``, Product>
+
+        type private ``ProductCategory (base)`` = ProductCategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCategory =
+            { [<ProviderDbType("Int")>]
+              ProductCategoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCategory (base)`` option =
+                match this.ProductCategoryID with
+                | Some value ->
+                    let record: ``ProductCategory (base)`` =
+                        { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
+
+        type private ``ProductCostHistory (base)`` = ProductCostHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCostHistory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              StandardCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCostHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCostHistory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductCostHistory (base)`` =
+                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCostHistory =
+            leftTable<``ProductCostHistory (base)``, ProductCostHistory>
+
+        type private ``ProductDescription (base)`` = ProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDescription =
+            { [<ProviderDbType("Int")>]
+              ProductDescriptionID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Description: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDescription (base)`` option =
+                match this.ProductDescriptionID with
+                | Some value ->
+                    let record: ``ProductDescription (base)`` =
+                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDescription =
+            leftTable<``ProductDescription (base)``, ProductDescription>
+
+        type private ``ProductDocument (base)`` = ProductDocument
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDocument =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SqlHierarchyId")>]
+              DocumentNode: Option<Microsoft.SqlServer.Types.SqlHierarchyId>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDocument (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDocument (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductDocument (base)`` =
+                        { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDocument = leftTable<``ProductDocument (base)``, ProductDocument>
+
+        type private ``ProductInventory (base)`` = ProductInventory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductInventory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Shelf: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              Bin: Option<byte>
+              [<ProviderDbType("SmallInt")>]
+              Quantity: Option<int16>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductInventory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductInventory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductInventory (base)`` =
+                        { ProductID = value
+                          LocationID = this.LocationID.Value
+                          Shelf = this.Shelf.Value
+                          Bin = this.Bin.Value
+                          Quantity = this.Quantity.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductInventory = leftTable<``ProductInventory (base)``, ProductInventory>
+
+        type private ``ProductListPriceHistory (base)`` = ProductListPriceHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductListPriceHistory =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              ListPrice: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductListPriceHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductListPriceHistory (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductListPriceHistory (base)`` =
+                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductListPriceHistory =
+            leftTable<``ProductListPriceHistory (base)``, ProductListPriceHistory>
+
+        type private ``ProductModel (base)`` = ProductModel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModel =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModel (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModel (base)`` =
+                        { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
+
+        type private ``ProductModelIllustration (base)`` = ProductModelIllustration
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelIllustration =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("Int")>]
+              IllustrationID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelIllustration (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelIllustration (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelIllustration (base)`` =
+                        { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelIllustration =
+            leftTable<``ProductModelIllustration (base)``, ProductModelIllustration>
+
+        type private ``ProductModelProductDescriptionCulture (base)`` = ProductModelProductDescriptionCulture
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelProductDescriptionCulture =
+            { [<ProviderDbType("Int")>]
+              ProductModelID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductDescriptionID: Option<int>
+              [<ProviderDbType("NChar")>]
+              CultureID: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelProductDescriptionCulture (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelProductDescriptionCulture (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelProductDescriptionCulture (base)`` =
+                        { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelProductDescriptionCulture =
+            leftTable<``ProductModelProductDescriptionCulture (base)``, ProductModelProductDescriptionCulture>
+
+        type private ``ProductPhoto (base)`` = ProductPhoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductPhoto =
+            { [<ProviderDbType("Int")>]
+              ProductPhotoID: Option<int>
+              [<ProviderDbType("VarBinary")>]
+              ThumbNailPhoto: Option<byte[]>
+              [<ProviderDbType("NVarChar")>]
+              ThumbnailPhotoFileName: Option<string>
+              [<ProviderDbType("VarBinary")>]
+              LargePhoto: Option<byte[]>
+              [<ProviderDbType("NVarChar")>]
+              LargePhotoFileName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductPhoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductPhoto (base)`` option =
+                match this.ProductPhotoID with
+                | Some value ->
+                    let record: ``ProductPhoto (base)`` =
+                        { ProductPhotoID = value
+                          ThumbNailPhoto = this.ThumbNailPhoto
+                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                          LargePhoto = this.LargePhoto
+                          LargePhotoFileName = this.LargePhotoFileName
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductPhoto = leftTable<``ProductPhoto (base)``, ProductPhoto>
+
+        type private ``ProductProductPhoto (base)`` = ProductProductPhoto
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductProductPhoto =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductPhotoID: Option<int>
+              [<ProviderDbType("Bit")>]
+              Primary: Option<bool>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductProductPhoto (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductProductPhoto (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductProductPhoto (base)`` =
+                        { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductProductPhoto =
+            leftTable<``ProductProductPhoto (base)``, ProductProductPhoto>
+
+        type private ``ProductReview (base)`` = ProductReview
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductReview =
+            { [<ProviderDbType("Int")>]
+              ProductReviewID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ReviewerName: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ReviewDate: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              EmailAddress: Option<string>
+              [<ProviderDbType("Int")>]
+              Rating: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Comments: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductReview (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductReview (base)`` option =
+                match this.ProductReviewID with
+                | Some value ->
+                    let record: ``ProductReview (base)`` =
+                        { ProductReviewID = value
+                          ProductID = this.ProductID.Value
+                          ReviewerName = this.ReviewerName.Value
+                          ReviewDate = this.ReviewDate.Value
+                          EmailAddress = this.EmailAddress.Value
+                          Rating = this.Rating.Value
+                          Comments = this.Comments
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductReview = leftTable<``ProductReview (base)``, ProductReview>
+
+        type private ``ProductSubcategory (base)`` = ProductSubcategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductSubcategory =
+            { [<ProviderDbType("Int")>]
+              ProductSubcategoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductCategoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductSubcategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductSubcategory (base)`` option =
+                match this.ProductSubcategoryID with
+                | Some value ->
+                    let record: ``ProductSubcategory (base)`` =
+                        { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductSubcategory =
+            leftTable<``ProductSubcategory (base)``, ProductSubcategory>
+
+        type private ``ScrapReason (base)`` = ScrapReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ScrapReason =
+            { [<ProviderDbType("SmallInt")>]
+              ScrapReasonID: Option<int16>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ScrapReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ScrapReason (base)`` option =
+                match this.ScrapReasonID with
+                | Some value ->
+                    let record: ``ScrapReason (base)`` =
+                        { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ScrapReason = leftTable<``ScrapReason (base)``, ScrapReason>
+
+        type private ``TransactionHistory (base)`` = TransactionHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type TransactionHistory =
+            { [<ProviderDbType("Int")>]
+              TransactionID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderLineID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              TransactionDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              TransactionType: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``TransactionHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``TransactionHistory (base)`` option =
+                match this.TransactionID with
+                | Some value ->
+                    let record: ``TransactionHistory (base)`` =
+                        { TransactionID = value
+                          ProductID = this.ProductID.Value
+                          ReferenceOrderID = this.ReferenceOrderID.Value
+                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                          TransactionDate = this.TransactionDate.Value
+                          TransactionType = this.TransactionType.Value
+                          Quantity = this.Quantity.Value
+                          ActualCost = this.ActualCost.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let TransactionHistory =
+            leftTable<``TransactionHistory (base)``, TransactionHistory>
+
+        type private ``TransactionHistoryArchive (base)`` = TransactionHistoryArchive
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type TransactionHistoryArchive =
+            { [<ProviderDbType("Int")>]
+              TransactionID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ReferenceOrderLineID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              TransactionDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              TransactionType: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``TransactionHistoryArchive (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``TransactionHistoryArchive (base)`` option =
+                match this.TransactionID with
+                | Some value ->
+                    let record: ``TransactionHistoryArchive (base)`` =
+                        { TransactionID = value
+                          ProductID = this.ProductID.Value
+                          ReferenceOrderID = this.ReferenceOrderID.Value
+                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                          TransactionDate = this.TransactionDate.Value
+                          TransactionType = this.TransactionType.Value
+                          Quantity = this.Quantity.Value
+                          ActualCost = this.ActualCost.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let TransactionHistoryArchive =
+            leftTable<``TransactionHistoryArchive (base)``, TransactionHistoryArchive>
+
+        type private ``UnitMeasure (base)`` = UnitMeasure
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type UnitMeasure =
+            { [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``UnitMeasure (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``UnitMeasure (base)`` option =
+                match this.UnitMeasureCode with
+                | Some value ->
+                    let record: ``UnitMeasure (base)`` =
+                        { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let UnitMeasure = leftTable<``UnitMeasure (base)``, UnitMeasure>
+
+        type private ``WorkOrder (base)`` = WorkOrder
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WorkOrder =
+            { [<ProviderDbType("Int")>]
+              WorkOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              OrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              StockedQty: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              ScrappedQty: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("SmallInt")>]
+              ScrapReasonID: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``WorkOrder (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WorkOrder (base)`` option =
+                match this.WorkOrderID with
+                | Some value ->
+                    let record: ``WorkOrder (base)`` =
+                        { WorkOrderID = value
+                          ProductID = this.ProductID.Value
+                          OrderQty = this.OrderQty.Value
+                          StockedQty = this.StockedQty.Value
+                          ScrappedQty = this.ScrappedQty.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          DueDate = this.DueDate.Value
+                          ScrapReasonID = this.ScrapReasonID
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let WorkOrder = leftTable<``WorkOrder (base)``, WorkOrder>
+
+        type private ``WorkOrderRouting (base)`` = WorkOrderRouting
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type WorkOrderRouting =
+            { [<ProviderDbType("Int")>]
+              WorkOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("SmallInt")>]
+              OperationSequence: Option<int16>
+              [<ProviderDbType("SmallInt")>]
+              LocationID: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ScheduledStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ScheduledEndDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ActualStartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ActualEndDate: Option<System.DateTime>
+              [<ProviderDbType("Decimal")>]
+              ActualResourceHrs: Option<decimal>
+              [<ProviderDbType("Money")>]
+              PlannedCost: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ActualCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``WorkOrderRouting (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``WorkOrderRouting (base)`` option =
+                match this.WorkOrderID with
+                | Some value ->
+                    let record: ``WorkOrderRouting (base)`` =
+                        { WorkOrderID = value
+                          ProductID = this.ProductID.Value
+                          OperationSequence = this.OperationSequence.Value
+                          LocationID = this.LocationID.Value
+                          ScheduledStartDate = this.ScheduledStartDate.Value
+                          ScheduledEndDate = this.ScheduledEndDate.Value
+                          ActualStartDate = this.ActualStartDate
+                          ActualEndDate = this.ActualEndDate
+                          ActualResourceHrs = this.ActualResourceHrs
+                          PlannedCost = this.PlannedCost.Value
+                          ActualCost = this.ActualCost
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let WorkOrderRouting = leftTable<``WorkOrderRouting (base)``, WorkOrderRouting>
+
+
 module Purchasing =
 
     [<CLIMutable>]
@@ -1372,6 +2968,254 @@ module Purchasing =
                   { WriteColumn.Name = "ModifiedDate"; Value = box this.ModifiedDate; ProviderDbType = Some "DateTime" } ]
 
     let Vendor = table<Vendor>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``ProductVendor (base)`` = ProductVendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductVendor =
+            { [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              AverageLeadTime: Option<int>
+              [<ProviderDbType("Money")>]
+              StandardPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              LastReceiptCost: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              LastReceiptDate: Option<System.DateTime>
+              [<ProviderDbType("Int")>]
+              MinOrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              MaxOrderQty: Option<int>
+              [<ProviderDbType("Int")>]
+              OnOrderQty: Option<int>
+              [<ProviderDbType("NChar")>]
+              UnitMeasureCode: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductVendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductVendor (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``ProductVendor (base)`` =
+                        { ProductID = value
+                          BusinessEntityID = this.BusinessEntityID.Value
+                          AverageLeadTime = this.AverageLeadTime.Value
+                          StandardPrice = this.StandardPrice.Value
+                          LastReceiptCost = this.LastReceiptCost
+                          LastReceiptDate = this.LastReceiptDate
+                          MinOrderQty = this.MinOrderQty.Value
+                          MaxOrderQty = this.MaxOrderQty.Value
+                          OnOrderQty = this.OnOrderQty
+                          UnitMeasureCode = this.UnitMeasureCode.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductVendor = leftTable<``ProductVendor (base)``, ProductVendor>
+
+        type private ``PurchaseOrderDetail (base)`` = PurchaseOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PurchaseOrderDetail =
+            { [<ProviderDbType("Int")>]
+              PurchaseOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              PurchaseOrderDetailID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("SmallInt")>]
+              OrderQty: Option<int16>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Money")>]
+              UnitPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              LineTotal: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              ReceivedQty: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              RejectedQty: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              StockedQty: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PurchaseOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PurchaseOrderDetail (base)`` option =
+                match this.PurchaseOrderID with
+                | Some value ->
+                    let record: ``PurchaseOrderDetail (base)`` =
+                        { PurchaseOrderID = value
+                          PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
+                          DueDate = this.DueDate.Value
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          LineTotal = this.LineTotal.Value
+                          ReceivedQty = this.ReceivedQty.Value
+                          RejectedQty = this.RejectedQty.Value
+                          StockedQty = this.StockedQty.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PurchaseOrderDetail =
+            leftTable<``PurchaseOrderDetail (base)``, PurchaseOrderDetail>
+
+        type private ``PurchaseOrderHeader (base)`` = PurchaseOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PurchaseOrderHeader =
+            { [<ProviderDbType("Int")>]
+              PurchaseOrderID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              RevisionNumber: Option<byte>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("Int")>]
+              EmployeeID: Option<int>
+              [<ProviderDbType("Int")>]
+              VendorID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              OrderDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ShipDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              SubTotal: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TaxAmt: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Freight: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TotalDue: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PurchaseOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PurchaseOrderHeader (base)`` option =
+                match this.PurchaseOrderID with
+                | Some value ->
+                    let record: ``PurchaseOrderHeader (base)`` =
+                        { PurchaseOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          Status = this.Status.Value
+                          EmployeeID = this.EmployeeID.Value
+                          VendorID = this.VendorID.Value
+                          ShipMethodID = this.ShipMethodID.Value
+                          OrderDate = this.OrderDate.Value
+                          ShipDate = this.ShipDate
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PurchaseOrderHeader =
+            leftTable<``PurchaseOrderHeader (base)``, PurchaseOrderHeader>
+
+        type private ``ShipMethod (base)`` = ShipMethod
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ShipMethod =
+            { [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Money")>]
+              ShipBase: Option<decimal>
+              [<ProviderDbType("Money")>]
+              ShipRate: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ShipMethod (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ShipMethod (base)`` option =
+                match this.ShipMethodID with
+                | Some value ->
+                    let record: ``ShipMethod (base)`` =
+                        { ShipMethodID = value
+                          Name = this.Name.Value
+                          ShipBase = this.ShipBase.Value
+                          ShipRate = this.ShipRate.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ShipMethod = leftTable<``ShipMethod (base)``, ShipMethod>
+
+        type private ``Vendor (base)`` = Vendor
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Vendor =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              CreditRating: Option<byte>
+              [<ProviderDbType("Bit")>]
+              PreferredVendorStatus: Option<bool>
+              [<ProviderDbType("Bit")>]
+              ActiveFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              PurchasingWebServiceURL: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Vendor (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Vendor (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Vendor (base)`` =
+                        { BusinessEntityID = value
+                          AccountNumber = this.AccountNumber.Value
+                          Name = this.Name.Value
+                          CreditRating = this.CreditRating.Value
+                          PreferredVendorStatus = this.PreferredVendorStatus.Value
+                          ActiveFlag = this.ActiveFlag.Value
+                          PurchasingWebServiceURL = this.PurchasingWebServiceURL
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Vendor = leftTable<``Vendor (base)``, Vendor>
+
 
 module Sales =
 
@@ -1935,6 +3779,762 @@ module Sales =
 
     let Store = table<Store>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``CountryRegionCurrency (base)`` = CountryRegionCurrency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CountryRegionCurrency =
+            { [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              CurrencyCode: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CountryRegionCurrency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CountryRegionCurrency (base)`` option =
+                match this.CountryRegionCode with
+                | Some value ->
+                    let record: ``CountryRegionCurrency (base)`` =
+                        { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CountryRegionCurrency =
+            leftTable<``CountryRegionCurrency (base)``, CountryRegionCurrency>
+
+        type private ``CreditCard (base)`` = CreditCard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CreditCard =
+            { [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              CardType: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CardNumber: Option<string>
+              [<ProviderDbType("TinyInt")>]
+              ExpMonth: Option<byte>
+              [<ProviderDbType("SmallInt")>]
+              ExpYear: Option<int16>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CreditCard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CreditCard (base)`` option =
+                match this.CreditCardID with
+                | Some value ->
+                    let record: ``CreditCard (base)`` =
+                        { CreditCardID = value
+                          CardType = this.CardType.Value
+                          CardNumber = this.CardNumber.Value
+                          ExpMonth = this.ExpMonth.Value
+                          ExpYear = this.ExpYear.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CreditCard = leftTable<``CreditCard (base)``, CreditCard>
+
+        type private ``Currency (base)`` = Currency
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Currency =
+            { [<ProviderDbType("NChar")>]
+              CurrencyCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Currency (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Currency (base)`` option =
+                match this.CurrencyCode with
+                | Some value ->
+                    let record: ``Currency (base)`` =
+                        { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Currency = leftTable<``Currency (base)``, Currency>
+
+        type private ``CurrencyRate (base)`` = CurrencyRate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CurrencyRate =
+            { [<ProviderDbType("Int")>]
+              CurrencyRateID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              CurrencyRateDate: Option<System.DateTime>
+              [<ProviderDbType("NChar")>]
+              FromCurrencyCode: Option<string>
+              [<ProviderDbType("NChar")>]
+              ToCurrencyCode: Option<string>
+              [<ProviderDbType("Money")>]
+              AverageRate: Option<decimal>
+              [<ProviderDbType("Money")>]
+              EndOfDayRate: Option<decimal>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CurrencyRate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CurrencyRate (base)`` option =
+                match this.CurrencyRateID with
+                | Some value ->
+                    let record: ``CurrencyRate (base)`` =
+                        { CurrencyRateID = value
+                          CurrencyRateDate = this.CurrencyRateDate.Value
+                          FromCurrencyCode = this.FromCurrencyCode.Value
+                          ToCurrencyCode = this.ToCurrencyCode.Value
+                          AverageRate = this.AverageRate.Value
+                          EndOfDayRate = this.EndOfDayRate.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CurrencyRate = leftTable<``CurrencyRate (base)``, CurrencyRate>
+
+        type private ``Customer (base)`` = Customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Customer =
+            { [<ProviderDbType("Int")>]
+              CustomerID: Option<int>
+              [<ProviderDbType("Int")>]
+              PersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              StoreID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Customer (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``Customer (base)`` =
+                        { CustomerID = value
+                          PersonID = this.PersonID
+                          StoreID = this.StoreID
+                          TerritoryID = this.TerritoryID
+                          AccountNumber = this.AccountNumber.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Customer = leftTable<``Customer (base)``, Customer>
+
+        type private ``PersonCreditCard (base)`` = PersonCreditCard
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type PersonCreditCard =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``PersonCreditCard (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``PersonCreditCard (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``PersonCreditCard (base)`` =
+                        { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let PersonCreditCard = leftTable<``PersonCreditCard (base)``, PersonCreditCard>
+
+        type private ``SalesOrderDetail (base)`` = SalesOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderDetail =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesOrderDetailID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              CarrierTrackingNumber: Option<string>
+              [<ProviderDbType("SmallInt")>]
+              OrderQty: Option<int16>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("Money")>]
+              UnitPrice: Option<decimal>
+              [<ProviderDbType("Money")>]
+              UnitPriceDiscount: Option<decimal>
+              [<ProviderDbType("Decimal")>]
+              LineTotal: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderDetail (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderDetail (base)`` =
+                        { SalesOrderID = value
+                          SalesOrderDetailID = this.SalesOrderDetailID.Value
+                          CarrierTrackingNumber = this.CarrierTrackingNumber
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          SpecialOfferID = this.SpecialOfferID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          UnitPriceDiscount = this.UnitPriceDiscount.Value
+                          LineTotal = this.LineTotal.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
+
+        type private ``SalesOrderHeader (base)`` = SalesOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeader =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              RevisionNumber: Option<byte>
+              [<ProviderDbType("DateTime")>]
+              OrderDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              DueDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ShipDate: Option<System.DateTime>
+              [<ProviderDbType("TinyInt")>]
+              Status: Option<byte>
+              [<ProviderDbType("Bit")>]
+              OnlineOrderFlag: Option<bool>
+              [<ProviderDbType("NVarChar")>]
+              SalesOrderNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              PurchaseOrderNumber: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              AccountNumber: Option<string>
+              [<ProviderDbType("Int")>]
+              CustomerID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("Int")>]
+              BillToAddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipToAddressID: Option<int>
+              [<ProviderDbType("Int")>]
+              ShipMethodID: Option<int>
+              [<ProviderDbType("Int")>]
+              CreditCardID: Option<int>
+              [<ProviderDbType("VarChar")>]
+              CreditCardApprovalCode: Option<string>
+              [<ProviderDbType("Int")>]
+              CurrencyRateID: Option<int>
+              [<ProviderDbType("Money")>]
+              SubTotal: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TaxAmt: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Freight: Option<decimal>
+              [<ProviderDbType("Money")>]
+              TotalDue: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Comment: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeader (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeader (base)`` =
+                        { SalesOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          OrderDate = this.OrderDate.Value
+                          DueDate = this.DueDate.Value
+                          ShipDate = this.ShipDate
+                          Status = this.Status.Value
+                          OnlineOrderFlag = this.OnlineOrderFlag.Value
+                          SalesOrderNumber = this.SalesOrderNumber.Value
+                          PurchaseOrderNumber = this.PurchaseOrderNumber
+                          AccountNumber = this.AccountNumber
+                          CustomerID = this.CustomerID.Value
+                          SalesPersonID = this.SalesPersonID
+                          TerritoryID = this.TerritoryID
+                          BillToAddressID = this.BillToAddressID.Value
+                          ShipToAddressID = this.ShipToAddressID.Value
+                          ShipMethodID = this.ShipMethodID.Value
+                          CreditCardID = this.CreditCardID
+                          CreditCardApprovalCode = this.CreditCardApprovalCode
+                          CurrencyRateID = this.CurrencyRateID
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          Comment = this.Comment
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+        type private ``SalesOrderHeaderSalesReason (base)`` = SalesOrderHeaderSalesReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeaderSalesReason =
+            { [<ProviderDbType("Int")>]
+              SalesOrderID: Option<int>
+              [<ProviderDbType("Int")>]
+              SalesReasonID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeaderSalesReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeaderSalesReason (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeaderSalesReason (base)`` =
+                        { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeaderSalesReason =
+            leftTable<``SalesOrderHeaderSalesReason (base)``, SalesOrderHeaderSalesReason>
+
+        type private ``SalesPerson (base)`` = SalesPerson
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesPerson =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("Money")>]
+              SalesQuota: Option<decimal>
+              [<ProviderDbType("Money")>]
+              Bonus: Option<decimal>
+              [<ProviderDbType("SmallMoney")>]
+              CommissionPct: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesLastYear: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesPerson (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesPerson (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesPerson (base)`` =
+                        { BusinessEntityID = value
+                          TerritoryID = this.TerritoryID
+                          SalesQuota = this.SalesQuota
+                          Bonus = this.Bonus.Value
+                          CommissionPct = this.CommissionPct.Value
+                          SalesYTD = this.SalesYTD.Value
+                          SalesLastYear = this.SalesLastYear.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesPerson = leftTable<``SalesPerson (base)``, SalesPerson>
+
+        type private ``SalesPersonQuotaHistory (base)`` = SalesPersonQuotaHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesPersonQuotaHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              QuotaDate: Option<System.DateTime>
+              [<ProviderDbType("Money")>]
+              SalesQuota: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesPersonQuotaHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesPersonQuotaHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesPersonQuotaHistory (base)`` =
+                        { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesPersonQuotaHistory =
+            leftTable<``SalesPersonQuotaHistory (base)``, SalesPersonQuotaHistory>
+
+        type private ``SalesReason (base)`` = SalesReason
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesReason =
+            { [<ProviderDbType("Int")>]
+              SalesReasonID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              ReasonType: Option<string>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesReason (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesReason (base)`` option =
+                match this.SalesReasonID with
+                | Some value ->
+                    let record: ``SalesReason (base)`` =
+                        { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesReason = leftTable<``SalesReason (base)``, SalesReason>
+
+        type private ``SalesTaxRate (base)`` = SalesTaxRate
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTaxRate =
+            { [<ProviderDbType("Int")>]
+              SalesTaxRateID: Option<int>
+              [<ProviderDbType("Int")>]
+              StateProvinceID: Option<int>
+              [<ProviderDbType("TinyInt")>]
+              TaxType: Option<byte>
+              [<ProviderDbType("SmallMoney")>]
+              TaxRate: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTaxRate (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTaxRate (base)`` option =
+                match this.SalesTaxRateID with
+                | Some value ->
+                    let record: ``SalesTaxRate (base)`` =
+                        { SalesTaxRateID = value
+                          StateProvinceID = this.StateProvinceID.Value
+                          TaxType = this.TaxType.Value
+                          TaxRate = this.TaxRate.Value
+                          Name = this.Name.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTaxRate = leftTable<``SalesTaxRate (base)``, SalesTaxRate>
+
+        type private ``SalesTerritory (base)`` = SalesTerritory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTerritory =
+            { [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              CountryRegionCode: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Group: Option<string>
+              [<ProviderDbType("Money")>]
+              SalesYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              SalesLastYear: Option<decimal>
+              [<ProviderDbType("Money")>]
+              CostYTD: Option<decimal>
+              [<ProviderDbType("Money")>]
+              CostLastYear: Option<decimal>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTerritory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTerritory (base)`` option =
+                match this.TerritoryID with
+                | Some value ->
+                    let record: ``SalesTerritory (base)`` =
+                        { TerritoryID = value
+                          Name = this.Name.Value
+                          CountryRegionCode = this.CountryRegionCode.Value
+                          Group = this.Group.Value
+                          SalesYTD = this.SalesYTD.Value
+                          SalesLastYear = this.SalesLastYear.Value
+                          CostYTD = this.CostYTD.Value
+                          CostLastYear = this.CostLastYear.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTerritory = leftTable<``SalesTerritory (base)``, SalesTerritory>
+
+        type private ``SalesTerritoryHistory (base)`` = SalesTerritoryHistory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesTerritoryHistory =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("Int")>]
+              TerritoryID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesTerritoryHistory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesTerritoryHistory (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``SalesTerritoryHistory (base)`` =
+                        { BusinessEntityID = value
+                          TerritoryID = this.TerritoryID.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesTerritoryHistory =
+            leftTable<``SalesTerritoryHistory (base)``, SalesTerritoryHistory>
+
+        type private ``ShoppingCartItem (base)`` = ShoppingCartItem
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ShoppingCartItem =
+            { [<ProviderDbType("Int")>]
+              ShoppingCartItemID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ShoppingCartID: Option<string>
+              [<ProviderDbType("Int")>]
+              Quantity: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              DateCreated: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ShoppingCartItem (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ShoppingCartItem (base)`` option =
+                match this.ShoppingCartItemID with
+                | Some value ->
+                    let record: ``ShoppingCartItem (base)`` =
+                        { ShoppingCartItemID = value
+                          ShoppingCartID = this.ShoppingCartID.Value
+                          Quantity = this.Quantity.Value
+                          ProductID = this.ProductID.Value
+                          DateCreated = this.DateCreated.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ShoppingCartItem = leftTable<``ShoppingCartItem (base)``, ShoppingCartItem>
+
+        type private ``SpecialOffer (base)`` = SpecialOffer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SpecialOffer =
+            { [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Description: Option<string>
+              [<ProviderDbType("SmallMoney")>]
+              DiscountPct: Option<decimal>
+              [<ProviderDbType("NVarChar")>]
+              Type: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Category: Option<string>
+              [<ProviderDbType("DateTime")>]
+              StartDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              EndDate: Option<System.DateTime>
+              [<ProviderDbType("Int")>]
+              MinQty: Option<int>
+              [<ProviderDbType("Int")>]
+              MaxQty: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SpecialOffer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SpecialOffer (base)`` option =
+                match this.SpecialOfferID with
+                | Some value ->
+                    let record: ``SpecialOffer (base)`` =
+                        { SpecialOfferID = value
+                          Description = this.Description.Value
+                          DiscountPct = this.DiscountPct.Value
+                          Type = this.Type.Value
+                          Category = this.Category.Value
+                          StartDate = this.StartDate.Value
+                          EndDate = this.EndDate.Value
+                          MinQty = this.MinQty.Value
+                          MaxQty = this.MaxQty
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SpecialOffer = leftTable<``SpecialOffer (base)``, SpecialOffer>
+
+        type private ``SpecialOfferProduct (base)`` = SpecialOfferProduct
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SpecialOfferProduct =
+            { [<ProviderDbType("Int")>]
+              SpecialOfferID: Option<int>
+              [<ProviderDbType("Int")>]
+              ProductID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SpecialOfferProduct (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SpecialOfferProduct (base)`` option =
+                match this.SpecialOfferID with
+                | Some value ->
+                    let record: ``SpecialOfferProduct (base)`` =
+                        { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SpecialOfferProduct =
+            leftTable<``SpecialOfferProduct (base)``, SpecialOfferProduct>
+
+        type private ``Store (base)`` = Store
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Store =
+            { [<ProviderDbType("Int")>]
+              BusinessEntityID: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              Name: Option<string>
+              [<ProviderDbType("Int")>]
+              SalesPersonID: Option<int>
+              [<ProviderDbType("UniqueIdentifier")>]
+              rowguid: Option<System.Guid>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Store (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Store (base)`` option =
+                match this.BusinessEntityID with
+                | Some value ->
+                    let record: ``Store (base)`` =
+                        { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Store = leftTable<``Store (base)``, Store>
+
+
 module dbo =
 
     [<CLIMutable>]
@@ -2021,6 +4621,124 @@ module dbo =
 
     let ErrorLog = table<ErrorLog>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``AWBuildVersion (base)`` = AWBuildVersion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type AWBuildVersion =
+            { [<ProviderDbType("TinyInt")>]
+              SystemInformationID: Option<byte>
+              [<ProviderDbType("NVarChar")>]
+              ``Database Version``: Option<string>
+              [<ProviderDbType("DateTime")>]
+              VersionDate: Option<System.DateTime>
+              [<ProviderDbType("DateTime")>]
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``AWBuildVersion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``AWBuildVersion (base)`` option =
+                match this.SystemInformationID with
+                | Some value ->
+                    let record: ``AWBuildVersion (base)`` =
+                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let AWBuildVersion = leftTable<``AWBuildVersion (base)``, AWBuildVersion>
+
+        type private ``DatabaseLog (base)`` = DatabaseLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type DatabaseLog =
+            { [<ProviderDbType("Int")>]
+              DatabaseLogID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              PostTime: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              DatabaseUser: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Event: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Schema: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Object: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              TSQL: Option<string> }
+
+            interface ILeftViewOf<``DatabaseLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``DatabaseLog (base)`` option =
+                match this.DatabaseLogID with
+                | Some value ->
+                    let record: ``DatabaseLog (base)`` =
+                        { DatabaseLogID = value
+                          PostTime = this.PostTime.Value
+                          DatabaseUser = this.DatabaseUser.Value
+                          Event = this.Event.Value
+                          Schema = this.Schema
+                          Object = this.Object
+                          TSQL = this.TSQL.Value }
+
+                    Some record
+                | None -> None
+
+        let DatabaseLog = leftTable<``DatabaseLog (base)``, DatabaseLog>
+
+        type private ``ErrorLog (base)`` = ErrorLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ErrorLog =
+            { [<ProviderDbType("Int")>]
+              ErrorLogID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              ErrorTime: Option<System.DateTime>
+              [<ProviderDbType("NVarChar")>]
+              UserName: Option<string>
+              [<ProviderDbType("Int")>]
+              ErrorNumber: Option<int>
+              [<ProviderDbType("Int")>]
+              ErrorSeverity: Option<int>
+              [<ProviderDbType("Int")>]
+              ErrorState: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ErrorProcedure: Option<string>
+              [<ProviderDbType("Int")>]
+              ErrorLine: Option<int>
+              [<ProviderDbType("NVarChar")>]
+              ErrorMessage: Option<string> }
+
+            interface ILeftViewOf<``ErrorLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ErrorLog (base)`` option =
+                match this.ErrorLogID with
+                | Some value ->
+                    let record: ``ErrorLog (base)`` =
+                        { ErrorLogID = value
+                          ErrorTime = this.ErrorTime.Value
+                          UserName = this.UserName.Value
+                          ErrorNumber = this.ErrorNumber.Value
+                          ErrorSeverity = this.ErrorSeverity
+                          ErrorState = this.ErrorState
+                          ErrorProcedure = this.ErrorProcedure
+                          ErrorLine = this.ErrorLine
+                          ErrorMessage = this.ErrorMessage.Value }
+
+                    Some record
+                | None -> None
+
+        let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
+
+
 module ext =
 
     [<CLIMutable>]
@@ -2084,6 +4802,111 @@ module ext =
                   { WriteColumn.Name = "Value"; Value = box this.Value; ProviderDbType = Some "NVarChar" } ]
 
     let NullableKeyUpsert = table<NullableKeyUpsert>
+
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``DateTime2Support (base)`` = DateTime2Support
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type DateTime2Support =
+            { [<ProviderDbType("Int")>]
+              ID: Option<int>
+              [<ProviderDbType("DateTime")>]
+              LessPrecision: Option<System.DateTime>
+              [<ProviderDbType("DateTime2")>]
+              MorePrecision: Option<System.DateTime> }
+
+            interface ILeftViewOf<``DateTime2Support (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``DateTime2Support (base)`` option =
+                match this.ID with
+                | Some value ->
+                    let record: ``DateTime2Support (base)`` =
+                        { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
+
+                    Some record
+                | None -> None
+
+        let DateTime2Support = leftTable<``DateTime2Support (base)``, DateTime2Support>
+
+        type private ``GetIdGuidRepro (base)`` = GetIdGuidRepro
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type GetIdGuidRepro =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Id: Option<System.Guid>
+              [<ProviderDbType("NChar")>]
+              EmailAddress: Option<string> }
+
+            interface ILeftViewOf<``GetIdGuidRepro (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``GetIdGuidRepro (base)`` option =
+                match this.Id with
+                | Some value ->
+                    let record: ``GetIdGuidRepro (base)`` =
+                        { Id = value; EmailAddress = this.EmailAddress.Value }
+
+                    Some record
+                | None -> None
+
+        let GetIdGuidRepro = leftTable<``GetIdGuidRepro (base)``, GetIdGuidRepro>
+
+        type private ``HierarchyIdSupport (base)`` = HierarchyIdSupport
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type HierarchyIdSupport =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Id: Option<System.Guid>
+              [<ProviderDbType("SqlHierarchyId")>]
+              Hierarchy: Option<Microsoft.SqlServer.Types.SqlHierarchyId> }
+
+            interface ILeftViewOf<``HierarchyIdSupport (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``HierarchyIdSupport (base)`` option =
+                match this.Id with
+                | Some value ->
+                    let record: ``HierarchyIdSupport (base)`` =
+                        { Id = value; Hierarchy = this.Hierarchy.Value }
+
+                    Some record
+                | None -> None
+
+        let HierarchyIdSupport =
+            leftTable<``HierarchyIdSupport (base)``, HierarchyIdSupport>
+
+        type private ``NullableKeyUpsert (base)`` = NullableKeyUpsert
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type NullableKeyUpsert =
+            { [<ProviderDbType("UniqueIdentifier")>]
+              Key1: Option<System.Guid>
+              [<ProviderDbType("NVarChar")>]
+              Key2: Option<string>
+              [<ProviderDbType("NVarChar")>]
+              Value: Option<string> }
+
+            interface ILeftViewOf<``NullableKeyUpsert (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``NullableKeyUpsert (base)`` option =
+                match this.Key1 with
+                | Some value ->
+                    let record: ``NullableKeyUpsert (base)`` =
+                        { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
+
+                    Some record
+                | None -> None
+
+        let NullableKeyUpsert = leftTable<``NullableKeyUpsert (base)``, NullableKeyUpsert>
+
 
 
 

--- a/src/Tests/SqlServer/AdventureWorksNet9.fs
+++ b/src/Tests/SqlServer/AdventureWorksNet9.fs
@@ -194,17 +194,6 @@ module HumanResources =
 
             interface ILeftViewOf<``Department (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Department (base)`` option =
-                match this.DepartmentID with
-                | Some value ->
-                    let record: ``Department (base)`` =
-                        { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Department = leftTable<``Department (base)``, Department>
 
         type private ``Employee (base)`` = Employee
@@ -246,32 +235,6 @@ module HumanResources =
 
             interface ILeftViewOf<``Employee (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Employee (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Employee (base)`` =
-                        { BusinessEntityID = value
-                          NationalIDNumber = this.NationalIDNumber.Value
-                          LoginID = this.LoginID.Value
-                          OrganizationNode = this.OrganizationNode
-                          OrganizationLevel = this.OrganizationLevel
-                          JobTitle = this.JobTitle.Value
-                          BirthDate = this.BirthDate.Value
-                          MaritalStatus = this.MaritalStatus.Value
-                          Gender = this.Gender.Value
-                          HireDate = this.HireDate.Value
-                          SalariedFlag = this.SalariedFlag.Value
-                          VacationHours = this.VacationHours.Value
-                          SickLeaveHours = this.SickLeaveHours.Value
-                          CurrentFlag = this.CurrentFlag.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Employee = leftTable<``Employee (base)``, Employee>
 
         type private ``EmployeeDepartmentHistory (base)`` = EmployeeDepartmentHistory
@@ -293,22 +256,6 @@ module HumanResources =
 
             interface ILeftViewOf<``EmployeeDepartmentHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmployeeDepartmentHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmployeeDepartmentHistory (base)`` =
-                        { BusinessEntityID = value
-                          DepartmentID = this.DepartmentID.Value
-                          ShiftID = this.ShiftID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmployeeDepartmentHistory =
             leftTable<``EmployeeDepartmentHistory (base)``, EmployeeDepartmentHistory>
 
@@ -329,17 +276,6 @@ module HumanResources =
 
             interface ILeftViewOf<``EmployeePayHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmployeePayHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmployeePayHistory (base)`` =
-                        { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmployeePayHistory =
             leftTable<``EmployeePayHistory (base)``, EmployeePayHistory>
 
@@ -355,17 +291,6 @@ module HumanResources =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``JobCandidate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``JobCandidate (base)`` option =
-                match this.JobCandidateID with
-                | Some value ->
-                    let record: ``JobCandidate (base)`` =
-                        { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let JobCandidate = leftTable<``JobCandidate (base)``, JobCandidate>
 
@@ -385,17 +310,6 @@ module HumanResources =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Shift (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Shift (base)`` option =
-                match this.ShiftID with
-                | Some value ->
-                    let record: ``Shift (base)`` =
-                        { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Shift = leftTable<``Shift (base)``, Shift>
 
@@ -733,24 +647,6 @@ module Person =
 
             interface ILeftViewOf<``Address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Address (base)`` option =
-                match this.AddressID with
-                | Some value ->
-                    let record: ``Address (base)`` =
-                        { AddressID = value
-                          AddressLine1 = this.AddressLine1.Value
-                          AddressLine2 = this.AddressLine2
-                          City = this.City.Value
-                          StateProvinceID = this.StateProvinceID.Value
-                          PostalCode = this.PostalCode.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Address = leftTable<``Address (base)``, Address>
 
         type private ``AddressType (base)`` = AddressType
@@ -768,17 +664,6 @@ module Person =
 
             interface ILeftViewOf<``AddressType (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``AddressType (base)`` option =
-                match this.AddressTypeID with
-                | Some value ->
-                    let record: ``AddressType (base)`` =
-                        { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let AddressType = leftTable<``AddressType (base)``, AddressType>
 
         type private ``BusinessEntity (base)`` = BusinessEntity
@@ -793,17 +678,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BusinessEntity (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntity (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntity (base)`` =
-                        { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BusinessEntity = leftTable<``BusinessEntity (base)``, BusinessEntity>
 
@@ -823,17 +697,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BusinessEntityAddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntityAddress (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntityAddress (base)`` =
-                        { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BusinessEntityAddress =
             leftTable<``BusinessEntityAddress (base)``, BusinessEntityAddress>
@@ -855,17 +718,6 @@ module Person =
 
             interface ILeftViewOf<``BusinessEntityContact (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BusinessEntityContact (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``BusinessEntityContact (base)`` =
-                        { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let BusinessEntityContact =
             leftTable<``BusinessEntityContact (base)``, BusinessEntityContact>
 
@@ -882,17 +734,6 @@ module Person =
 
             interface ILeftViewOf<``ContactType (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ContactType (base)`` option =
-                match this.ContactTypeID with
-                | Some value ->
-                    let record: ``ContactType (base)`` =
-                        { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ContactType = leftTable<``ContactType (base)``, ContactType>
 
         type private ``CountryRegion (base)`` = CountryRegion
@@ -907,17 +748,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``CountryRegion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CountryRegion (base)`` option =
-                match this.CountryRegionCode with
-                | Some value ->
-                    let record: ``CountryRegion (base)`` =
-                        { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let CountryRegion = leftTable<``CountryRegion (base)``, CountryRegion>
 
@@ -938,17 +768,6 @@ module Person =
 
             interface ILeftViewOf<``EmailAddress (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``EmailAddress (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``EmailAddress (base)`` =
-                        { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let EmailAddress = leftTable<``EmailAddress (base)``, EmailAddress>
 
         type private ``Password (base)`` = Password
@@ -967,21 +786,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Password (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Password (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Password (base)`` =
-                        { BusinessEntityID = value
-                          PasswordHash = this.PasswordHash.Value
-                          PasswordSalt = this.PasswordSalt.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Password = leftTable<``Password (base)``, Password>
 
@@ -1014,27 +818,6 @@ module Person =
 
             interface ILeftViewOf<``Person (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Person (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Person (base)`` =
-                        { BusinessEntityID = value
-                          PersonType = this.PersonType.Value
-                          NameStyle = this.NameStyle.Value
-                          Title = this.Title
-                          FirstName = this.FirstName.Value
-                          MiddleName = this.MiddleName
-                          LastName = this.LastName.Value
-                          Suffix = this.Suffix
-                          EmailPromotion = this.EmailPromotion.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Person = leftTable<``Person (base)``, Person>
 
         type private ``PersonPhone (base)`` = PersonPhone
@@ -1052,17 +835,6 @@ module Person =
 
             interface ILeftViewOf<``PersonPhone (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PersonPhone (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``PersonPhone (base)`` =
-                        { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let PersonPhone = leftTable<``PersonPhone (base)``, PersonPhone>
 
         type private ``PhoneNumberType (base)`` = PhoneNumberType
@@ -1077,17 +849,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PhoneNumberType (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PhoneNumberType (base)`` option =
-                match this.PhoneNumberTypeID with
-                | Some value ->
-                    let record: ``PhoneNumberType (base)`` =
-                        { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PhoneNumberType = leftTable<``PhoneNumberType (base)``, PhoneNumberType>
 
@@ -1113,24 +874,6 @@ module Person =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``StateProvince (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``StateProvince (base)`` option =
-                match this.StateProvinceID with
-                | Some value ->
-                    let record: ``StateProvince (base)`` =
-                        { StateProvinceID = value
-                          StateProvinceCode = this.StateProvinceCode.Value
-                          CountryRegionCode = this.CountryRegionCode.Value
-                          IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
-                          Name = this.Name.Value
-                          TerritoryID = this.TerritoryID.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let StateProvince = leftTable<``StateProvince (base)``, StateProvince>
 
@@ -1864,25 +1607,6 @@ module Production =
 
             interface ILeftViewOf<``BillOfMaterials (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BillOfMaterials (base)`` option =
-                match this.BillOfMaterialsID with
-                | Some value ->
-                    let record: ``BillOfMaterials (base)`` =
-                        { BillOfMaterialsID = value
-                          ProductAssemblyID = this.ProductAssemblyID
-                          ComponentID = this.ComponentID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          UnitMeasureCode = this.UnitMeasureCode.Value
-                          BOMLevel = this.BOMLevel.Value
-                          PerAssemblyQty = this.PerAssemblyQty.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let BillOfMaterials = leftTable<``BillOfMaterials (base)``, BillOfMaterials>
 
         type private ``Culture (base)`` = Culture
@@ -1897,17 +1621,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Culture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Culture (base)`` option =
-                match this.CultureID with
-                | Some value ->
-                    let record: ``Culture (base)`` =
-                        { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Culture = leftTable<``Culture (base)``, Culture>
 
@@ -1946,30 +1659,6 @@ module Production =
 
             interface ILeftViewOf<``Document (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Document (base)`` option =
-                match this.DocumentNode with
-                | Some value ->
-                    let record: ``Document (base)`` =
-                        { DocumentNode = value
-                          DocumentLevel = this.DocumentLevel
-                          Title = this.Title.Value
-                          Owner = this.Owner.Value
-                          FolderFlag = this.FolderFlag.Value
-                          FileName = this.FileName.Value
-                          FileExtension = this.FileExtension.Value
-                          Revision = this.Revision.Value
-                          ChangeNumber = this.ChangeNumber.Value
-                          Status = this.Status.Value
-                          DocumentSummary = this.DocumentSummary
-                          Document = this.Document
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Document = leftTable<``Document (base)``, Document>
 
         type private ``Illustration (base)`` = Illustration
@@ -1982,17 +1671,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Illustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Illustration (base)`` option =
-                match this.IllustrationID with
-                | Some value ->
-                    let record: ``Illustration (base)`` =
-                        { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Illustration = leftTable<``Illustration (base)``, Illustration>
 
@@ -2012,17 +1690,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Location (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Location (base)`` option =
-                match this.LocationID with
-                | Some value ->
-                    let record: ``Location (base)`` =
-                        { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Location = leftTable<``Location (base)``, Location>
 
@@ -2083,41 +1750,6 @@ module Production =
 
             interface ILeftViewOf<``Product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Product (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``Product (base)`` =
-                        { ProductID = value
-                          Name = this.Name.Value
-                          ProductNumber = this.ProductNumber.Value
-                          MakeFlag = this.MakeFlag.Value
-                          FinishedGoodsFlag = this.FinishedGoodsFlag.Value
-                          Color = this.Color
-                          SafetyStockLevel = this.SafetyStockLevel.Value
-                          ReorderPoint = this.ReorderPoint.Value
-                          StandardCost = this.StandardCost.Value
-                          ListPrice = this.ListPrice.Value
-                          Size = this.Size
-                          SizeUnitMeasureCode = this.SizeUnitMeasureCode
-                          WeightUnitMeasureCode = this.WeightUnitMeasureCode
-                          Weight = this.Weight
-                          DaysToManufacture = this.DaysToManufacture.Value
-                          ProductLine = this.ProductLine
-                          Class = this.Class
-                          Style = this.Style
-                          ProductSubcategoryID = this.ProductSubcategoryID
-                          ProductModelID = this.ProductModelID
-                          SellStartDate = this.SellStartDate.Value
-                          SellEndDate = this.SellEndDate
-                          DiscontinuedDate = this.DiscontinuedDate
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Product = leftTable<``Product (base)``, Product>
 
         type private ``ProductCategory (base)`` = ProductCategory
@@ -2134,17 +1766,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductCategory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCategory (base)`` option =
-                match this.ProductCategoryID with
-                | Some value ->
-                    let record: ``ProductCategory (base)`` =
-                        { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
 
@@ -2165,17 +1786,6 @@ module Production =
 
             interface ILeftViewOf<``ProductCostHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCostHistory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductCostHistory (base)`` =
-                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductCostHistory =
             leftTable<``ProductCostHistory (base)``, ProductCostHistory>
 
@@ -2194,17 +1804,6 @@ module Production =
 
             interface ILeftViewOf<``ProductDescription (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDescription (base)`` option =
-                match this.ProductDescriptionID with
-                | Some value ->
-                    let record: ``ProductDescription (base)`` =
-                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductDescription =
             leftTable<``ProductDescription (base)``, ProductDescription>
 
@@ -2220,17 +1819,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductDocument (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDocument (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductDocument (base)`` =
-                        { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductDocument = leftTable<``ProductDocument (base)``, ProductDocument>
 
@@ -2255,23 +1843,6 @@ module Production =
 
             interface ILeftViewOf<``ProductInventory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductInventory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductInventory (base)`` =
-                        { ProductID = value
-                          LocationID = this.LocationID.Value
-                          Shelf = this.Shelf.Value
-                          Bin = this.Bin.Value
-                          Quantity = this.Quantity.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductInventory = leftTable<``ProductInventory (base)``, ProductInventory>
 
         type private ``ProductListPriceHistory (base)`` = ProductListPriceHistory
@@ -2291,17 +1862,6 @@ module Production =
 
             interface ILeftViewOf<``ProductListPriceHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductListPriceHistory (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductListPriceHistory (base)`` =
-                        { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductListPriceHistory =
             leftTable<``ProductListPriceHistory (base)``, ProductListPriceHistory>
 
@@ -2320,17 +1880,6 @@ module Production =
 
             interface ILeftViewOf<``ProductModel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModel (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModel (base)`` =
-                        { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
 
         type private ``ProductModelIllustration (base)`` = ProductModelIllustration
@@ -2345,17 +1894,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelIllustration (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelIllustration (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelIllustration (base)`` =
-                        { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelIllustration =
             leftTable<``ProductModelIllustration (base)``, ProductModelIllustration>
@@ -2374,17 +1912,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelProductDescriptionCulture (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelProductDescriptionCulture (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelProductDescriptionCulture (base)`` =
-                        { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelProductDescriptionCulture =
             leftTable<``ProductModelProductDescriptionCulture (base)``, ProductModelProductDescriptionCulture>
@@ -2408,22 +1935,6 @@ module Production =
 
             interface ILeftViewOf<``ProductPhoto (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductPhoto (base)`` option =
-                match this.ProductPhotoID with
-                | Some value ->
-                    let record: ``ProductPhoto (base)`` =
-                        { ProductPhotoID = value
-                          ThumbNailPhoto = this.ThumbNailPhoto
-                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
-                          LargePhoto = this.LargePhoto
-                          LargePhotoFileName = this.LargePhotoFileName
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductPhoto = leftTable<``ProductPhoto (base)``, ProductPhoto>
 
         type private ``ProductProductPhoto (base)`` = ProductProductPhoto
@@ -2440,17 +1951,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductProductPhoto (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductProductPhoto (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductProductPhoto (base)`` =
-                        { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductProductPhoto =
             leftTable<``ProductProductPhoto (base)``, ProductProductPhoto>
@@ -2478,24 +1978,6 @@ module Production =
 
             interface ILeftViewOf<``ProductReview (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductReview (base)`` option =
-                match this.ProductReviewID with
-                | Some value ->
-                    let record: ``ProductReview (base)`` =
-                        { ProductReviewID = value
-                          ProductID = this.ProductID.Value
-                          ReviewerName = this.ReviewerName.Value
-                          ReviewDate = this.ReviewDate.Value
-                          EmailAddress = this.EmailAddress.Value
-                          Rating = this.Rating.Value
-                          Comments = this.Comments
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductReview = leftTable<``ProductReview (base)``, ProductReview>
 
         type private ``ProductSubcategory (base)`` = ProductSubcategory
@@ -2515,17 +1997,6 @@ module Production =
 
             interface ILeftViewOf<``ProductSubcategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductSubcategory (base)`` option =
-                match this.ProductSubcategoryID with
-                | Some value ->
-                    let record: ``ProductSubcategory (base)`` =
-                        { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductSubcategory =
             leftTable<``ProductSubcategory (base)``, ProductSubcategory>
 
@@ -2541,17 +2012,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ScrapReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ScrapReason (base)`` option =
-                match this.ScrapReasonID with
-                | Some value ->
-                    let record: ``ScrapReason (base)`` =
-                        { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ScrapReason = leftTable<``ScrapReason (base)``, ScrapReason>
 
@@ -2579,25 +2039,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``TransactionHistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``TransactionHistory (base)`` option =
-                match this.TransactionID with
-                | Some value ->
-                    let record: ``TransactionHistory (base)`` =
-                        { TransactionID = value
-                          ProductID = this.ProductID.Value
-                          ReferenceOrderID = this.ReferenceOrderID.Value
-                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
-                          TransactionDate = this.TransactionDate.Value
-                          TransactionType = this.TransactionType.Value
-                          Quantity = this.Quantity.Value
-                          ActualCost = this.ActualCost.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let TransactionHistory =
             leftTable<``TransactionHistory (base)``, TransactionHistory>
@@ -2627,25 +2068,6 @@ module Production =
 
             interface ILeftViewOf<``TransactionHistoryArchive (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``TransactionHistoryArchive (base)`` option =
-                match this.TransactionID with
-                | Some value ->
-                    let record: ``TransactionHistoryArchive (base)`` =
-                        { TransactionID = value
-                          ProductID = this.ProductID.Value
-                          ReferenceOrderID = this.ReferenceOrderID.Value
-                          ReferenceOrderLineID = this.ReferenceOrderLineID.Value
-                          TransactionDate = this.TransactionDate.Value
-                          TransactionType = this.TransactionType.Value
-                          Quantity = this.Quantity.Value
-                          ActualCost = this.ActualCost.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let TransactionHistoryArchive =
             leftTable<``TransactionHistoryArchive (base)``, TransactionHistoryArchive>
 
@@ -2661,17 +2083,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``UnitMeasure (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``UnitMeasure (base)`` option =
-                match this.UnitMeasureCode with
-                | Some value ->
-                    let record: ``UnitMeasure (base)`` =
-                        { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let UnitMeasure = leftTable<``UnitMeasure (base)``, UnitMeasure>
 
@@ -2701,26 +2112,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``WorkOrder (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WorkOrder (base)`` option =
-                match this.WorkOrderID with
-                | Some value ->
-                    let record: ``WorkOrder (base)`` =
-                        { WorkOrderID = value
-                          ProductID = this.ProductID.Value
-                          OrderQty = this.OrderQty.Value
-                          StockedQty = this.StockedQty.Value
-                          ScrappedQty = this.ScrappedQty.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          DueDate = this.DueDate.Value
-                          ScrapReasonID = this.ScrapReasonID
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let WorkOrder = leftTable<``WorkOrder (base)``, WorkOrder>
 
@@ -2754,28 +2145,6 @@ module Production =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``WorkOrderRouting (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``WorkOrderRouting (base)`` option =
-                match this.WorkOrderID with
-                | Some value ->
-                    let record: ``WorkOrderRouting (base)`` =
-                        { WorkOrderID = value
-                          ProductID = this.ProductID.Value
-                          OperationSequence = this.OperationSequence.Value
-                          LocationID = this.LocationID.Value
-                          ScheduledStartDate = this.ScheduledStartDate.Value
-                          ScheduledEndDate = this.ScheduledEndDate.Value
-                          ActualStartDate = this.ActualStartDate
-                          ActualEndDate = this.ActualEndDate
-                          ActualResourceHrs = this.ActualResourceHrs
-                          PlannedCost = this.PlannedCost.Value
-                          ActualCost = this.ActualCost
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let WorkOrderRouting = leftTable<``WorkOrderRouting (base)``, WorkOrderRouting>
 
@@ -3001,27 +2370,6 @@ module Purchasing =
 
             interface ILeftViewOf<``ProductVendor (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductVendor (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``ProductVendor (base)`` =
-                        { ProductID = value
-                          BusinessEntityID = this.BusinessEntityID.Value
-                          AverageLeadTime = this.AverageLeadTime.Value
-                          StandardPrice = this.StandardPrice.Value
-                          LastReceiptCost = this.LastReceiptCost
-                          LastReceiptDate = this.LastReceiptDate
-                          MinOrderQty = this.MinOrderQty.Value
-                          MaxOrderQty = this.MaxOrderQty.Value
-                          OnOrderQty = this.OnOrderQty
-                          UnitMeasureCode = this.UnitMeasureCode.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductVendor = leftTable<``ProductVendor (base)``, ProductVendor>
 
         type private ``PurchaseOrderDetail (base)`` = PurchaseOrderDetail
@@ -3052,27 +2400,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PurchaseOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PurchaseOrderDetail (base)`` option =
-                match this.PurchaseOrderID with
-                | Some value ->
-                    let record: ``PurchaseOrderDetail (base)`` =
-                        { PurchaseOrderID = value
-                          PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
-                          DueDate = this.DueDate.Value
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          LineTotal = this.LineTotal.Value
-                          ReceivedQty = this.ReceivedQty.Value
-                          RejectedQty = this.RejectedQty.Value
-                          StockedQty = this.StockedQty.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PurchaseOrderDetail =
             leftTable<``PurchaseOrderDetail (base)``, PurchaseOrderDetail>
@@ -3110,29 +2437,6 @@ module Purchasing =
 
             interface ILeftViewOf<``PurchaseOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PurchaseOrderHeader (base)`` option =
-                match this.PurchaseOrderID with
-                | Some value ->
-                    let record: ``PurchaseOrderHeader (base)`` =
-                        { PurchaseOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          Status = this.Status.Value
-                          EmployeeID = this.EmployeeID.Value
-                          VendorID = this.VendorID.Value
-                          ShipMethodID = this.ShipMethodID.Value
-                          OrderDate = this.OrderDate.Value
-                          ShipDate = this.ShipDate
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let PurchaseOrderHeader =
             leftTable<``PurchaseOrderHeader (base)``, PurchaseOrderHeader>
 
@@ -3154,22 +2458,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ShipMethod (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ShipMethod (base)`` option =
-                match this.ShipMethodID with
-                | Some value ->
-                    let record: ``ShipMethod (base)`` =
-                        { ShipMethodID = value
-                          Name = this.Name.Value
-                          ShipBase = this.ShipBase.Value
-                          ShipRate = this.ShipRate.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ShipMethod = leftTable<``ShipMethod (base)``, ShipMethod>
 
@@ -3195,24 +2483,6 @@ module Purchasing =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Vendor (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Vendor (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Vendor (base)`` =
-                        { BusinessEntityID = value
-                          AccountNumber = this.AccountNumber.Value
-                          Name = this.Name.Value
-                          CreditRating = this.CreditRating.Value
-                          PreferredVendorStatus = this.PreferredVendorStatus.Value
-                          ActiveFlag = this.ActiveFlag.Value
-                          PurchasingWebServiceURL = this.PurchasingWebServiceURL
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Vendor = leftTable<``Vendor (base)``, Vendor>
 
@@ -3795,17 +3065,6 @@ module Sales =
 
             interface ILeftViewOf<``CountryRegionCurrency (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CountryRegionCurrency (base)`` option =
-                match this.CountryRegionCode with
-                | Some value ->
-                    let record: ``CountryRegionCurrency (base)`` =
-                        { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CountryRegionCurrency =
             leftTable<``CountryRegionCurrency (base)``, CountryRegionCurrency>
 
@@ -3828,22 +3087,6 @@ module Sales =
 
             interface ILeftViewOf<``CreditCard (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CreditCard (base)`` option =
-                match this.CreditCardID with
-                | Some value ->
-                    let record: ``CreditCard (base)`` =
-                        { CreditCardID = value
-                          CardType = this.CardType.Value
-                          CardNumber = this.CardNumber.Value
-                          ExpMonth = this.ExpMonth.Value
-                          ExpYear = this.ExpYear.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CreditCard = leftTable<``CreditCard (base)``, CreditCard>
 
         type private ``Currency (base)`` = Currency
@@ -3858,17 +3101,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Currency (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Currency (base)`` option =
-                match this.CurrencyCode with
-                | Some value ->
-                    let record: ``Currency (base)`` =
-                        { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Currency = leftTable<``Currency (base)``, Currency>
 
@@ -3893,23 +3125,6 @@ module Sales =
 
             interface ILeftViewOf<``CurrencyRate (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CurrencyRate (base)`` option =
-                match this.CurrencyRateID with
-                | Some value ->
-                    let record: ``CurrencyRate (base)`` =
-                        { CurrencyRateID = value
-                          CurrencyRateDate = this.CurrencyRateDate.Value
-                          FromCurrencyCode = this.FromCurrencyCode.Value
-                          ToCurrencyCode = this.ToCurrencyCode.Value
-                          AverageRate = this.AverageRate.Value
-                          EndOfDayRate = this.EndOfDayRate.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let CurrencyRate = leftTable<``CurrencyRate (base)``, CurrencyRate>
 
         type private ``Customer (base)`` = Customer
@@ -3933,23 +3148,6 @@ module Sales =
 
             interface ILeftViewOf<``Customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Customer (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``Customer (base)`` =
-                        { CustomerID = value
-                          PersonID = this.PersonID
-                          StoreID = this.StoreID
-                          TerritoryID = this.TerritoryID
-                          AccountNumber = this.AccountNumber.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Customer = leftTable<``Customer (base)``, Customer>
 
         type private ``PersonCreditCard (base)`` = PersonCreditCard
@@ -3964,17 +3162,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``PersonCreditCard (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``PersonCreditCard (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``PersonCreditCard (base)`` =
-                        { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let PersonCreditCard = leftTable<``PersonCreditCard (base)``, PersonCreditCard>
 
@@ -4006,27 +3193,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderDetail (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderDetail (base)`` =
-                        { SalesOrderID = value
-                          SalesOrderDetailID = this.SalesOrderDetailID.Value
-                          CarrierTrackingNumber = this.CarrierTrackingNumber
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          SpecialOfferID = this.SpecialOfferID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          UnitPriceDiscount = this.UnitPriceDiscount.Value
-                          LineTotal = this.LineTotal.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
 
@@ -4089,42 +3255,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeader (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeader (base)`` =
-                        { SalesOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          OrderDate = this.OrderDate.Value
-                          DueDate = this.DueDate.Value
-                          ShipDate = this.ShipDate
-                          Status = this.Status.Value
-                          OnlineOrderFlag = this.OnlineOrderFlag.Value
-                          SalesOrderNumber = this.SalesOrderNumber.Value
-                          PurchaseOrderNumber = this.PurchaseOrderNumber
-                          AccountNumber = this.AccountNumber
-                          CustomerID = this.CustomerID.Value
-                          SalesPersonID = this.SalesPersonID
-                          TerritoryID = this.TerritoryID
-                          BillToAddressID = this.BillToAddressID.Value
-                          ShipToAddressID = this.ShipToAddressID.Value
-                          ShipMethodID = this.ShipMethodID.Value
-                          CreditCardID = this.CreditCardID
-                          CreditCardApprovalCode = this.CreditCardApprovalCode
-                          CurrencyRateID = this.CurrencyRateID
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          Comment = this.Comment
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
 
         type private ``SalesOrderHeaderSalesReason (base)`` = SalesOrderHeaderSalesReason
@@ -4139,17 +3269,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderHeaderSalesReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeaderSalesReason (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeaderSalesReason (base)`` =
-                        { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderHeaderSalesReason =
             leftTable<``SalesOrderHeaderSalesReason (base)``, SalesOrderHeaderSalesReason>
@@ -4179,25 +3298,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesPerson (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesPerson (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesPerson (base)`` =
-                        { BusinessEntityID = value
-                          TerritoryID = this.TerritoryID
-                          SalesQuota = this.SalesQuota
-                          Bonus = this.Bonus.Value
-                          CommissionPct = this.CommissionPct.Value
-                          SalesYTD = this.SalesYTD.Value
-                          SalesLastYear = this.SalesLastYear.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesPerson = leftTable<``SalesPerson (base)``, SalesPerson>
 
         type private ``SalesPersonQuotaHistory (base)`` = SalesPersonQuotaHistory
@@ -4217,17 +3317,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesPersonQuotaHistory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesPersonQuotaHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesPersonQuotaHistory (base)`` =
-                        { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesPersonQuotaHistory =
             leftTable<``SalesPersonQuotaHistory (base)``, SalesPersonQuotaHistory>
 
@@ -4245,17 +3334,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesReason (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesReason (base)`` option =
-                match this.SalesReasonID with
-                | Some value ->
-                    let record: ``SalesReason (base)`` =
-                        { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesReason = leftTable<``SalesReason (base)``, SalesReason>
 
@@ -4279,23 +3357,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesTaxRate (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTaxRate (base)`` option =
-                match this.SalesTaxRateID with
-                | Some value ->
-                    let record: ``SalesTaxRate (base)`` =
-                        { SalesTaxRateID = value
-                          StateProvinceID = this.StateProvinceID.Value
-                          TaxType = this.TaxType.Value
-                          TaxRate = this.TaxRate.Value
-                          Name = this.Name.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesTaxRate = leftTable<``SalesTaxRate (base)``, SalesTaxRate>
 
@@ -4326,26 +3387,6 @@ module Sales =
 
             interface ILeftViewOf<``SalesTerritory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTerritory (base)`` option =
-                match this.TerritoryID with
-                | Some value ->
-                    let record: ``SalesTerritory (base)`` =
-                        { TerritoryID = value
-                          Name = this.Name.Value
-                          CountryRegionCode = this.CountryRegionCode.Value
-                          Group = this.Group.Value
-                          SalesYTD = this.SalesYTD.Value
-                          SalesLastYear = this.SalesLastYear.Value
-                          CostYTD = this.CostYTD.Value
-                          CostLastYear = this.CostLastYear.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesTerritory = leftTable<``SalesTerritory (base)``, SalesTerritory>
 
         type private ``SalesTerritoryHistory (base)`` = SalesTerritoryHistory
@@ -4366,22 +3407,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesTerritoryHistory (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesTerritoryHistory (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``SalesTerritoryHistory (base)`` =
-                        { BusinessEntityID = value
-                          TerritoryID = this.TerritoryID.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesTerritoryHistory =
             leftTable<``SalesTerritoryHistory (base)``, SalesTerritoryHistory>
@@ -4404,22 +3429,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ShoppingCartItem (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ShoppingCartItem (base)`` option =
-                match this.ShoppingCartItemID with
-                | Some value ->
-                    let record: ``ShoppingCartItem (base)`` =
-                        { ShoppingCartItemID = value
-                          ShoppingCartID = this.ShoppingCartID.Value
-                          Quantity = this.Quantity.Value
-                          ProductID = this.ProductID.Value
-                          DateCreated = this.DateCreated.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ShoppingCartItem = leftTable<``ShoppingCartItem (base)``, ShoppingCartItem>
 
@@ -4452,27 +3461,6 @@ module Sales =
 
             interface ILeftViewOf<``SpecialOffer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SpecialOffer (base)`` option =
-                match this.SpecialOfferID with
-                | Some value ->
-                    let record: ``SpecialOffer (base)`` =
-                        { SpecialOfferID = value
-                          Description = this.Description.Value
-                          DiscountPct = this.DiscountPct.Value
-                          Type = this.Type.Value
-                          Category = this.Category.Value
-                          StartDate = this.StartDate.Value
-                          EndDate = this.EndDate.Value
-                          MinQty = this.MinQty.Value
-                          MaxQty = this.MaxQty
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SpecialOffer = leftTable<``SpecialOffer (base)``, SpecialOffer>
 
         type private ``SpecialOfferProduct (base)`` = SpecialOfferProduct
@@ -4489,17 +3477,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SpecialOfferProduct (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SpecialOfferProduct (base)`` option =
-                match this.SpecialOfferID with
-                | Some value ->
-                    let record: ``SpecialOfferProduct (base)`` =
-                        { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SpecialOfferProduct =
             leftTable<``SpecialOfferProduct (base)``, SpecialOfferProduct>
@@ -4520,17 +3497,6 @@ module Sales =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``Store (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Store (base)`` option =
-                match this.BusinessEntityID with
-                | Some value ->
-                    let record: ``Store (base)`` =
-                        { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let Store = leftTable<``Store (base)``, Store>
 
@@ -4639,17 +3605,6 @@ module dbo =
 
             interface ILeftViewOf<``AWBuildVersion (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``AWBuildVersion (base)`` option =
-                match this.SystemInformationID with
-                | Some value ->
-                    let record: ``AWBuildVersion (base)`` =
-                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let AWBuildVersion = leftTable<``AWBuildVersion (base)``, AWBuildVersion>
 
         type private ``DatabaseLog (base)`` = DatabaseLog
@@ -4672,23 +3627,6 @@ module dbo =
               TSQL: Option<string> }
 
             interface ILeftViewOf<``DatabaseLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``DatabaseLog (base)`` option =
-                match this.DatabaseLogID with
-                | Some value ->
-                    let record: ``DatabaseLog (base)`` =
-                        { DatabaseLogID = value
-                          PostTime = this.PostTime.Value
-                          DatabaseUser = this.DatabaseUser.Value
-                          Event = this.Event.Value
-                          Schema = this.Schema
-                          Object = this.Object
-                          TSQL = this.TSQL.Value }
-
-                    Some record
-                | None -> None
 
         let DatabaseLog = leftTable<``DatabaseLog (base)``, DatabaseLog>
 
@@ -4716,25 +3654,6 @@ module dbo =
               ErrorMessage: Option<string> }
 
             interface ILeftViewOf<``ErrorLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ErrorLog (base)`` option =
-                match this.ErrorLogID with
-                | Some value ->
-                    let record: ``ErrorLog (base)`` =
-                        { ErrorLogID = value
-                          ErrorTime = this.ErrorTime.Value
-                          UserName = this.UserName.Value
-                          ErrorNumber = this.ErrorNumber.Value
-                          ErrorSeverity = this.ErrorSeverity
-                          ErrorState = this.ErrorState
-                          ErrorProcedure = this.ErrorProcedure
-                          ErrorLine = this.ErrorLine
-                          ErrorMessage = this.ErrorMessage.Value }
-
-                    Some record
-                | None -> None
 
         let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
 
@@ -4819,17 +3738,6 @@ module ext =
 
             interface ILeftViewOf<``DateTime2Support (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``DateTime2Support (base)`` option =
-                match this.ID with
-                | Some value ->
-                    let record: ``DateTime2Support (base)`` =
-                        { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
-
-                    Some record
-                | None -> None
-
         let DateTime2Support = leftTable<``DateTime2Support (base)``, DateTime2Support>
 
         type private ``GetIdGuidRepro (base)`` = GetIdGuidRepro
@@ -4843,17 +3751,6 @@ module ext =
 
             interface ILeftViewOf<``GetIdGuidRepro (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``GetIdGuidRepro (base)`` option =
-                match this.Id with
-                | Some value ->
-                    let record: ``GetIdGuidRepro (base)`` =
-                        { Id = value; EmailAddress = this.EmailAddress.Value }
-
-                    Some record
-                | None -> None
-
         let GetIdGuidRepro = leftTable<``GetIdGuidRepro (base)``, GetIdGuidRepro>
 
         type private ``HierarchyIdSupport (base)`` = HierarchyIdSupport
@@ -4866,17 +3763,6 @@ module ext =
               Hierarchy: Option<Microsoft.SqlServer.Types.SqlHierarchyId> }
 
             interface ILeftViewOf<``HierarchyIdSupport (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``HierarchyIdSupport (base)`` option =
-                match this.Id with
-                | Some value ->
-                    let record: ``HierarchyIdSupport (base)`` =
-                        { Id = value; Hierarchy = this.Hierarchy.Value }
-
-                    Some record
-                | None -> None
 
         let HierarchyIdSupport =
             leftTable<``HierarchyIdSupport (base)``, HierarchyIdSupport>
@@ -4894,18 +3780,1206 @@ module ext =
 
             interface ILeftViewOf<``NullableKeyUpsert (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``NullableKeyUpsert (base)`` option =
-                match this.Key1 with
-                | Some value ->
-                    let record: ``NullableKeyUpsert (base)`` =
-                        { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
-
-                    Some record
-                | None -> None
-
         let NullableKeyUpsert = leftTable<``NullableKeyUpsert (base)``, NullableKeyUpsert>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type HumanResources.LeftJoined.Department with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Department option =
+            match this.DepartmentID with
+            | Some value ->
+                let record: HumanResources.Department =
+                    { DepartmentID = value; Name = this.Name.Value; GroupName = this.GroupName.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.Employee with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Employee option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.Employee =
+                    { BusinessEntityID = value
+                      NationalIDNumber = this.NationalIDNumber.Value
+                      LoginID = this.LoginID.Value
+                      OrganizationNode = this.OrganizationNode
+                      OrganizationLevel = this.OrganizationLevel
+                      JobTitle = this.JobTitle.Value
+                      BirthDate = this.BirthDate.Value
+                      MaritalStatus = this.MaritalStatus.Value
+                      Gender = this.Gender.Value
+                      HireDate = this.HireDate.Value
+                      SalariedFlag = this.SalariedFlag.Value
+                      VacationHours = this.VacationHours.Value
+                      SickLeaveHours = this.SickLeaveHours.Value
+                      CurrentFlag = this.CurrentFlag.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.EmployeeDepartmentHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.EmployeeDepartmentHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.EmployeeDepartmentHistory =
+                    { BusinessEntityID = value
+                      DepartmentID = this.DepartmentID.Value
+                      ShiftID = this.ShiftID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.EmployeePayHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.EmployeePayHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: HumanResources.EmployeePayHistory =
+                    { BusinessEntityID = value; RateChangeDate = this.RateChangeDate.Value; Rate = this.Rate.Value; PayFrequency = this.PayFrequency.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.JobCandidate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.JobCandidate option =
+            match this.JobCandidateID with
+            | Some value ->
+                let record: HumanResources.JobCandidate =
+                    { JobCandidateID = value; BusinessEntityID = this.BusinessEntityID; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type HumanResources.LeftJoined.Shift with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : HumanResources.Shift option =
+            match this.ShiftID with
+            | Some value ->
+                let record: HumanResources.Shift =
+                    { ShiftID = value; Name = this.Name.Value; StartTime = this.StartTime.Value; EndTime = this.EndTime.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Address option =
+            match this.AddressID with
+            | Some value ->
+                let record: Person.Address =
+                    { AddressID = value
+                      AddressLine1 = this.AddressLine1.Value
+                      AddressLine2 = this.AddressLine2
+                      City = this.City.Value
+                      StateProvinceID = this.StateProvinceID.Value
+                      PostalCode = this.PostalCode.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.AddressType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.AddressType option =
+            match this.AddressTypeID with
+            | Some value ->
+                let record: Person.AddressType =
+                    { AddressTypeID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntity with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntity option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntity =
+                    { BusinessEntityID = value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntityAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntityAddress option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntityAddress =
+                    { BusinessEntityID = value; AddressID = this.AddressID.Value; AddressTypeID = this.AddressTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.BusinessEntityContact with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.BusinessEntityContact option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.BusinessEntityContact =
+                    { BusinessEntityID = value; PersonID = this.PersonID.Value; ContactTypeID = this.ContactTypeID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.ContactType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.ContactType option =
+            match this.ContactTypeID with
+            | Some value ->
+                let record: Person.ContactType =
+                    { ContactTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.CountryRegion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.CountryRegion option =
+            match this.CountryRegionCode with
+            | Some value ->
+                let record: Person.CountryRegion =
+                    { CountryRegionCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.EmailAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.EmailAddress option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.EmailAddress =
+                    { BusinessEntityID = value; EmailAddressID = this.EmailAddressID.Value; EmailAddress = this.EmailAddress; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Password with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Password option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.Password =
+                    { BusinessEntityID = value; PasswordHash = this.PasswordHash.Value; PasswordSalt = this.PasswordSalt.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.Person with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.Person option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.Person =
+                    { BusinessEntityID = value
+                      PersonType = this.PersonType.Value
+                      NameStyle = this.NameStyle.Value
+                      Title = this.Title
+                      FirstName = this.FirstName.Value
+                      MiddleName = this.MiddleName
+                      LastName = this.LastName.Value
+                      Suffix = this.Suffix
+                      EmailPromotion = this.EmailPromotion.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.PersonPhone with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.PersonPhone option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Person.PersonPhone =
+                    { BusinessEntityID = value; PhoneNumber = this.PhoneNumber.Value; PhoneNumberTypeID = this.PhoneNumberTypeID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.PhoneNumberType with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.PhoneNumberType option =
+            match this.PhoneNumberTypeID with
+            | Some value ->
+                let record: Person.PhoneNumberType =
+                    { PhoneNumberTypeID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Person.LeftJoined.StateProvince with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Person.StateProvince option =
+            match this.StateProvinceID with
+            | Some value ->
+                let record: Person.StateProvince =
+                    { StateProvinceID = value
+                      StateProvinceCode = this.StateProvinceCode.Value
+                      CountryRegionCode = this.CountryRegionCode.Value
+                      IsOnlyStateProvinceFlag = this.IsOnlyStateProvinceFlag.Value
+                      Name = this.Name.Value
+                      TerritoryID = this.TerritoryID.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.BillOfMaterials with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.BillOfMaterials option =
+            match this.BillOfMaterialsID with
+            | Some value ->
+                let record: Production.BillOfMaterials =
+                    { BillOfMaterialsID = value
+                      ProductAssemblyID = this.ProductAssemblyID
+                      ComponentID = this.ComponentID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      UnitMeasureCode = this.UnitMeasureCode.Value
+                      BOMLevel = this.BOMLevel.Value
+                      PerAssemblyQty = this.PerAssemblyQty.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Culture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Culture option =
+            match this.CultureID with
+            | Some value ->
+                let record: Production.Culture =
+                    { CultureID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Document with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Document option =
+            match this.DocumentNode with
+            | Some value ->
+                let record: Production.Document =
+                    { DocumentNode = value
+                      DocumentLevel = this.DocumentLevel
+                      Title = this.Title.Value
+                      Owner = this.Owner.Value
+                      FolderFlag = this.FolderFlag.Value
+                      FileName = this.FileName.Value
+                      FileExtension = this.FileExtension.Value
+                      Revision = this.Revision.Value
+                      ChangeNumber = this.ChangeNumber.Value
+                      Status = this.Status.Value
+                      DocumentSummary = this.DocumentSummary
+                      Document = this.Document
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Illustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Illustration option =
+            match this.IllustrationID with
+            | Some value ->
+                let record: Production.Illustration =
+                    { IllustrationID = value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Location with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Location option =
+            match this.LocationID with
+            | Some value ->
+                let record: Production.Location =
+                    { LocationID = value; Name = this.Name.Value; CostRate = this.CostRate.Value; Availability = this.Availability.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.Product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.Product option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.Product =
+                    { ProductID = value
+                      Name = this.Name.Value
+                      ProductNumber = this.ProductNumber.Value
+                      MakeFlag = this.MakeFlag.Value
+                      FinishedGoodsFlag = this.FinishedGoodsFlag.Value
+                      Color = this.Color
+                      SafetyStockLevel = this.SafetyStockLevel.Value
+                      ReorderPoint = this.ReorderPoint.Value
+                      StandardCost = this.StandardCost.Value
+                      ListPrice = this.ListPrice.Value
+                      Size = this.Size
+                      SizeUnitMeasureCode = this.SizeUnitMeasureCode
+                      WeightUnitMeasureCode = this.WeightUnitMeasureCode
+                      Weight = this.Weight
+                      DaysToManufacture = this.DaysToManufacture.Value
+                      ProductLine = this.ProductLine
+                      Class = this.Class
+                      Style = this.Style
+                      ProductSubcategoryID = this.ProductSubcategoryID
+                      ProductModelID = this.ProductModelID
+                      SellStartDate = this.SellStartDate.Value
+                      SellEndDate = this.SellEndDate
+                      DiscontinuedDate = this.DiscontinuedDate
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductCategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductCategory option =
+            match this.ProductCategoryID with
+            | Some value ->
+                let record: Production.ProductCategory =
+                    { ProductCategoryID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductCostHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductCostHistory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductCostHistory =
+                    { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; StandardCost = this.StandardCost.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductDescription option =
+            match this.ProductDescriptionID with
+            | Some value ->
+                let record: Production.ProductDescription =
+                    { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductDocument with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductDocument option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductDocument =
+                    { ProductID = value; DocumentNode = this.DocumentNode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductInventory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductInventory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductInventory =
+                    { ProductID = value
+                      LocationID = this.LocationID.Value
+                      Shelf = this.Shelf.Value
+                      Bin = this.Bin.Value
+                      Quantity = this.Quantity.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductListPriceHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductListPriceHistory option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductListPriceHistory =
+                    { ProductID = value; StartDate = this.StartDate.Value; EndDate = this.EndDate; ListPrice = this.ListPrice.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModel option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModel =
+                    { ProductModelID = value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModelIllustration with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModelIllustration option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModelIllustration =
+                    { ProductModelID = value; IllustrationID = this.IllustrationID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductModelProductDescriptionCulture with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductModelProductDescriptionCulture option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: Production.ProductModelProductDescriptionCulture =
+                    { ProductModelID = value; ProductDescriptionID = this.ProductDescriptionID.Value; CultureID = this.CultureID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductPhoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductPhoto option =
+            match this.ProductPhotoID with
+            | Some value ->
+                let record: Production.ProductPhoto =
+                    { ProductPhotoID = value
+                      ThumbNailPhoto = this.ThumbNailPhoto
+                      ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                      LargePhoto = this.LargePhoto
+                      LargePhotoFileName = this.LargePhotoFileName
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductProductPhoto with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductProductPhoto option =
+            match this.ProductID with
+            | Some value ->
+                let record: Production.ProductProductPhoto =
+                    { ProductID = value; ProductPhotoID = this.ProductPhotoID.Value; Primary = this.Primary.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductReview with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductReview option =
+            match this.ProductReviewID with
+            | Some value ->
+                let record: Production.ProductReview =
+                    { ProductReviewID = value
+                      ProductID = this.ProductID.Value
+                      ReviewerName = this.ReviewerName.Value
+                      ReviewDate = this.ReviewDate.Value
+                      EmailAddress = this.EmailAddress.Value
+                      Rating = this.Rating.Value
+                      Comments = this.Comments
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ProductSubcategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ProductSubcategory option =
+            match this.ProductSubcategoryID with
+            | Some value ->
+                let record: Production.ProductSubcategory =
+                    { ProductSubcategoryID = value; ProductCategoryID = this.ProductCategoryID.Value; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.ScrapReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.ScrapReason option =
+            match this.ScrapReasonID with
+            | Some value ->
+                let record: Production.ScrapReason =
+                    { ScrapReasonID = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.TransactionHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.TransactionHistory option =
+            match this.TransactionID with
+            | Some value ->
+                let record: Production.TransactionHistory =
+                    { TransactionID = value
+                      ProductID = this.ProductID.Value
+                      ReferenceOrderID = this.ReferenceOrderID.Value
+                      ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                      TransactionDate = this.TransactionDate.Value
+                      TransactionType = this.TransactionType.Value
+                      Quantity = this.Quantity.Value
+                      ActualCost = this.ActualCost.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.TransactionHistoryArchive with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.TransactionHistoryArchive option =
+            match this.TransactionID with
+            | Some value ->
+                let record: Production.TransactionHistoryArchive =
+                    { TransactionID = value
+                      ProductID = this.ProductID.Value
+                      ReferenceOrderID = this.ReferenceOrderID.Value
+                      ReferenceOrderLineID = this.ReferenceOrderLineID.Value
+                      TransactionDate = this.TransactionDate.Value
+                      TransactionType = this.TransactionType.Value
+                      Quantity = this.Quantity.Value
+                      ActualCost = this.ActualCost.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.UnitMeasure with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.UnitMeasure option =
+            match this.UnitMeasureCode with
+            | Some value ->
+                let record: Production.UnitMeasure =
+                    { UnitMeasureCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.WorkOrder with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.WorkOrder option =
+            match this.WorkOrderID with
+            | Some value ->
+                let record: Production.WorkOrder =
+                    { WorkOrderID = value
+                      ProductID = this.ProductID.Value
+                      OrderQty = this.OrderQty.Value
+                      StockedQty = this.StockedQty.Value
+                      ScrappedQty = this.ScrappedQty.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      DueDate = this.DueDate.Value
+                      ScrapReasonID = this.ScrapReasonID
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Production.LeftJoined.WorkOrderRouting with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Production.WorkOrderRouting option =
+            match this.WorkOrderID with
+            | Some value ->
+                let record: Production.WorkOrderRouting =
+                    { WorkOrderID = value
+                      ProductID = this.ProductID.Value
+                      OperationSequence = this.OperationSequence.Value
+                      LocationID = this.LocationID.Value
+                      ScheduledStartDate = this.ScheduledStartDate.Value
+                      ScheduledEndDate = this.ScheduledEndDate.Value
+                      ActualStartDate = this.ActualStartDate
+                      ActualEndDate = this.ActualEndDate
+                      ActualResourceHrs = this.ActualResourceHrs
+                      PlannedCost = this.PlannedCost.Value
+                      ActualCost = this.ActualCost
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.ProductVendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.ProductVendor option =
+            match this.ProductID with
+            | Some value ->
+                let record: Purchasing.ProductVendor =
+                    { ProductID = value
+                      BusinessEntityID = this.BusinessEntityID.Value
+                      AverageLeadTime = this.AverageLeadTime.Value
+                      StandardPrice = this.StandardPrice.Value
+                      LastReceiptCost = this.LastReceiptCost
+                      LastReceiptDate = this.LastReceiptDate
+                      MinOrderQty = this.MinOrderQty.Value
+                      MaxOrderQty = this.MaxOrderQty.Value
+                      OnOrderQty = this.OnOrderQty
+                      UnitMeasureCode = this.UnitMeasureCode.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.PurchaseOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.PurchaseOrderDetail option =
+            match this.PurchaseOrderID with
+            | Some value ->
+                let record: Purchasing.PurchaseOrderDetail =
+                    { PurchaseOrderID = value
+                      PurchaseOrderDetailID = this.PurchaseOrderDetailID.Value
+                      DueDate = this.DueDate.Value
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      LineTotal = this.LineTotal.Value
+                      ReceivedQty = this.ReceivedQty.Value
+                      RejectedQty = this.RejectedQty.Value
+                      StockedQty = this.StockedQty.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.PurchaseOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.PurchaseOrderHeader option =
+            match this.PurchaseOrderID with
+            | Some value ->
+                let record: Purchasing.PurchaseOrderHeader =
+                    { PurchaseOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      Status = this.Status.Value
+                      EmployeeID = this.EmployeeID.Value
+                      VendorID = this.VendorID.Value
+                      ShipMethodID = this.ShipMethodID.Value
+                      OrderDate = this.OrderDate.Value
+                      ShipDate = this.ShipDate
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.ShipMethod with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.ShipMethod option =
+            match this.ShipMethodID with
+            | Some value ->
+                let record: Purchasing.ShipMethod =
+                    { ShipMethodID = value
+                      Name = this.Name.Value
+                      ShipBase = this.ShipBase.Value
+                      ShipRate = this.ShipRate.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Purchasing.LeftJoined.Vendor with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Purchasing.Vendor option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Purchasing.Vendor =
+                    { BusinessEntityID = value
+                      AccountNumber = this.AccountNumber.Value
+                      Name = this.Name.Value
+                      CreditRating = this.CreditRating.Value
+                      PreferredVendorStatus = this.PreferredVendorStatus.Value
+                      ActiveFlag = this.ActiveFlag.Value
+                      PurchasingWebServiceURL = this.PurchasingWebServiceURL
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CountryRegionCurrency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CountryRegionCurrency option =
+            match this.CountryRegionCode with
+            | Some value ->
+                let record: Sales.CountryRegionCurrency =
+                    { CountryRegionCode = value; CurrencyCode = this.CurrencyCode.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CreditCard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CreditCard option =
+            match this.CreditCardID with
+            | Some value ->
+                let record: Sales.CreditCard =
+                    { CreditCardID = value
+                      CardType = this.CardType.Value
+                      CardNumber = this.CardNumber.Value
+                      ExpMonth = this.ExpMonth.Value
+                      ExpYear = this.ExpYear.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Currency with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Currency option =
+            match this.CurrencyCode with
+            | Some value ->
+                let record: Sales.Currency =
+                    { CurrencyCode = value; Name = this.Name.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.CurrencyRate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.CurrencyRate option =
+            match this.CurrencyRateID with
+            | Some value ->
+                let record: Sales.CurrencyRate =
+                    { CurrencyRateID = value
+                      CurrencyRateDate = this.CurrencyRateDate.Value
+                      FromCurrencyCode = this.FromCurrencyCode.Value
+                      ToCurrencyCode = this.ToCurrencyCode.Value
+                      AverageRate = this.AverageRate.Value
+                      EndOfDayRate = this.EndOfDayRate.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Customer option =
+            match this.CustomerID with
+            | Some value ->
+                let record: Sales.Customer =
+                    { CustomerID = value
+                      PersonID = this.PersonID
+                      StoreID = this.StoreID
+                      TerritoryID = this.TerritoryID
+                      AccountNumber = this.AccountNumber.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.PersonCreditCard with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.PersonCreditCard option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.PersonCreditCard =
+                    { BusinessEntityID = value; CreditCardID = this.CreditCardID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderDetail option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderDetail =
+                    { SalesOrderID = value
+                      SalesOrderDetailID = this.SalesOrderDetailID.Value
+                      CarrierTrackingNumber = this.CarrierTrackingNumber
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      SpecialOfferID = this.SpecialOfferID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      UnitPriceDiscount = this.UnitPriceDiscount.Value
+                      LineTotal = this.LineTotal.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderHeader option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderHeader =
+                    { SalesOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      OrderDate = this.OrderDate.Value
+                      DueDate = this.DueDate.Value
+                      ShipDate = this.ShipDate
+                      Status = this.Status.Value
+                      OnlineOrderFlag = this.OnlineOrderFlag.Value
+                      SalesOrderNumber = this.SalesOrderNumber.Value
+                      PurchaseOrderNumber = this.PurchaseOrderNumber
+                      AccountNumber = this.AccountNumber
+                      CustomerID = this.CustomerID.Value
+                      SalesPersonID = this.SalesPersonID
+                      TerritoryID = this.TerritoryID
+                      BillToAddressID = this.BillToAddressID.Value
+                      ShipToAddressID = this.ShipToAddressID.Value
+                      ShipMethodID = this.ShipMethodID.Value
+                      CreditCardID = this.CreditCardID
+                      CreditCardApprovalCode = this.CreditCardApprovalCode
+                      CurrencyRateID = this.CurrencyRateID
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      Comment = this.Comment
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesOrderHeaderSalesReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesOrderHeaderSalesReason option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: Sales.SalesOrderHeaderSalesReason =
+                    { SalesOrderID = value; SalesReasonID = this.SalesReasonID.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesPerson with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesPerson option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesPerson =
+                    { BusinessEntityID = value
+                      TerritoryID = this.TerritoryID
+                      SalesQuota = this.SalesQuota
+                      Bonus = this.Bonus.Value
+                      CommissionPct = this.CommissionPct.Value
+                      SalesYTD = this.SalesYTD.Value
+                      SalesLastYear = this.SalesLastYear.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesPersonQuotaHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesPersonQuotaHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesPersonQuotaHistory =
+                    { BusinessEntityID = value; QuotaDate = this.QuotaDate.Value; SalesQuota = this.SalesQuota.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesReason with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesReason option =
+            match this.SalesReasonID with
+            | Some value ->
+                let record: Sales.SalesReason =
+                    { SalesReasonID = value; Name = this.Name.Value; ReasonType = this.ReasonType.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTaxRate with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTaxRate option =
+            match this.SalesTaxRateID with
+            | Some value ->
+                let record: Sales.SalesTaxRate =
+                    { SalesTaxRateID = value
+                      StateProvinceID = this.StateProvinceID.Value
+                      TaxType = this.TaxType.Value
+                      TaxRate = this.TaxRate.Value
+                      Name = this.Name.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTerritory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTerritory option =
+            match this.TerritoryID with
+            | Some value ->
+                let record: Sales.SalesTerritory =
+                    { TerritoryID = value
+                      Name = this.Name.Value
+                      CountryRegionCode = this.CountryRegionCode.Value
+                      Group = this.Group.Value
+                      SalesYTD = this.SalesYTD.Value
+                      SalesLastYear = this.SalesLastYear.Value
+                      CostYTD = this.CostYTD.Value
+                      CostLastYear = this.CostLastYear.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SalesTerritoryHistory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SalesTerritoryHistory option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.SalesTerritoryHistory =
+                    { BusinessEntityID = value
+                      TerritoryID = this.TerritoryID.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.ShoppingCartItem with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.ShoppingCartItem option =
+            match this.ShoppingCartItemID with
+            | Some value ->
+                let record: Sales.ShoppingCartItem =
+                    { ShoppingCartItemID = value
+                      ShoppingCartID = this.ShoppingCartID.Value
+                      Quantity = this.Quantity.Value
+                      ProductID = this.ProductID.Value
+                      DateCreated = this.DateCreated.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SpecialOffer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SpecialOffer option =
+            match this.SpecialOfferID with
+            | Some value ->
+                let record: Sales.SpecialOffer =
+                    { SpecialOfferID = value
+                      Description = this.Description.Value
+                      DiscountPct = this.DiscountPct.Value
+                      Type = this.Type.Value
+                      Category = this.Category.Value
+                      StartDate = this.StartDate.Value
+                      EndDate = this.EndDate.Value
+                      MinQty = this.MinQty.Value
+                      MaxQty = this.MaxQty
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.SpecialOfferProduct with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.SpecialOfferProduct option =
+            match this.SpecialOfferID with
+            | Some value ->
+                let record: Sales.SpecialOfferProduct =
+                    { SpecialOfferID = value; ProductID = this.ProductID.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type Sales.LeftJoined.Store with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : Sales.Store option =
+            match this.BusinessEntityID with
+            | Some value ->
+                let record: Sales.Store =
+                    { BusinessEntityID = value; Name = this.Name.Value; SalesPersonID = this.SalesPersonID; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.AWBuildVersion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.AWBuildVersion option =
+            match this.SystemInformationID with
+            | Some value ->
+                let record: dbo.AWBuildVersion =
+                    { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.DatabaseLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.DatabaseLog option =
+            match this.DatabaseLogID with
+            | Some value ->
+                let record: dbo.DatabaseLog =
+                    { DatabaseLogID = value
+                      PostTime = this.PostTime.Value
+                      DatabaseUser = this.DatabaseUser.Value
+                      Event = this.Event.Value
+                      Schema = this.Schema
+                      Object = this.Object
+                      TSQL = this.TSQL.Value }
+
+                Some record
+            | None -> None
+
+    type dbo.LeftJoined.ErrorLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : dbo.ErrorLog option =
+            match this.ErrorLogID with
+            | Some value ->
+                let record: dbo.ErrorLog =
+                    { ErrorLogID = value
+                      ErrorTime = this.ErrorTime.Value
+                      UserName = this.UserName.Value
+                      ErrorNumber = this.ErrorNumber.Value
+                      ErrorSeverity = this.ErrorSeverity
+                      ErrorState = this.ErrorState
+                      ErrorProcedure = this.ErrorProcedure
+                      ErrorLine = this.ErrorLine
+                      ErrorMessage = this.ErrorMessage.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.DateTime2Support with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.DateTime2Support option =
+            match this.ID with
+            | Some value ->
+                let record: ext.DateTime2Support =
+                    { ID = value; LessPrecision = this.LessPrecision.Value; MorePrecision = this.MorePrecision.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.GetIdGuidRepro with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.GetIdGuidRepro option =
+            match this.Id with
+            | Some value ->
+                let record: ext.GetIdGuidRepro =
+                    { Id = value; EmailAddress = this.EmailAddress.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.HierarchyIdSupport with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.HierarchyIdSupport option =
+            match this.Id with
+            | Some value ->
+                let record: ext.HierarchyIdSupport =
+                    { Id = value; Hierarchy = this.Hierarchy.Value }
+
+                Some record
+            | None -> None
+
+    type ext.LeftJoined.NullableKeyUpsert with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : ext.NullableKeyUpsert option =
+            match this.Key1 with
+            | Some value ->
+                let record: ext.NullableKeyUpsert =
+                    { Key1 = value; Key2 = this.Key2; Value = this.Value.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/SqlServer/QueryIntegrationTests.fs
+++ b/src/Tests/SqlServer/QueryIntegrationTests.fs
@@ -1071,14 +1071,59 @@ let ``Individual column from a leftJoin table should be optional if Some``() = t
         }
         |> ctx.SelectAsync
 
-    let reasonsExist = 
-        results 
-        |> Seq.forall (fun (id, reasonType, name) -> 
+    let reasonsExist =
+        results
+        |> Seq.forall (fun (id, reasonType, name) ->
             reasonType <> None && name <> None
         )
 
     gt0 results
     reasonsExist =! false
+}
+
+[<Test>]
+let ``Left-view leftJoin: an unmatched row hydrates as all-None and ToOption is None``() = task {
+    use! ctx = db.OpenContextAsync()
+
+    let! results =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin sr in Sales.LeftJoined.SalesOrderHeaderSalesReason on (o.SalesOrderID = sr.SalesOrderID)
+            where (isNullValue sr.SalesReasonID)
+            select (o.SalesOrderID, sr)
+            take 10
+        }
+        |> ctx.SelectAsync
+
+    gt0 results
+
+    for (_, sr) in results do
+        sr.SalesOrderID =! None
+        sr.SalesReasonID =! None
+        sr.ModifiedDate =! None
+        sr.ToOption() =! None
+}
+
+[<Test>]
+let ``Left-view leftJoin: a matched row hydrates as all-Some and ToOption recovers the record``() = task {
+    use! ctx = db.OpenContextAsync()
+
+    let! results =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin sr in Sales.LeftJoined.SalesOrderHeaderSalesReason on (o.SalesOrderID = sr.SalesOrderID)
+            where (isNotNullValue sr.SalesReasonID)
+            select (o.SalesOrderID, sr)
+            take 10
+        }
+        |> ctx.SelectAsync
+
+    gt0 results
+
+    for (oid, sr) in results do
+        match sr.ToOption() with
+        | Some record -> record.SalesOrderID =! oid
+        | None -> failwith "expected a matched row"
 }
     
 type Person = { Id: int; Name: string; Age: int }

--- a/src/Tests/SqlServer/QueryUnitTests.fs
+++ b/src/Tests/SqlServer/QueryUnitTests.fs
@@ -464,7 +464,77 @@ let ``Left Join - Multi Column``() =
     sql.Contains("LEFT JOIN [Sales].[SalesOrderDetail] AS [d] ON ([o].[SalesOrderID] = [d].[SalesOrderID] AND [o].[ModifiedDate] = [d].[ModifiedDate])") =! true
 
 [<Test>]
-let ``Correlated Subquery``() = 
+let ``Left Join Left-View - plain ON, nullable columns downstream``() =
+    let sql =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin d in Sales.LeftJoined.SalesOrderDetail on (o.SalesOrderID = d.SalesOrderID)
+            where (d.OrderQty = Some 1s)
+            select (o, d)
+        }
+        |> toSql
+
+    sql =!
+        "SELECT [o].*, [d].* FROM [Sales].[SalesOrderHeader] AS [o] \
+        LEFT JOIN [Sales].[SalesOrderDetail] AS [d] ON ([o].[SalesOrderID] = [d].[SalesOrderID]) \
+        WHERE ([d].[OrderQty] = @p0)"
+
+[<Test>]
+let ``Left Join Left-View - Multi Column``() =
+    let sql =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin d in Sales.LeftJoined.SalesOrderDetail on ((o.SalesOrderID, o.ModifiedDate) = (d.SalesOrderID, d.ModifiedDate))
+            select o
+        }
+        |> toSql
+
+    sql.Contains("LEFT JOIN [Sales].[SalesOrderDetail] AS [d] ON ([o].[SalesOrderID] = [d].[SalesOrderID] AND [o].[ModifiedDate] = [d].[ModifiedDate])") =! true
+
+[<Test>]
+let ``Left Join Left-View - anti-join via isNullValue on the witness column``() =
+    let sql =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin d in Sales.LeftJoined.SalesOrderDetail on (o.SalesOrderID = d.SalesOrderID)
+            where (isNullValue d.SalesOrderDetailID)
+            select o.SalesOrderID
+        }
+        |> toSql
+
+    sql =!
+        "SELECT [o].[SalesOrderID] FROM [Sales].[SalesOrderHeader] AS [o] \
+        LEFT JOIN [Sales].[SalesOrderDetail] AS [d] ON ([o].[SalesOrderID] = [d].[SalesOrderID]) \
+        WHERE ([d].[SalesOrderDetailID] IS NULL)"
+
+[<Test>]
+let ``Left Join Left-View - groupBy and aggregate over view columns``() =
+    let sql =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin d in Sales.LeftJoined.SalesOrderDetail on (o.SalesOrderID = d.SalesOrderID)
+            groupBy d.ProductID
+            select (d.ProductID, countBy o.SalesOrderID)
+        }
+        |> toSql
+
+    sql.Contains("GROUP BY [d].[ProductID]") =! true
+    sql.Contains("COUNT([o].[SalesOrderID])") =! true
+
+[<Test>]
+let ``Left Join Left-View - individual view columns in select``() =
+    let sql =
+        select {
+            for o in Sales.SalesOrderHeader do
+            leftJoin d in Sales.LeftJoined.SalesOrderDetail on (o.SalesOrderID = d.SalesOrderID)
+            select (o.SalesOrderID, d.OrderQty)
+        }
+        |> toSql
+
+    sql.Contains("SELECT [o].[SalesOrderID], [d].[OrderQty]") =! true
+
+[<Test>]
+let ``Correlated Subquery``() =
     let maxOrderQty = 
         select {
             for d in Sales.SalesOrderDetail do

--- a/src/Tests/Sqlite/AdventureWorksNet10.fs
+++ b/src/Tests/Sqlite/AdventureWorksNet10.fs
@@ -325,6 +325,444 @@ module main =
 
     let SalesOrderHeader = table<SalesOrderHeader>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Address (base)`` = Address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Address =
+            { AddressID: Option<int64>
+              AddressLine1: Option<Sqlite.CustomTypes.Text>
+              AddressLine2: Option<Sqlite.CustomTypes.Text>
+              City: Option<Sqlite.CustomTypes.Text>
+              StateProvince: Option<Sqlite.CustomTypes.Text>
+              CountryRegion: Option<Sqlite.CustomTypes.Text>
+              PostalCode: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Address (base)`` option =
+                match this.AddressID with
+                | Some value ->
+                    let record: ``Address (base)`` =
+                        { AddressID = value
+                          AddressLine1 = this.AddressLine1.Value
+                          AddressLine2 = this.AddressLine2
+                          City = this.City.Value
+                          StateProvince = this.StateProvince.Value
+                          CountryRegion = this.CountryRegion.Value
+                          PostalCode = this.PostalCode.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Address = leftTable<``Address (base)``, Address>
+
+        type private ``BuildVersion (base)`` = BuildVersion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BuildVersion =
+            { SystemInformationID: Option<int64>
+              ``Database Version``: Option<Sqlite.CustomTypes.Text>
+              VersionDate: Option<System.DateTime>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BuildVersion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BuildVersion (base)`` option =
+                match this.SystemInformationID with
+                | Some value ->
+                    let record: ``BuildVersion (base)`` =
+                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BuildVersion = leftTable<``BuildVersion (base)``, BuildVersion>
+
+        type private ``Customer (base)`` = Customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Customer =
+            { CustomerID: Option<int64>
+              NameStyle: Option<int64>
+              Title: Option<Sqlite.CustomTypes.Text>
+              FirstName: Option<Sqlite.CustomTypes.Text>
+              MiddleName: Option<Sqlite.CustomTypes.Text>
+              LastName: Option<Sqlite.CustomTypes.Text>
+              Suffix: Option<Sqlite.CustomTypes.Text>
+              CompanyName: Option<Sqlite.CustomTypes.Text>
+              SalesPerson: Option<Sqlite.CustomTypes.Text>
+              EmailAddress: Option<Sqlite.CustomTypes.Text>
+              Phone: Option<Sqlite.CustomTypes.Text>
+              PasswordHash: Option<Sqlite.CustomTypes.Text>
+              PasswordSalt: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Customer (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``Customer (base)`` =
+                        { CustomerID = value
+                          NameStyle = this.NameStyle.Value
+                          Title = this.Title
+                          FirstName = this.FirstName.Value
+                          MiddleName = this.MiddleName
+                          LastName = this.LastName.Value
+                          Suffix = this.Suffix
+                          CompanyName = this.CompanyName
+                          SalesPerson = this.SalesPerson
+                          EmailAddress = this.EmailAddress
+                          Phone = this.Phone
+                          PasswordHash = this.PasswordHash.Value
+                          PasswordSalt = this.PasswordSalt.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Customer = leftTable<``Customer (base)``, Customer>
+
+        type private ``CustomerAddress (base)`` = CustomerAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CustomerAddress =
+            { CustomerID: Option<int64>
+              AddressID: Option<int64>
+              AddressType: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CustomerAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CustomerAddress (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``CustomerAddress (base)`` =
+                        { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CustomerAddress = leftTable<``CustomerAddress (base)``, CustomerAddress>
+
+        type private ``ErrorLog (base)`` = ErrorLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ErrorLog =
+            { ErrorLogID: Option<int64>
+              ErrorTime: Option<System.DateTime>
+              UserName: Option<Sqlite.CustomTypes.Text>
+              ErrorNumber: Option<int64>
+              ErrorSeverity: Option<int64>
+              ErrorState: Option<int64>
+              ErrorProcedure: Option<Sqlite.CustomTypes.Text>
+              ErrorLine: Option<int64>
+              ErrorMessage: Option<Sqlite.CustomTypes.Text> }
+
+            interface ILeftViewOf<``ErrorLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ErrorLog (base)`` option =
+                match this.ErrorLogID with
+                | Some value ->
+                    let record: ``ErrorLog (base)`` =
+                        { ErrorLogID = value
+                          ErrorTime = this.ErrorTime.Value
+                          UserName = this.UserName.Value
+                          ErrorNumber = this.ErrorNumber.Value
+                          ErrorSeverity = this.ErrorSeverity
+                          ErrorState = this.ErrorState
+                          ErrorProcedure = this.ErrorProcedure
+                          ErrorLine = this.ErrorLine
+                          ErrorMessage = this.ErrorMessage.Value }
+
+                    Some record
+                | None -> None
+
+        let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
+
+        type private ``Product (base)`` = Product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Product =
+            { ProductID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              ProductNumber: Option<Sqlite.CustomTypes.Text>
+              Color: Option<Sqlite.CustomTypes.Text>
+              StandardCost: Option<int64>
+              ListPrice: Option<int64>
+              Size: Option<Sqlite.CustomTypes.Text>
+              Weight: Option<int64>
+              ProductCategoryID: Option<int64>
+              ProductModelID: Option<int64>
+              SellStartDate: Option<System.DateTime>
+              SellEndDate: Option<System.DateTime>
+              DiscontinuedDate: Option<System.DateTime>
+              ThumbNailPhoto: Option<byte[]>
+              ThumbnailPhotoFileName: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Product (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``Product (base)`` =
+                        { ProductID = value
+                          Name = this.Name.Value
+                          ProductNumber = this.ProductNumber.Value
+                          Color = this.Color
+                          StandardCost = this.StandardCost.Value
+                          ListPrice = this.ListPrice.Value
+                          Size = this.Size
+                          Weight = this.Weight
+                          ProductCategoryID = this.ProductCategoryID
+                          ProductModelID = this.ProductModelID
+                          SellStartDate = this.SellStartDate.Value
+                          SellEndDate = this.SellEndDate
+                          DiscontinuedDate = this.DiscontinuedDate
+                          ThumbNailPhoto = this.ThumbNailPhoto
+                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Product = leftTable<``Product (base)``, Product>
+
+        type private ``ProductCategory (base)`` = ProductCategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCategory =
+            { ProductCategoryID: Option<int64>
+              ParentProductCategoryID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCategory (base)`` option =
+                match this.ProductCategoryID with
+                | Some value ->
+                    let record: ``ProductCategory (base)`` =
+                        { ProductCategoryID = value
+                          ParentProductCategoryID = this.ParentProductCategoryID
+                          Name = this.Name.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
+
+        type private ``ProductDescription (base)`` = ProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDescription =
+            { ProductDescriptionID: Option<int64>
+              Description: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDescription (base)`` option =
+                match this.ProductDescriptionID with
+                | Some value ->
+                    let record: ``ProductDescription (base)`` =
+                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDescription =
+            leftTable<``ProductDescription (base)``, ProductDescription>
+
+        type private ``ProductModel (base)`` = ProductModel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModel =
+            { ProductModelID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              CatalogDescription: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModel (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModel (base)`` =
+                        { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
+
+        type private ``ProductModelProductDescription (base)`` = ProductModelProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelProductDescription =
+            { ProductModelID: Option<int64>
+              ProductDescriptionID: Option<int64>
+              Culture: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelProductDescription (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelProductDescription (base)`` =
+                        { ProductModelID = value
+                          ProductDescriptionID = this.ProductDescriptionID.Value
+                          Culture = this.Culture.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelProductDescription =
+            leftTable<``ProductModelProductDescription (base)``, ProductModelProductDescription>
+
+        type private ``SalesOrderDetail (base)`` = SalesOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderDetail =
+            { SalesOrderID: Option<int64>
+              SalesOrderDetailID: Option<int64>
+              OrderQty: Option<int64>
+              ProductID: Option<int64>
+              UnitPrice: Option<int64>
+              UnitPriceDiscount: Option<int64>
+              LineTotal: Option<int64>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderDetail (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderDetail (base)`` =
+                        { SalesOrderID = value
+                          SalesOrderDetailID = this.SalesOrderDetailID.Value
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          UnitPriceDiscount = this.UnitPriceDiscount.Value
+                          LineTotal = this.LineTotal.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
+
+        type private ``SalesOrderHeader (base)`` = SalesOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeader =
+            { SalesOrderID: Option<int64>
+              RevisionNumber: Option<int64>
+              OrderDate: Option<System.DateTime>
+              DueDate: Option<System.DateTime>
+              ShipDate: Option<System.DateTime>
+              Status: Option<int64>
+              OnlineOrderFlag: Option<int64>
+              SalesOrderNumber: Option<string>
+              PurchaseOrderNumber: Option<int64>
+              AccountNumber: Option<Sqlite.CustomTypes.Text>
+              CustomerID: Option<int64>
+              ShipToAddressID: Option<int>
+              BillToAddressID: Option<int>
+              ShipMethod: Option<Sqlite.CustomTypes.Text>
+              CreditCardApprovalCode: Option<Sqlite.CustomTypes.Text>
+              SubTotal: Option<int64>
+              TaxAmt: Option<int64>
+              Freight: Option<int64>
+              TotalDue: Option<int64>
+              Comment: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeader (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeader (base)`` =
+                        { SalesOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          OrderDate = this.OrderDate.Value
+                          DueDate = this.DueDate.Value
+                          ShipDate = this.ShipDate
+                          Status = this.Status.Value
+                          OnlineOrderFlag = this.OnlineOrderFlag.Value
+                          SalesOrderNumber = this.SalesOrderNumber.Value
+                          PurchaseOrderNumber = this.PurchaseOrderNumber
+                          AccountNumber = this.AccountNumber
+                          CustomerID = this.CustomerID.Value
+                          ShipToAddressID = this.ShipToAddressID
+                          BillToAddressID = this.BillToAddressID
+                          ShipMethod = this.ShipMethod.Value
+                          CreditCardApprovalCode = this.CreditCardApprovalCode
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          Comment = this.Comment
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+
 
 
 type QueryContextFactory =

--- a/src/Tests/Sqlite/AdventureWorksNet10.fs
+++ b/src/Tests/Sqlite/AdventureWorksNet10.fs
@@ -344,25 +344,6 @@ module main =
 
             interface ILeftViewOf<``Address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Address (base)`` option =
-                match this.AddressID with
-                | Some value ->
-                    let record: ``Address (base)`` =
-                        { AddressID = value
-                          AddressLine1 = this.AddressLine1.Value
-                          AddressLine2 = this.AddressLine2
-                          City = this.City.Value
-                          StateProvince = this.StateProvince.Value
-                          CountryRegion = this.CountryRegion.Value
-                          PostalCode = this.PostalCode.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Address = leftTable<``Address (base)``, Address>
 
         type private ``BuildVersion (base)`` = BuildVersion
@@ -375,17 +356,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BuildVersion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BuildVersion (base)`` option =
-                match this.SystemInformationID with
-                | Some value ->
-                    let record: ``BuildVersion (base)`` =
-                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BuildVersion = leftTable<``BuildVersion (base)``, BuildVersion>
 
@@ -411,31 +381,6 @@ module main =
 
             interface ILeftViewOf<``Customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Customer (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``Customer (base)`` =
-                        { CustomerID = value
-                          NameStyle = this.NameStyle.Value
-                          Title = this.Title
-                          FirstName = this.FirstName.Value
-                          MiddleName = this.MiddleName
-                          LastName = this.LastName.Value
-                          Suffix = this.Suffix
-                          CompanyName = this.CompanyName
-                          SalesPerson = this.SalesPerson
-                          EmailAddress = this.EmailAddress
-                          Phone = this.Phone
-                          PasswordHash = this.PasswordHash.Value
-                          PasswordSalt = this.PasswordSalt.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Customer = leftTable<``Customer (base)``, Customer>
 
         type private ``CustomerAddress (base)`` = CustomerAddress
@@ -449,17 +394,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``CustomerAddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CustomerAddress (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``CustomerAddress (base)`` =
-                        { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let CustomerAddress = leftTable<``CustomerAddress (base)``, CustomerAddress>
 
@@ -478,25 +412,6 @@ module main =
               ErrorMessage: Option<Sqlite.CustomTypes.Text> }
 
             interface ILeftViewOf<``ErrorLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ErrorLog (base)`` option =
-                match this.ErrorLogID with
-                | Some value ->
-                    let record: ``ErrorLog (base)`` =
-                        { ErrorLogID = value
-                          ErrorTime = this.ErrorTime.Value
-                          UserName = this.UserName.Value
-                          ErrorNumber = this.ErrorNumber.Value
-                          ErrorSeverity = this.ErrorSeverity
-                          ErrorState = this.ErrorState
-                          ErrorProcedure = this.ErrorProcedure
-                          ErrorLine = this.ErrorLine
-                          ErrorMessage = this.ErrorMessage.Value }
-
-                    Some record
-                | None -> None
 
         let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
 
@@ -524,33 +439,6 @@ module main =
 
             interface ILeftViewOf<``Product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Product (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``Product (base)`` =
-                        { ProductID = value
-                          Name = this.Name.Value
-                          ProductNumber = this.ProductNumber.Value
-                          Color = this.Color
-                          StandardCost = this.StandardCost.Value
-                          ListPrice = this.ListPrice.Value
-                          Size = this.Size
-                          Weight = this.Weight
-                          ProductCategoryID = this.ProductCategoryID
-                          ProductModelID = this.ProductModelID
-                          SellStartDate = this.SellStartDate.Value
-                          SellEndDate = this.SellEndDate
-                          DiscontinuedDate = this.DiscontinuedDate
-                          ThumbNailPhoto = this.ThumbNailPhoto
-                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Product = leftTable<``Product (base)``, Product>
 
         type private ``ProductCategory (base)`` = ProductCategory
@@ -565,21 +453,6 @@ module main =
 
             interface ILeftViewOf<``ProductCategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCategory (base)`` option =
-                match this.ProductCategoryID with
-                | Some value ->
-                    let record: ``ProductCategory (base)`` =
-                        { ProductCategoryID = value
-                          ParentProductCategoryID = this.ParentProductCategoryID
-                          Name = this.Name.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
 
         type private ``ProductDescription (base)`` = ProductDescription
@@ -592,17 +465,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductDescription (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDescription (base)`` option =
-                match this.ProductDescriptionID with
-                | Some value ->
-                    let record: ``ProductDescription (base)`` =
-                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductDescription =
             leftTable<``ProductDescription (base)``, ProductDescription>
@@ -619,17 +481,6 @@ module main =
 
             interface ILeftViewOf<``ProductModel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModel (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModel (base)`` =
-                        { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
 
         type private ``ProductModelProductDescription (base)`` = ProductModelProductDescription
@@ -643,21 +494,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelProductDescription (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelProductDescription (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelProductDescription (base)`` =
-                        { ProductModelID = value
-                          ProductDescriptionID = this.ProductDescriptionID.Value
-                          Culture = this.Culture.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelProductDescription =
             leftTable<``ProductModelProductDescription (base)``, ProductModelProductDescription>
@@ -677,25 +513,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderDetail (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderDetail (base)`` =
-                        { SalesOrderID = value
-                          SalesOrderDetailID = this.SalesOrderDetailID.Value
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          UnitPriceDiscount = this.UnitPriceDiscount.Value
-                          LineTotal = this.LineTotal.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
 
@@ -728,39 +545,233 @@ module main =
 
             interface ILeftViewOf<``SalesOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeader (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeader (base)`` =
-                        { SalesOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          OrderDate = this.OrderDate.Value
-                          DueDate = this.DueDate.Value
-                          ShipDate = this.ShipDate
-                          Status = this.Status.Value
-                          OnlineOrderFlag = this.OnlineOrderFlag.Value
-                          SalesOrderNumber = this.SalesOrderNumber.Value
-                          PurchaseOrderNumber = this.PurchaseOrderNumber
-                          AccountNumber = this.AccountNumber
-                          CustomerID = this.CustomerID.Value
-                          ShipToAddressID = this.ShipToAddressID
-                          BillToAddressID = this.BillToAddressID
-                          ShipMethod = this.ShipMethod.Value
-                          CreditCardApprovalCode = this.CreditCardApprovalCode
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          Comment = this.Comment
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type main.LeftJoined.Address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Address option =
+            match this.AddressID with
+            | Some value ->
+                let record: main.Address =
+                    { AddressID = value
+                      AddressLine1 = this.AddressLine1.Value
+                      AddressLine2 = this.AddressLine2
+                      City = this.City.Value
+                      StateProvince = this.StateProvince.Value
+                      CountryRegion = this.CountryRegion.Value
+                      PostalCode = this.PostalCode.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.BuildVersion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.BuildVersion option =
+            match this.SystemInformationID with
+            | Some value ->
+                let record: main.BuildVersion =
+                    { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.Customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Customer option =
+            match this.CustomerID with
+            | Some value ->
+                let record: main.Customer =
+                    { CustomerID = value
+                      NameStyle = this.NameStyle.Value
+                      Title = this.Title
+                      FirstName = this.FirstName.Value
+                      MiddleName = this.MiddleName
+                      LastName = this.LastName.Value
+                      Suffix = this.Suffix
+                      CompanyName = this.CompanyName
+                      SalesPerson = this.SalesPerson
+                      EmailAddress = this.EmailAddress
+                      Phone = this.Phone
+                      PasswordHash = this.PasswordHash.Value
+                      PasswordSalt = this.PasswordSalt.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.CustomerAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.CustomerAddress option =
+            match this.CustomerID with
+            | Some value ->
+                let record: main.CustomerAddress =
+                    { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ErrorLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ErrorLog option =
+            match this.ErrorLogID with
+            | Some value ->
+                let record: main.ErrorLog =
+                    { ErrorLogID = value
+                      ErrorTime = this.ErrorTime.Value
+                      UserName = this.UserName.Value
+                      ErrorNumber = this.ErrorNumber.Value
+                      ErrorSeverity = this.ErrorSeverity
+                      ErrorState = this.ErrorState
+                      ErrorProcedure = this.ErrorProcedure
+                      ErrorLine = this.ErrorLine
+                      ErrorMessage = this.ErrorMessage.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.Product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Product option =
+            match this.ProductID with
+            | Some value ->
+                let record: main.Product =
+                    { ProductID = value
+                      Name = this.Name.Value
+                      ProductNumber = this.ProductNumber.Value
+                      Color = this.Color
+                      StandardCost = this.StandardCost.Value
+                      ListPrice = this.ListPrice.Value
+                      Size = this.Size
+                      Weight = this.Weight
+                      ProductCategoryID = this.ProductCategoryID
+                      ProductModelID = this.ProductModelID
+                      SellStartDate = this.SellStartDate.Value
+                      SellEndDate = this.SellEndDate
+                      DiscontinuedDate = this.DiscontinuedDate
+                      ThumbNailPhoto = this.ThumbNailPhoto
+                      ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductCategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductCategory option =
+            match this.ProductCategoryID with
+            | Some value ->
+                let record: main.ProductCategory =
+                    { ProductCategoryID = value; ParentProductCategoryID = this.ParentProductCategoryID; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductDescription option =
+            match this.ProductDescriptionID with
+            | Some value ->
+                let record: main.ProductDescription =
+                    { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductModel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductModel option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: main.ProductModel =
+                    { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductModelProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductModelProductDescription option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: main.ProductModelProductDescription =
+                    { ProductModelID = value
+                      ProductDescriptionID = this.ProductDescriptionID.Value
+                      Culture = this.Culture.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.SalesOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.SalesOrderDetail option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: main.SalesOrderDetail =
+                    { SalesOrderID = value
+                      SalesOrderDetailID = this.SalesOrderDetailID.Value
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      UnitPriceDiscount = this.UnitPriceDiscount.Value
+                      LineTotal = this.LineTotal.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.SalesOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.SalesOrderHeader option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: main.SalesOrderHeader =
+                    { SalesOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      OrderDate = this.OrderDate.Value
+                      DueDate = this.DueDate.Value
+                      ShipDate = this.ShipDate
+                      Status = this.Status.Value
+                      OnlineOrderFlag = this.OnlineOrderFlag.Value
+                      SalesOrderNumber = this.SalesOrderNumber.Value
+                      PurchaseOrderNumber = this.PurchaseOrderNumber
+                      AccountNumber = this.AccountNumber
+                      CustomerID = this.CustomerID.Value
+                      ShipToAddressID = this.ShipToAddressID
+                      BillToAddressID = this.BillToAddressID
+                      ShipMethod = this.ShipMethod.Value
+                      CreditCardApprovalCode = this.CreditCardApprovalCode
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      Comment = this.Comment
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Sqlite/AdventureWorksNet8.fs
+++ b/src/Tests/Sqlite/AdventureWorksNet8.fs
@@ -325,6 +325,444 @@ module main =
 
     let SalesOrderHeader = table<SalesOrderHeader>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Address (base)`` = Address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Address =
+            { AddressID: Option<int64>
+              AddressLine1: Option<Sqlite.CustomTypes.Text>
+              AddressLine2: Option<Sqlite.CustomTypes.Text>
+              City: Option<Sqlite.CustomTypes.Text>
+              StateProvince: Option<Sqlite.CustomTypes.Text>
+              CountryRegion: Option<Sqlite.CustomTypes.Text>
+              PostalCode: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Address (base)`` option =
+                match this.AddressID with
+                | Some value ->
+                    let record: ``Address (base)`` =
+                        { AddressID = value
+                          AddressLine1 = this.AddressLine1.Value
+                          AddressLine2 = this.AddressLine2
+                          City = this.City.Value
+                          StateProvince = this.StateProvince.Value
+                          CountryRegion = this.CountryRegion.Value
+                          PostalCode = this.PostalCode.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Address = leftTable<``Address (base)``, Address>
+
+        type private ``BuildVersion (base)`` = BuildVersion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BuildVersion =
+            { SystemInformationID: Option<int64>
+              ``Database Version``: Option<Sqlite.CustomTypes.Text>
+              VersionDate: Option<System.DateTime>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BuildVersion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BuildVersion (base)`` option =
+                match this.SystemInformationID with
+                | Some value ->
+                    let record: ``BuildVersion (base)`` =
+                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BuildVersion = leftTable<``BuildVersion (base)``, BuildVersion>
+
+        type private ``Customer (base)`` = Customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Customer =
+            { CustomerID: Option<int64>
+              NameStyle: Option<int64>
+              Title: Option<Sqlite.CustomTypes.Text>
+              FirstName: Option<Sqlite.CustomTypes.Text>
+              MiddleName: Option<Sqlite.CustomTypes.Text>
+              LastName: Option<Sqlite.CustomTypes.Text>
+              Suffix: Option<Sqlite.CustomTypes.Text>
+              CompanyName: Option<Sqlite.CustomTypes.Text>
+              SalesPerson: Option<Sqlite.CustomTypes.Text>
+              EmailAddress: Option<Sqlite.CustomTypes.Text>
+              Phone: Option<Sqlite.CustomTypes.Text>
+              PasswordHash: Option<Sqlite.CustomTypes.Text>
+              PasswordSalt: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Customer (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``Customer (base)`` =
+                        { CustomerID = value
+                          NameStyle = this.NameStyle.Value
+                          Title = this.Title
+                          FirstName = this.FirstName.Value
+                          MiddleName = this.MiddleName
+                          LastName = this.LastName.Value
+                          Suffix = this.Suffix
+                          CompanyName = this.CompanyName
+                          SalesPerson = this.SalesPerson
+                          EmailAddress = this.EmailAddress
+                          Phone = this.Phone
+                          PasswordHash = this.PasswordHash.Value
+                          PasswordSalt = this.PasswordSalt.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Customer = leftTable<``Customer (base)``, Customer>
+
+        type private ``CustomerAddress (base)`` = CustomerAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CustomerAddress =
+            { CustomerID: Option<int64>
+              AddressID: Option<int64>
+              AddressType: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CustomerAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CustomerAddress (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``CustomerAddress (base)`` =
+                        { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CustomerAddress = leftTable<``CustomerAddress (base)``, CustomerAddress>
+
+        type private ``ErrorLog (base)`` = ErrorLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ErrorLog =
+            { ErrorLogID: Option<int64>
+              ErrorTime: Option<System.DateTime>
+              UserName: Option<Sqlite.CustomTypes.Text>
+              ErrorNumber: Option<int64>
+              ErrorSeverity: Option<int64>
+              ErrorState: Option<int64>
+              ErrorProcedure: Option<Sqlite.CustomTypes.Text>
+              ErrorLine: Option<int64>
+              ErrorMessage: Option<Sqlite.CustomTypes.Text> }
+
+            interface ILeftViewOf<``ErrorLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ErrorLog (base)`` option =
+                match this.ErrorLogID with
+                | Some value ->
+                    let record: ``ErrorLog (base)`` =
+                        { ErrorLogID = value
+                          ErrorTime = this.ErrorTime.Value
+                          UserName = this.UserName.Value
+                          ErrorNumber = this.ErrorNumber.Value
+                          ErrorSeverity = this.ErrorSeverity
+                          ErrorState = this.ErrorState
+                          ErrorProcedure = this.ErrorProcedure
+                          ErrorLine = this.ErrorLine
+                          ErrorMessage = this.ErrorMessage.Value }
+
+                    Some record
+                | None -> None
+
+        let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
+
+        type private ``Product (base)`` = Product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Product =
+            { ProductID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              ProductNumber: Option<Sqlite.CustomTypes.Text>
+              Color: Option<Sqlite.CustomTypes.Text>
+              StandardCost: Option<int64>
+              ListPrice: Option<int64>
+              Size: Option<Sqlite.CustomTypes.Text>
+              Weight: Option<int64>
+              ProductCategoryID: Option<int64>
+              ProductModelID: Option<int64>
+              SellStartDate: Option<System.DateTime>
+              SellEndDate: Option<System.DateTime>
+              DiscontinuedDate: Option<System.DateTime>
+              ThumbNailPhoto: Option<byte[]>
+              ThumbnailPhotoFileName: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Product (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``Product (base)`` =
+                        { ProductID = value
+                          Name = this.Name.Value
+                          ProductNumber = this.ProductNumber.Value
+                          Color = this.Color
+                          StandardCost = this.StandardCost.Value
+                          ListPrice = this.ListPrice.Value
+                          Size = this.Size
+                          Weight = this.Weight
+                          ProductCategoryID = this.ProductCategoryID
+                          ProductModelID = this.ProductModelID
+                          SellStartDate = this.SellStartDate.Value
+                          SellEndDate = this.SellEndDate
+                          DiscontinuedDate = this.DiscontinuedDate
+                          ThumbNailPhoto = this.ThumbNailPhoto
+                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Product = leftTable<``Product (base)``, Product>
+
+        type private ``ProductCategory (base)`` = ProductCategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCategory =
+            { ProductCategoryID: Option<int64>
+              ParentProductCategoryID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCategory (base)`` option =
+                match this.ProductCategoryID with
+                | Some value ->
+                    let record: ``ProductCategory (base)`` =
+                        { ProductCategoryID = value
+                          ParentProductCategoryID = this.ParentProductCategoryID
+                          Name = this.Name.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
+
+        type private ``ProductDescription (base)`` = ProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDescription =
+            { ProductDescriptionID: Option<int64>
+              Description: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDescription (base)`` option =
+                match this.ProductDescriptionID with
+                | Some value ->
+                    let record: ``ProductDescription (base)`` =
+                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDescription =
+            leftTable<``ProductDescription (base)``, ProductDescription>
+
+        type private ``ProductModel (base)`` = ProductModel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModel =
+            { ProductModelID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              CatalogDescription: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModel (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModel (base)`` =
+                        { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
+
+        type private ``ProductModelProductDescription (base)`` = ProductModelProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelProductDescription =
+            { ProductModelID: Option<int64>
+              ProductDescriptionID: Option<int64>
+              Culture: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelProductDescription (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelProductDescription (base)`` =
+                        { ProductModelID = value
+                          ProductDescriptionID = this.ProductDescriptionID.Value
+                          Culture = this.Culture.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelProductDescription =
+            leftTable<``ProductModelProductDescription (base)``, ProductModelProductDescription>
+
+        type private ``SalesOrderDetail (base)`` = SalesOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderDetail =
+            { SalesOrderID: Option<int64>
+              SalesOrderDetailID: Option<int64>
+              OrderQty: Option<int64>
+              ProductID: Option<int64>
+              UnitPrice: Option<int64>
+              UnitPriceDiscount: Option<int64>
+              LineTotal: Option<int64>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderDetail (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderDetail (base)`` =
+                        { SalesOrderID = value
+                          SalesOrderDetailID = this.SalesOrderDetailID.Value
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          UnitPriceDiscount = this.UnitPriceDiscount.Value
+                          LineTotal = this.LineTotal.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
+
+        type private ``SalesOrderHeader (base)`` = SalesOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeader =
+            { SalesOrderID: Option<int64>
+              RevisionNumber: Option<int64>
+              OrderDate: Option<System.DateTime>
+              DueDate: Option<System.DateTime>
+              ShipDate: Option<System.DateTime>
+              Status: Option<int64>
+              OnlineOrderFlag: Option<int64>
+              SalesOrderNumber: Option<string>
+              PurchaseOrderNumber: Option<int64>
+              AccountNumber: Option<Sqlite.CustomTypes.Text>
+              CustomerID: Option<int64>
+              ShipToAddressID: Option<int>
+              BillToAddressID: Option<int>
+              ShipMethod: Option<Sqlite.CustomTypes.Text>
+              CreditCardApprovalCode: Option<Sqlite.CustomTypes.Text>
+              SubTotal: Option<int64>
+              TaxAmt: Option<int64>
+              Freight: Option<int64>
+              TotalDue: Option<int64>
+              Comment: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeader (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeader (base)`` =
+                        { SalesOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          OrderDate = this.OrderDate.Value
+                          DueDate = this.DueDate.Value
+                          ShipDate = this.ShipDate
+                          Status = this.Status.Value
+                          OnlineOrderFlag = this.OnlineOrderFlag.Value
+                          SalesOrderNumber = this.SalesOrderNumber.Value
+                          PurchaseOrderNumber = this.PurchaseOrderNumber
+                          AccountNumber = this.AccountNumber
+                          CustomerID = this.CustomerID.Value
+                          ShipToAddressID = this.ShipToAddressID
+                          BillToAddressID = this.BillToAddressID
+                          ShipMethod = this.ShipMethod.Value
+                          CreditCardApprovalCode = this.CreditCardApprovalCode
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          Comment = this.Comment
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+
 
 
 type QueryContextFactory =

--- a/src/Tests/Sqlite/AdventureWorksNet8.fs
+++ b/src/Tests/Sqlite/AdventureWorksNet8.fs
@@ -344,25 +344,6 @@ module main =
 
             interface ILeftViewOf<``Address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Address (base)`` option =
-                match this.AddressID with
-                | Some value ->
-                    let record: ``Address (base)`` =
-                        { AddressID = value
-                          AddressLine1 = this.AddressLine1.Value
-                          AddressLine2 = this.AddressLine2
-                          City = this.City.Value
-                          StateProvince = this.StateProvince.Value
-                          CountryRegion = this.CountryRegion.Value
-                          PostalCode = this.PostalCode.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Address = leftTable<``Address (base)``, Address>
 
         type private ``BuildVersion (base)`` = BuildVersion
@@ -375,17 +356,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BuildVersion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BuildVersion (base)`` option =
-                match this.SystemInformationID with
-                | Some value ->
-                    let record: ``BuildVersion (base)`` =
-                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BuildVersion = leftTable<``BuildVersion (base)``, BuildVersion>
 
@@ -411,31 +381,6 @@ module main =
 
             interface ILeftViewOf<``Customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Customer (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``Customer (base)`` =
-                        { CustomerID = value
-                          NameStyle = this.NameStyle.Value
-                          Title = this.Title
-                          FirstName = this.FirstName.Value
-                          MiddleName = this.MiddleName
-                          LastName = this.LastName.Value
-                          Suffix = this.Suffix
-                          CompanyName = this.CompanyName
-                          SalesPerson = this.SalesPerson
-                          EmailAddress = this.EmailAddress
-                          Phone = this.Phone
-                          PasswordHash = this.PasswordHash.Value
-                          PasswordSalt = this.PasswordSalt.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Customer = leftTable<``Customer (base)``, Customer>
 
         type private ``CustomerAddress (base)`` = CustomerAddress
@@ -449,17 +394,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``CustomerAddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CustomerAddress (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``CustomerAddress (base)`` =
-                        { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let CustomerAddress = leftTable<``CustomerAddress (base)``, CustomerAddress>
 
@@ -478,25 +412,6 @@ module main =
               ErrorMessage: Option<Sqlite.CustomTypes.Text> }
 
             interface ILeftViewOf<``ErrorLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ErrorLog (base)`` option =
-                match this.ErrorLogID with
-                | Some value ->
-                    let record: ``ErrorLog (base)`` =
-                        { ErrorLogID = value
-                          ErrorTime = this.ErrorTime.Value
-                          UserName = this.UserName.Value
-                          ErrorNumber = this.ErrorNumber.Value
-                          ErrorSeverity = this.ErrorSeverity
-                          ErrorState = this.ErrorState
-                          ErrorProcedure = this.ErrorProcedure
-                          ErrorLine = this.ErrorLine
-                          ErrorMessage = this.ErrorMessage.Value }
-
-                    Some record
-                | None -> None
 
         let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
 
@@ -524,33 +439,6 @@ module main =
 
             interface ILeftViewOf<``Product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Product (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``Product (base)`` =
-                        { ProductID = value
-                          Name = this.Name.Value
-                          ProductNumber = this.ProductNumber.Value
-                          Color = this.Color
-                          StandardCost = this.StandardCost.Value
-                          ListPrice = this.ListPrice.Value
-                          Size = this.Size
-                          Weight = this.Weight
-                          ProductCategoryID = this.ProductCategoryID
-                          ProductModelID = this.ProductModelID
-                          SellStartDate = this.SellStartDate.Value
-                          SellEndDate = this.SellEndDate
-                          DiscontinuedDate = this.DiscontinuedDate
-                          ThumbNailPhoto = this.ThumbNailPhoto
-                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Product = leftTable<``Product (base)``, Product>
 
         type private ``ProductCategory (base)`` = ProductCategory
@@ -565,21 +453,6 @@ module main =
 
             interface ILeftViewOf<``ProductCategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCategory (base)`` option =
-                match this.ProductCategoryID with
-                | Some value ->
-                    let record: ``ProductCategory (base)`` =
-                        { ProductCategoryID = value
-                          ParentProductCategoryID = this.ParentProductCategoryID
-                          Name = this.Name.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
 
         type private ``ProductDescription (base)`` = ProductDescription
@@ -592,17 +465,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductDescription (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDescription (base)`` option =
-                match this.ProductDescriptionID with
-                | Some value ->
-                    let record: ``ProductDescription (base)`` =
-                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductDescription =
             leftTable<``ProductDescription (base)``, ProductDescription>
@@ -619,17 +481,6 @@ module main =
 
             interface ILeftViewOf<``ProductModel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModel (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModel (base)`` =
-                        { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
 
         type private ``ProductModelProductDescription (base)`` = ProductModelProductDescription
@@ -643,21 +494,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelProductDescription (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelProductDescription (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelProductDescription (base)`` =
-                        { ProductModelID = value
-                          ProductDescriptionID = this.ProductDescriptionID.Value
-                          Culture = this.Culture.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelProductDescription =
             leftTable<``ProductModelProductDescription (base)``, ProductModelProductDescription>
@@ -677,25 +513,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderDetail (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderDetail (base)`` =
-                        { SalesOrderID = value
-                          SalesOrderDetailID = this.SalesOrderDetailID.Value
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          UnitPriceDiscount = this.UnitPriceDiscount.Value
-                          LineTotal = this.LineTotal.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
 
@@ -728,39 +545,233 @@ module main =
 
             interface ILeftViewOf<``SalesOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeader (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeader (base)`` =
-                        { SalesOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          OrderDate = this.OrderDate.Value
-                          DueDate = this.DueDate.Value
-                          ShipDate = this.ShipDate
-                          Status = this.Status.Value
-                          OnlineOrderFlag = this.OnlineOrderFlag.Value
-                          SalesOrderNumber = this.SalesOrderNumber.Value
-                          PurchaseOrderNumber = this.PurchaseOrderNumber
-                          AccountNumber = this.AccountNumber
-                          CustomerID = this.CustomerID.Value
-                          ShipToAddressID = this.ShipToAddressID
-                          BillToAddressID = this.BillToAddressID
-                          ShipMethod = this.ShipMethod.Value
-                          CreditCardApprovalCode = this.CreditCardApprovalCode
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          Comment = this.Comment
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type main.LeftJoined.Address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Address option =
+            match this.AddressID with
+            | Some value ->
+                let record: main.Address =
+                    { AddressID = value
+                      AddressLine1 = this.AddressLine1.Value
+                      AddressLine2 = this.AddressLine2
+                      City = this.City.Value
+                      StateProvince = this.StateProvince.Value
+                      CountryRegion = this.CountryRegion.Value
+                      PostalCode = this.PostalCode.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.BuildVersion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.BuildVersion option =
+            match this.SystemInformationID with
+            | Some value ->
+                let record: main.BuildVersion =
+                    { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.Customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Customer option =
+            match this.CustomerID with
+            | Some value ->
+                let record: main.Customer =
+                    { CustomerID = value
+                      NameStyle = this.NameStyle.Value
+                      Title = this.Title
+                      FirstName = this.FirstName.Value
+                      MiddleName = this.MiddleName
+                      LastName = this.LastName.Value
+                      Suffix = this.Suffix
+                      CompanyName = this.CompanyName
+                      SalesPerson = this.SalesPerson
+                      EmailAddress = this.EmailAddress
+                      Phone = this.Phone
+                      PasswordHash = this.PasswordHash.Value
+                      PasswordSalt = this.PasswordSalt.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.CustomerAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.CustomerAddress option =
+            match this.CustomerID with
+            | Some value ->
+                let record: main.CustomerAddress =
+                    { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ErrorLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ErrorLog option =
+            match this.ErrorLogID with
+            | Some value ->
+                let record: main.ErrorLog =
+                    { ErrorLogID = value
+                      ErrorTime = this.ErrorTime.Value
+                      UserName = this.UserName.Value
+                      ErrorNumber = this.ErrorNumber.Value
+                      ErrorSeverity = this.ErrorSeverity
+                      ErrorState = this.ErrorState
+                      ErrorProcedure = this.ErrorProcedure
+                      ErrorLine = this.ErrorLine
+                      ErrorMessage = this.ErrorMessage.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.Product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Product option =
+            match this.ProductID with
+            | Some value ->
+                let record: main.Product =
+                    { ProductID = value
+                      Name = this.Name.Value
+                      ProductNumber = this.ProductNumber.Value
+                      Color = this.Color
+                      StandardCost = this.StandardCost.Value
+                      ListPrice = this.ListPrice.Value
+                      Size = this.Size
+                      Weight = this.Weight
+                      ProductCategoryID = this.ProductCategoryID
+                      ProductModelID = this.ProductModelID
+                      SellStartDate = this.SellStartDate.Value
+                      SellEndDate = this.SellEndDate
+                      DiscontinuedDate = this.DiscontinuedDate
+                      ThumbNailPhoto = this.ThumbNailPhoto
+                      ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductCategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductCategory option =
+            match this.ProductCategoryID with
+            | Some value ->
+                let record: main.ProductCategory =
+                    { ProductCategoryID = value; ParentProductCategoryID = this.ParentProductCategoryID; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductDescription option =
+            match this.ProductDescriptionID with
+            | Some value ->
+                let record: main.ProductDescription =
+                    { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductModel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductModel option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: main.ProductModel =
+                    { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductModelProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductModelProductDescription option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: main.ProductModelProductDescription =
+                    { ProductModelID = value
+                      ProductDescriptionID = this.ProductDescriptionID.Value
+                      Culture = this.Culture.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.SalesOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.SalesOrderDetail option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: main.SalesOrderDetail =
+                    { SalesOrderID = value
+                      SalesOrderDetailID = this.SalesOrderDetailID.Value
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      UnitPriceDiscount = this.UnitPriceDiscount.Value
+                      LineTotal = this.LineTotal.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.SalesOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.SalesOrderHeader option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: main.SalesOrderHeader =
+                    { SalesOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      OrderDate = this.OrderDate.Value
+                      DueDate = this.DueDate.Value
+                      ShipDate = this.ShipDate
+                      Status = this.Status.Value
+                      OnlineOrderFlag = this.OnlineOrderFlag.Value
+                      SalesOrderNumber = this.SalesOrderNumber.Value
+                      PurchaseOrderNumber = this.PurchaseOrderNumber
+                      AccountNumber = this.AccountNumber
+                      CustomerID = this.CustomerID.Value
+                      ShipToAddressID = this.ShipToAddressID
+                      BillToAddressID = this.BillToAddressID
+                      ShipMethod = this.ShipMethod.Value
+                      CreditCardApprovalCode = this.CreditCardApprovalCode
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      Comment = this.Comment
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Sqlite/AdventureWorksNet9.fs
+++ b/src/Tests/Sqlite/AdventureWorksNet9.fs
@@ -325,6 +325,444 @@ module main =
 
     let SalesOrderHeader = table<SalesOrderHeader>
 
+    /// Left-views for `leftJoin`: each table record with every column in its nullable form,
+    /// so an unmatched row reads as None per column instead of one Option around the record.
+    module LeftJoined =
+        type private ``Address (base)`` = Address
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Address =
+            { AddressID: Option<int64>
+              AddressLine1: Option<Sqlite.CustomTypes.Text>
+              AddressLine2: Option<Sqlite.CustomTypes.Text>
+              City: Option<Sqlite.CustomTypes.Text>
+              StateProvince: Option<Sqlite.CustomTypes.Text>
+              CountryRegion: Option<Sqlite.CustomTypes.Text>
+              PostalCode: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Address (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Address (base)`` option =
+                match this.AddressID with
+                | Some value ->
+                    let record: ``Address (base)`` =
+                        { AddressID = value
+                          AddressLine1 = this.AddressLine1.Value
+                          AddressLine2 = this.AddressLine2
+                          City = this.City.Value
+                          StateProvince = this.StateProvince.Value
+                          CountryRegion = this.CountryRegion.Value
+                          PostalCode = this.PostalCode.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Address = leftTable<``Address (base)``, Address>
+
+        type private ``BuildVersion (base)`` = BuildVersion
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type BuildVersion =
+            { SystemInformationID: Option<int64>
+              ``Database Version``: Option<Sqlite.CustomTypes.Text>
+              VersionDate: Option<System.DateTime>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``BuildVersion (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``BuildVersion (base)`` option =
+                match this.SystemInformationID with
+                | Some value ->
+                    let record: ``BuildVersion (base)`` =
+                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let BuildVersion = leftTable<``BuildVersion (base)``, BuildVersion>
+
+        type private ``Customer (base)`` = Customer
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Customer =
+            { CustomerID: Option<int64>
+              NameStyle: Option<int64>
+              Title: Option<Sqlite.CustomTypes.Text>
+              FirstName: Option<Sqlite.CustomTypes.Text>
+              MiddleName: Option<Sqlite.CustomTypes.Text>
+              LastName: Option<Sqlite.CustomTypes.Text>
+              Suffix: Option<Sqlite.CustomTypes.Text>
+              CompanyName: Option<Sqlite.CustomTypes.Text>
+              SalesPerson: Option<Sqlite.CustomTypes.Text>
+              EmailAddress: Option<Sqlite.CustomTypes.Text>
+              Phone: Option<Sqlite.CustomTypes.Text>
+              PasswordHash: Option<Sqlite.CustomTypes.Text>
+              PasswordSalt: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Customer (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Customer (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``Customer (base)`` =
+                        { CustomerID = value
+                          NameStyle = this.NameStyle.Value
+                          Title = this.Title
+                          FirstName = this.FirstName.Value
+                          MiddleName = this.MiddleName
+                          LastName = this.LastName.Value
+                          Suffix = this.Suffix
+                          CompanyName = this.CompanyName
+                          SalesPerson = this.SalesPerson
+                          EmailAddress = this.EmailAddress
+                          Phone = this.Phone
+                          PasswordHash = this.PasswordHash.Value
+                          PasswordSalt = this.PasswordSalt.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Customer = leftTable<``Customer (base)``, Customer>
+
+        type private ``CustomerAddress (base)`` = CustomerAddress
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type CustomerAddress =
+            { CustomerID: Option<int64>
+              AddressID: Option<int64>
+              AddressType: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``CustomerAddress (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``CustomerAddress (base)`` option =
+                match this.CustomerID with
+                | Some value ->
+                    let record: ``CustomerAddress (base)`` =
+                        { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let CustomerAddress = leftTable<``CustomerAddress (base)``, CustomerAddress>
+
+        type private ``ErrorLog (base)`` = ErrorLog
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ErrorLog =
+            { ErrorLogID: Option<int64>
+              ErrorTime: Option<System.DateTime>
+              UserName: Option<Sqlite.CustomTypes.Text>
+              ErrorNumber: Option<int64>
+              ErrorSeverity: Option<int64>
+              ErrorState: Option<int64>
+              ErrorProcedure: Option<Sqlite.CustomTypes.Text>
+              ErrorLine: Option<int64>
+              ErrorMessage: Option<Sqlite.CustomTypes.Text> }
+
+            interface ILeftViewOf<``ErrorLog (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ErrorLog (base)`` option =
+                match this.ErrorLogID with
+                | Some value ->
+                    let record: ``ErrorLog (base)`` =
+                        { ErrorLogID = value
+                          ErrorTime = this.ErrorTime.Value
+                          UserName = this.UserName.Value
+                          ErrorNumber = this.ErrorNumber.Value
+                          ErrorSeverity = this.ErrorSeverity
+                          ErrorState = this.ErrorState
+                          ErrorProcedure = this.ErrorProcedure
+                          ErrorLine = this.ErrorLine
+                          ErrorMessage = this.ErrorMessage.Value }
+
+                    Some record
+                | None -> None
+
+        let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
+
+        type private ``Product (base)`` = Product
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type Product =
+            { ProductID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              ProductNumber: Option<Sqlite.CustomTypes.Text>
+              Color: Option<Sqlite.CustomTypes.Text>
+              StandardCost: Option<int64>
+              ListPrice: Option<int64>
+              Size: Option<Sqlite.CustomTypes.Text>
+              Weight: Option<int64>
+              ProductCategoryID: Option<int64>
+              ProductModelID: Option<int64>
+              SellStartDate: Option<System.DateTime>
+              SellEndDate: Option<System.DateTime>
+              DiscontinuedDate: Option<System.DateTime>
+              ThumbNailPhoto: Option<byte[]>
+              ThumbnailPhotoFileName: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``Product (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``Product (base)`` option =
+                match this.ProductID with
+                | Some value ->
+                    let record: ``Product (base)`` =
+                        { ProductID = value
+                          Name = this.Name.Value
+                          ProductNumber = this.ProductNumber.Value
+                          Color = this.Color
+                          StandardCost = this.StandardCost.Value
+                          ListPrice = this.ListPrice.Value
+                          Size = this.Size
+                          Weight = this.Weight
+                          ProductCategoryID = this.ProductCategoryID
+                          ProductModelID = this.ProductModelID
+                          SellStartDate = this.SellStartDate.Value
+                          SellEndDate = this.SellEndDate
+                          DiscontinuedDate = this.DiscontinuedDate
+                          ThumbNailPhoto = this.ThumbNailPhoto
+                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let Product = leftTable<``Product (base)``, Product>
+
+        type private ``ProductCategory (base)`` = ProductCategory
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductCategory =
+            { ProductCategoryID: Option<int64>
+              ParentProductCategoryID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductCategory (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductCategory (base)`` option =
+                match this.ProductCategoryID with
+                | Some value ->
+                    let record: ``ProductCategory (base)`` =
+                        { ProductCategoryID = value
+                          ParentProductCategoryID = this.ParentProductCategoryID
+                          Name = this.Name.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
+
+        type private ``ProductDescription (base)`` = ProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductDescription =
+            { ProductDescriptionID: Option<int64>
+              Description: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductDescription (base)`` option =
+                match this.ProductDescriptionID with
+                | Some value ->
+                    let record: ``ProductDescription (base)`` =
+                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductDescription =
+            leftTable<``ProductDescription (base)``, ProductDescription>
+
+        type private ``ProductModel (base)`` = ProductModel
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModel =
+            { ProductModelID: Option<int64>
+              Name: Option<Sqlite.CustomTypes.Text>
+              CatalogDescription: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModel (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModel (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModel (base)`` =
+                        { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
+
+        type private ``ProductModelProductDescription (base)`` = ProductModelProductDescription
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type ProductModelProductDescription =
+            { ProductModelID: Option<int64>
+              ProductDescriptionID: Option<int64>
+              Culture: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``ProductModelProductDescription (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``ProductModelProductDescription (base)`` option =
+                match this.ProductModelID with
+                | Some value ->
+                    let record: ``ProductModelProductDescription (base)`` =
+                        { ProductModelID = value
+                          ProductDescriptionID = this.ProductDescriptionID.Value
+                          Culture = this.Culture.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let ProductModelProductDescription =
+            leftTable<``ProductModelProductDescription (base)``, ProductModelProductDescription>
+
+        type private ``SalesOrderDetail (base)`` = SalesOrderDetail
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderDetail =
+            { SalesOrderID: Option<int64>
+              SalesOrderDetailID: Option<int64>
+              OrderQty: Option<int64>
+              ProductID: Option<int64>
+              UnitPrice: Option<int64>
+              UnitPriceDiscount: Option<int64>
+              LineTotal: Option<int64>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderDetail (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderDetail (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderDetail (base)`` =
+                        { SalesOrderID = value
+                          SalesOrderDetailID = this.SalesOrderDetailID.Value
+                          OrderQty = this.OrderQty.Value
+                          ProductID = this.ProductID.Value
+                          UnitPrice = this.UnitPrice.Value
+                          UnitPriceDiscount = this.UnitPriceDiscount.Value
+                          LineTotal = this.LineTotal.Value
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
+
+        type private ``SalesOrderHeader (base)`` = SalesOrderHeader
+
+        [<CLIMutable; NoEquality; NoComparison>]
+        type SalesOrderHeader =
+            { SalesOrderID: Option<int64>
+              RevisionNumber: Option<int64>
+              OrderDate: Option<System.DateTime>
+              DueDate: Option<System.DateTime>
+              ShipDate: Option<System.DateTime>
+              Status: Option<int64>
+              OnlineOrderFlag: Option<int64>
+              SalesOrderNumber: Option<string>
+              PurchaseOrderNumber: Option<int64>
+              AccountNumber: Option<Sqlite.CustomTypes.Text>
+              CustomerID: Option<int64>
+              ShipToAddressID: Option<int>
+              BillToAddressID: Option<int>
+              ShipMethod: Option<Sqlite.CustomTypes.Text>
+              CreditCardApprovalCode: Option<Sqlite.CustomTypes.Text>
+              SubTotal: Option<int64>
+              TaxAmt: Option<int64>
+              Freight: Option<int64>
+              TotalDue: Option<int64>
+              Comment: Option<Sqlite.CustomTypes.Text>
+              rowguid: Option<Sqlite.CustomTypes.Text>
+              ModifiedDate: Option<System.DateTime> }
+
+            interface ILeftViewOf<``SalesOrderHeader (base)``>
+
+            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+            /// Some when the left join matched, None when it did not.
+            member this.ToOption() : ``SalesOrderHeader (base)`` option =
+                match this.SalesOrderID with
+                | Some value ->
+                    let record: ``SalesOrderHeader (base)`` =
+                        { SalesOrderID = value
+                          RevisionNumber = this.RevisionNumber.Value
+                          OrderDate = this.OrderDate.Value
+                          DueDate = this.DueDate.Value
+                          ShipDate = this.ShipDate
+                          Status = this.Status.Value
+                          OnlineOrderFlag = this.OnlineOrderFlag.Value
+                          SalesOrderNumber = this.SalesOrderNumber.Value
+                          PurchaseOrderNumber = this.PurchaseOrderNumber
+                          AccountNumber = this.AccountNumber
+                          CustomerID = this.CustomerID.Value
+                          ShipToAddressID = this.ShipToAddressID
+                          BillToAddressID = this.BillToAddressID
+                          ShipMethod = this.ShipMethod.Value
+                          CreditCardApprovalCode = this.CreditCardApprovalCode
+                          SubTotal = this.SubTotal.Value
+                          TaxAmt = this.TaxAmt.Value
+                          Freight = this.Freight.Value
+                          TotalDue = this.TotalDue.Value
+                          Comment = this.Comment
+                          rowguid = this.rowguid.Value
+                          ModifiedDate = this.ModifiedDate.Value }
+
+                    Some record
+                | None -> None
+
+        let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+
 
 
 type QueryContextFactory =

--- a/src/Tests/Sqlite/AdventureWorksNet9.fs
+++ b/src/Tests/Sqlite/AdventureWorksNet9.fs
@@ -344,25 +344,6 @@ module main =
 
             interface ILeftViewOf<``Address (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Address (base)`` option =
-                match this.AddressID with
-                | Some value ->
-                    let record: ``Address (base)`` =
-                        { AddressID = value
-                          AddressLine1 = this.AddressLine1.Value
-                          AddressLine2 = this.AddressLine2
-                          City = this.City.Value
-                          StateProvince = this.StateProvince.Value
-                          CountryRegion = this.CountryRegion.Value
-                          PostalCode = this.PostalCode.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Address = leftTable<``Address (base)``, Address>
 
         type private ``BuildVersion (base)`` = BuildVersion
@@ -375,17 +356,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``BuildVersion (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``BuildVersion (base)`` option =
-                match this.SystemInformationID with
-                | Some value ->
-                    let record: ``BuildVersion (base)`` =
-                        { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let BuildVersion = leftTable<``BuildVersion (base)``, BuildVersion>
 
@@ -411,31 +381,6 @@ module main =
 
             interface ILeftViewOf<``Customer (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Customer (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``Customer (base)`` =
-                        { CustomerID = value
-                          NameStyle = this.NameStyle.Value
-                          Title = this.Title
-                          FirstName = this.FirstName.Value
-                          MiddleName = this.MiddleName
-                          LastName = this.LastName.Value
-                          Suffix = this.Suffix
-                          CompanyName = this.CompanyName
-                          SalesPerson = this.SalesPerson
-                          EmailAddress = this.EmailAddress
-                          Phone = this.Phone
-                          PasswordHash = this.PasswordHash.Value
-                          PasswordSalt = this.PasswordSalt.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Customer = leftTable<``Customer (base)``, Customer>
 
         type private ``CustomerAddress (base)`` = CustomerAddress
@@ -449,17 +394,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``CustomerAddress (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``CustomerAddress (base)`` option =
-                match this.CustomerID with
-                | Some value ->
-                    let record: ``CustomerAddress (base)`` =
-                        { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let CustomerAddress = leftTable<``CustomerAddress (base)``, CustomerAddress>
 
@@ -478,25 +412,6 @@ module main =
               ErrorMessage: Option<Sqlite.CustomTypes.Text> }
 
             interface ILeftViewOf<``ErrorLog (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ErrorLog (base)`` option =
-                match this.ErrorLogID with
-                | Some value ->
-                    let record: ``ErrorLog (base)`` =
-                        { ErrorLogID = value
-                          ErrorTime = this.ErrorTime.Value
-                          UserName = this.UserName.Value
-                          ErrorNumber = this.ErrorNumber.Value
-                          ErrorSeverity = this.ErrorSeverity
-                          ErrorState = this.ErrorState
-                          ErrorProcedure = this.ErrorProcedure
-                          ErrorLine = this.ErrorLine
-                          ErrorMessage = this.ErrorMessage.Value }
-
-                    Some record
-                | None -> None
 
         let ErrorLog = leftTable<``ErrorLog (base)``, ErrorLog>
 
@@ -524,33 +439,6 @@ module main =
 
             interface ILeftViewOf<``Product (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``Product (base)`` option =
-                match this.ProductID with
-                | Some value ->
-                    let record: ``Product (base)`` =
-                        { ProductID = value
-                          Name = this.Name.Value
-                          ProductNumber = this.ProductNumber.Value
-                          Color = this.Color
-                          StandardCost = this.StandardCost.Value
-                          ListPrice = this.ListPrice.Value
-                          Size = this.Size
-                          Weight = this.Weight
-                          ProductCategoryID = this.ProductCategoryID
-                          ProductModelID = this.ProductModelID
-                          SellStartDate = this.SellStartDate.Value
-                          SellEndDate = this.SellEndDate
-                          DiscontinuedDate = this.DiscontinuedDate
-                          ThumbNailPhoto = this.ThumbNailPhoto
-                          ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let Product = leftTable<``Product (base)``, Product>
 
         type private ``ProductCategory (base)`` = ProductCategory
@@ -565,21 +453,6 @@ module main =
 
             interface ILeftViewOf<``ProductCategory (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductCategory (base)`` option =
-                match this.ProductCategoryID with
-                | Some value ->
-                    let record: ``ProductCategory (base)`` =
-                        { ProductCategoryID = value
-                          ParentProductCategoryID = this.ParentProductCategoryID
-                          Name = this.Name.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductCategory = leftTable<``ProductCategory (base)``, ProductCategory>
 
         type private ``ProductDescription (base)`` = ProductDescription
@@ -592,17 +465,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductDescription (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductDescription (base)`` option =
-                match this.ProductDescriptionID with
-                | Some value ->
-                    let record: ``ProductDescription (base)`` =
-                        { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductDescription =
             leftTable<``ProductDescription (base)``, ProductDescription>
@@ -619,17 +481,6 @@ module main =
 
             interface ILeftViewOf<``ProductModel (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModel (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModel (base)`` =
-                        { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let ProductModel = leftTable<``ProductModel (base)``, ProductModel>
 
         type private ``ProductModelProductDescription (base)`` = ProductModelProductDescription
@@ -643,21 +494,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``ProductModelProductDescription (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``ProductModelProductDescription (base)`` option =
-                match this.ProductModelID with
-                | Some value ->
-                    let record: ``ProductModelProductDescription (base)`` =
-                        { ProductModelID = value
-                          ProductDescriptionID = this.ProductDescriptionID.Value
-                          Culture = this.Culture.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let ProductModelProductDescription =
             leftTable<``ProductModelProductDescription (base)``, ProductModelProductDescription>
@@ -677,25 +513,6 @@ module main =
               ModifiedDate: Option<System.DateTime> }
 
             interface ILeftViewOf<``SalesOrderDetail (base)``>
-
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderDetail (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderDetail (base)`` =
-                        { SalesOrderID = value
-                          SalesOrderDetailID = this.SalesOrderDetailID.Value
-                          OrderQty = this.OrderQty.Value
-                          ProductID = this.ProductID.Value
-                          UnitPrice = this.UnitPrice.Value
-                          UnitPriceDiscount = this.UnitPriceDiscount.Value
-                          LineTotal = this.LineTotal.Value
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
 
         let SalesOrderDetail = leftTable<``SalesOrderDetail (base)``, SalesOrderDetail>
 
@@ -728,39 +545,233 @@ module main =
 
             interface ILeftViewOf<``SalesOrderHeader (base)``>
 
-            /// Recovers the whole-record option after materialization (pure .NET, not SQL):
-            /// Some when the left join matched, None when it did not.
-            member this.ToOption() : ``SalesOrderHeader (base)`` option =
-                match this.SalesOrderID with
-                | Some value ->
-                    let record: ``SalesOrderHeader (base)`` =
-                        { SalesOrderID = value
-                          RevisionNumber = this.RevisionNumber.Value
-                          OrderDate = this.OrderDate.Value
-                          DueDate = this.DueDate.Value
-                          ShipDate = this.ShipDate
-                          Status = this.Status.Value
-                          OnlineOrderFlag = this.OnlineOrderFlag.Value
-                          SalesOrderNumber = this.SalesOrderNumber.Value
-                          PurchaseOrderNumber = this.PurchaseOrderNumber
-                          AccountNumber = this.AccountNumber
-                          CustomerID = this.CustomerID.Value
-                          ShipToAddressID = this.ShipToAddressID
-                          BillToAddressID = this.BillToAddressID
-                          ShipMethod = this.ShipMethod.Value
-                          CreditCardApprovalCode = this.CreditCardApprovalCode
-                          SubTotal = this.SubTotal.Value
-                          TaxAmt = this.TaxAmt.Value
-                          Freight = this.Freight.Value
-                          TotalDue = this.TotalDue.Value
-                          Comment = this.Comment
-                          rowguid = this.rowguid.Value
-                          ModifiedDate = this.ModifiedDate.Value }
-
-                    Some record
-                | None -> None
-
         let SalesOrderHeader = leftTable<``SalesOrderHeader (base)``, SalesOrderHeader>
+
+
+[<AutoOpen>]
+module LeftViewExtensions =
+    type main.LeftJoined.Address with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Address option =
+            match this.AddressID with
+            | Some value ->
+                let record: main.Address =
+                    { AddressID = value
+                      AddressLine1 = this.AddressLine1.Value
+                      AddressLine2 = this.AddressLine2
+                      City = this.City.Value
+                      StateProvince = this.StateProvince.Value
+                      CountryRegion = this.CountryRegion.Value
+                      PostalCode = this.PostalCode.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.BuildVersion with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.BuildVersion option =
+            match this.SystemInformationID with
+            | Some value ->
+                let record: main.BuildVersion =
+                    { SystemInformationID = value; ``Database Version`` = this.``Database Version``.Value; VersionDate = this.VersionDate.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.Customer with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Customer option =
+            match this.CustomerID with
+            | Some value ->
+                let record: main.Customer =
+                    { CustomerID = value
+                      NameStyle = this.NameStyle.Value
+                      Title = this.Title
+                      FirstName = this.FirstName.Value
+                      MiddleName = this.MiddleName
+                      LastName = this.LastName.Value
+                      Suffix = this.Suffix
+                      CompanyName = this.CompanyName
+                      SalesPerson = this.SalesPerson
+                      EmailAddress = this.EmailAddress
+                      Phone = this.Phone
+                      PasswordHash = this.PasswordHash.Value
+                      PasswordSalt = this.PasswordSalt.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.CustomerAddress with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.CustomerAddress option =
+            match this.CustomerID with
+            | Some value ->
+                let record: main.CustomerAddress =
+                    { CustomerID = value; AddressID = this.AddressID.Value; AddressType = this.AddressType.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ErrorLog with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ErrorLog option =
+            match this.ErrorLogID with
+            | Some value ->
+                let record: main.ErrorLog =
+                    { ErrorLogID = value
+                      ErrorTime = this.ErrorTime.Value
+                      UserName = this.UserName.Value
+                      ErrorNumber = this.ErrorNumber.Value
+                      ErrorSeverity = this.ErrorSeverity
+                      ErrorState = this.ErrorState
+                      ErrorProcedure = this.ErrorProcedure
+                      ErrorLine = this.ErrorLine
+                      ErrorMessage = this.ErrorMessage.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.Product with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.Product option =
+            match this.ProductID with
+            | Some value ->
+                let record: main.Product =
+                    { ProductID = value
+                      Name = this.Name.Value
+                      ProductNumber = this.ProductNumber.Value
+                      Color = this.Color
+                      StandardCost = this.StandardCost.Value
+                      ListPrice = this.ListPrice.Value
+                      Size = this.Size
+                      Weight = this.Weight
+                      ProductCategoryID = this.ProductCategoryID
+                      ProductModelID = this.ProductModelID
+                      SellStartDate = this.SellStartDate.Value
+                      SellEndDate = this.SellEndDate
+                      DiscontinuedDate = this.DiscontinuedDate
+                      ThumbNailPhoto = this.ThumbNailPhoto
+                      ThumbnailPhotoFileName = this.ThumbnailPhotoFileName
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductCategory with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductCategory option =
+            match this.ProductCategoryID with
+            | Some value ->
+                let record: main.ProductCategory =
+                    { ProductCategoryID = value; ParentProductCategoryID = this.ParentProductCategoryID; Name = this.Name.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductDescription option =
+            match this.ProductDescriptionID with
+            | Some value ->
+                let record: main.ProductDescription =
+                    { ProductDescriptionID = value; Description = this.Description.Value; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductModel with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductModel option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: main.ProductModel =
+                    { ProductModelID = value; Name = this.Name.Value; CatalogDescription = this.CatalogDescription; rowguid = this.rowguid.Value; ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.ProductModelProductDescription with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.ProductModelProductDescription option =
+            match this.ProductModelID with
+            | Some value ->
+                let record: main.ProductModelProductDescription =
+                    { ProductModelID = value
+                      ProductDescriptionID = this.ProductDescriptionID.Value
+                      Culture = this.Culture.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.SalesOrderDetail with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.SalesOrderDetail option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: main.SalesOrderDetail =
+                    { SalesOrderID = value
+                      SalesOrderDetailID = this.SalesOrderDetailID.Value
+                      OrderQty = this.OrderQty.Value
+                      ProductID = this.ProductID.Value
+                      UnitPrice = this.UnitPrice.Value
+                      UnitPriceDiscount = this.UnitPriceDiscount.Value
+                      LineTotal = this.LineTotal.Value
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
+
+    type main.LeftJoined.SalesOrderHeader with
+        /// Recovers the whole-record option after materialization (pure .NET, not SQL):
+        /// Some when the left join matched, None when it did not.
+        member this.ToOption() : main.SalesOrderHeader option =
+            match this.SalesOrderID with
+            | Some value ->
+                let record: main.SalesOrderHeader =
+                    { SalesOrderID = value
+                      RevisionNumber = this.RevisionNumber.Value
+                      OrderDate = this.OrderDate.Value
+                      DueDate = this.DueDate.Value
+                      ShipDate = this.ShipDate
+                      Status = this.Status.Value
+                      OnlineOrderFlag = this.OnlineOrderFlag.Value
+                      SalesOrderNumber = this.SalesOrderNumber.Value
+                      PurchaseOrderNumber = this.PurchaseOrderNumber
+                      AccountNumber = this.AccountNumber
+                      CustomerID = this.CustomerID.Value
+                      ShipToAddressID = this.ShipToAddressID
+                      BillToAddressID = this.BillToAddressID
+                      ShipMethod = this.ShipMethod.Value
+                      CreditCardApprovalCode = this.CreditCardApprovalCode
+                      SubTotal = this.SubTotal.Value
+                      TaxAmt = this.TaxAmt.Value
+                      Freight = this.Freight.Value
+                      TotalDue = this.TotalDue.Value
+                      Comment = this.Comment
+                      rowguid = this.rowguid.Value
+                      ModifiedDate = this.ModifiedDate.Value }
+
+                Some record
+            | None -> None
 
 
 

--- a/src/Tests/Sqlite/Generation.fs
+++ b/src/Tests/Sqlite/Generation.fs
@@ -22,6 +22,7 @@ let cfg =
         NullablePropertyType = NullablePropertyType.Option
         ProviderDbTypeAttributes = true
         TableDeclarations = true
+        LeftJoinedViews = false
         Readers = Some { ReadersConfig.ReaderType = "System.Data.Common.DbDataReader" }
         Filters = Filters.Empty
         TypeMappingExtensions = []

--- a/src/Tests/Sqlite/SchemaProviderTests.fs
+++ b/src/Tests/Sqlite/SchemaProviderTests.fs
@@ -36,6 +36,7 @@ let private mkConfig connectionString restrictions =
         NullablePropertyType = NullablePropertyType.Option
         ProviderDbTypeAttributes = true
         TableDeclarations = true
+        LeftJoinedViews = false
         Readers = Some { ReadersConfig.ReaderType = "System.Data.Common.DbDataReader" }
         Filters = { Filters.Empty with Restrictions = restrictions }
         TypeMappingExtensions = []

--- a/src/Tests/UnitTests/SchemaTemplateTests.fs
+++ b/src/Tests/UnitTests/SchemaTemplateTests.fs
@@ -16,6 +16,7 @@ let private mkCfg () : Config =
         NullablePropertyType = NullablePropertyType.Option
         ProviderDbTypeAttributes = true
         TableDeclarations = false
+        LeftJoinedViews = false
         Readers = None
         Filters = Filters.Empty
         TypeMappingExtensions = []

--- a/src/Tests/UnitTests/TomlConfigParser.fs
+++ b/src/Tests/UnitTests/TomlConfigParser.fs
@@ -23,6 +23,7 @@ let ``Save: All``() =
             NullablePropertyType = NullablePropertyType.Option
             ProviderDbTypeAttributes = true
             TableDeclarations = true
+            LeftJoinedViews = true
             Readers = Some { ReadersConfig.ReaderType = "Microsoft.Data.SqlClient.SqlDataReader" }
             Filters = Filters.Empty
             TypeMappingExtensions = []
@@ -40,6 +41,7 @@ let ``Save: All``() =
         [sqlhydra_query_integration]
         provider_db_type_attributes = true
         table_declarations = true
+        left_joined_views = true
         [readers]
         reader_type = "Microsoft.Data.SqlClient.SqlDataReader"
         [filters]
@@ -72,6 +74,7 @@ let ``Read: with no filters``() =
             NullablePropertyType = NullablePropertyType.Option
             ProviderDbTypeAttributes = true
             TableDeclarations = false
+            LeftJoinedViews = false
             Readers = Some { ReadersConfig.ReaderType = "Microsoft.Data.SqlClient.SqlDataReader" }
             Filters = Filters.Empty
             TypeMappingExtensions = []
@@ -102,6 +105,7 @@ let ``Read: when no readers section should be None``() =
             NullablePropertyType = NullablePropertyType.Option
             ProviderDbTypeAttributes = true
             TableDeclarations = false
+            LeftJoinedViews = false
             Readers = None
             Filters = Filters.Empty
             TypeMappingExtensions = []

--- a/src/Tests/sqlhydra-mssql-net10.toml
+++ b/src/Tests/sqlhydra-mssql-net10.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Microsoft.Data.SqlClient.SqlDataReader"
 [filters]

--- a/src/Tests/sqlhydra-mssql-net8.toml
+++ b/src/Tests/sqlhydra-mssql-net8.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Microsoft.Data.SqlClient.SqlDataReader"
 [filters]

--- a/src/Tests/sqlhydra-mssql-net9.toml
+++ b/src/Tests/sqlhydra-mssql-net9.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Microsoft.Data.SqlClient.SqlDataReader"
 [filters]

--- a/src/Tests/sqlhydra-npgsql-net10.toml
+++ b/src/Tests/sqlhydra-npgsql-net10.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Npgsql.NpgsqlDataReader"
 [filters]

--- a/src/Tests/sqlhydra-npgsql-net8.toml
+++ b/src/Tests/sqlhydra-npgsql-net8.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Npgsql.NpgsqlDataReader"
 [filters]

--- a/src/Tests/sqlhydra-npgsql-net9.toml
+++ b/src/Tests/sqlhydra-npgsql-net9.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Npgsql.NpgsqlDataReader"
 [filters]

--- a/src/Tests/sqlhydra-oracle-net10.toml
+++ b/src/Tests/sqlhydra-oracle-net10.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Oracle.ManagedDataAccess.Client.OracleDataReader"
 [filters]

--- a/src/Tests/sqlhydra-oracle-net8.toml
+++ b/src/Tests/sqlhydra-oracle-net8.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Oracle.ManagedDataAccess.Client.OracleDataReader"
 [filters]

--- a/src/Tests/sqlhydra-oracle-net9.toml
+++ b/src/Tests/sqlhydra-oracle-net9.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "Oracle.ManagedDataAccess.Client.OracleDataReader"
 [filters]

--- a/src/Tests/sqlhydra-sqlite-net10.toml
+++ b/src/Tests/sqlhydra-sqlite-net10.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "System.Data.Common.DbDataReader"
 [filters]

--- a/src/Tests/sqlhydra-sqlite-net8.toml
+++ b/src/Tests/sqlhydra-sqlite-net8.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "System.Data.Common.DbDataReader"
 [filters]

--- a/src/Tests/sqlhydra-sqlite-net9.toml
+++ b/src/Tests/sqlhydra-sqlite-net9.toml
@@ -6,6 +6,7 @@ cli_mutable = true
 [sqlhydra_query_integration]
 provider_db_type_attributes = true
 table_declarations = true
+left_joined_views = true
 [readers]
 reader_type = "System.Data.Common.DbDataReader"
 [filters]


### PR DESCRIPTION
Closes #153.

## What this does

Left joins currently wrap the whole joined record in an `Option`, forcing `.Value` theater into ON clauses and projections:

```fsharp
leftJoin d in Sales.SalesOrderDetail on (o.SalesOrderID = d.Value.SalesOrderID)  // before
```

With `left_joined_views = true`, each schema gets a `LeftJoined` module containing a "left-view" of every table record — the same record with every column in its nullable form — so nullability lands at the **column** level, as SQL itself models it:

```fsharp
selectTask db {
    for o in Sales.SalesOrderHeader do
    // The ON clause binds the plain record: no `.Value`, no `Some`.
    leftJoin d in Sales.LeftJoined.SalesOrderDetail on (o.SalesOrderID = d.SalesOrderID)
    // Downstream, d's columns behave like any nullable column.
    where (d.OrderQty = Some 2s)
    // Anti-join is the classic column IS NULL check:
    // where (isNullValue d.SalesOrderDetailID)
    select (o, d)
}
```

An unmatched row hydrates with every column `None`. To recover the whole-record option after materialization, each view gets a generated `ToOption()` whose signature names the real record type:

```fsharp
let orders = rows |> Seq.map (fun (o, d) -> o, d.ToOption())  // d.ToOption() : SalesOrderDetail option
```

The classic `.Value` form still works; both forms mix freely per join site, so queries migrate one at a time.

## Design notes

- **`ILeftViewOf<'Table>`** marker interface ties each view to its base record; `Table.leftTable<'Table,'View>` produces the join token, and a new `leftJoin` overload binds the ON lambda against the plain record while the variable space downstream carries the view. The token type deliberately does **not** inherit `QuerySource` — if it did, both `leftJoin` overloads would stay applicable and overload resolution could not commit before typing the ON lambda (FS0072).
- **`ToOption()` is emitted as an `[<AutoOpen>] module LeftViewExtensions`** after the schema modules close. Inside `LeftJoined` the view shadows its base record's name (and F# forbids referencing the enclosing module by qualified path from within itself), so an inline member could only name its return type through a `(base)` alias. As an extension, the signature reads `Sales.SalesOrderDetail option` — honest in tooltips. It resolves whenever the generated namespace is opened, which query code already requires.
- The match witness for `ToOption` prefers a NOT NULL PK column, falling back to the first NOT NULL column; a table whose columns are all nullable gets no `ToOption`, since a row of all NULLs is indistinguishable from a missed join in SQL itself.
- Hydration needed zero changes — the views are plain records of `Option` fields.
- **Config**: `left_joined_views` under `[sqlhydra_query_integration]`; absent defaults to `false`, the init wizard enables it for new configs. Requires `nullable_property_type = "option"` (the CLI warns otherwise, since the views are Option-shaped by design).

## Scope (v1)

Standard `leftJoin` only; `leftJoin'`/`join'` over a view token deliberately does not compile. Chained joins keyed on a prior view's column use `.Value` in the ON clause as before.

## Testing

- DB-free codegen tests for the `LeftJoined` module and `LeftViewExtensions` shape (witness selection, no double-wrapping of nullable columns, ProviderDbType attributes, flag/Nullable-config gating).
- SQL unit tests: plain-ON left join, multi-column ON, anti-join via `isNullValue`, groupBy/aggregates over view columns (SqlServer + Npgsql).
- Live-DB integration tests: unmatched rows hydrate all-`None` with `ToOption() = None`; matched rows recover `Some record`.
- Full suite green on net8/net9/net10: 527 passed, 0 failed each; all AdventureWorks schemas regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3hhyMD8BmPCH76NkDB4N3