### PR TITLE
CLAUDE.md: document Trusted Publishing and the regen-on-version-bump gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,19 @@ cd src/Build
 dotnet run -- Build     # Builds all projects for all frameworks
 dotnet run -- Test      # Runs all tests for all frameworks
 dotnet run -- Pack      # Creates NuGet packages
-dotnet run -- Publish   # Publishes to NuGet (requires SQLHYDRA_NUGET_KEY env var)
 ```
+
+## Publishing to NuGet
+
+Releases are published by the "Publish to NuGet" GitHub Actions workflow
+(`.github/workflows/publish.yml`) using NuGet Trusted Publishing (OIDC) — there is no
+stored API key, and the local Build project's `Publish` target is not the release path.
+Trigger it manually after bumping versions: Actions tab → Publish to NuGet → Run workflow,
+or `gh workflow run "Publish to NuGet"`.
+
+Note: the generated `AdventureWorks*.fs` test schemas embed the CLI version in their
+headers, so any `<Version>` bump requires `dotnet run -- Regen` (with the docker test
+databases running) or CI's regen guard will fail.
 
 For specific framework testing:
 ```bash


### PR DESCRIPTION
CLAUDE.md still described the pre-Trusted-Publishing release path (local `Publish` target + `SQLHYDRA_NUGET_KEY`), which misled this session. Now points at the `Publish to NuGet` workflow, and documents that a `<Version>` bump requires `Regen` because the generated schema headers embed the CLI version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3hhyMD8BmPCH76NkDB4N3