### PR TITLE
helpful error messages when failing to pull in an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,8 @@ type_mappings = ["SqlHydra.Query.Pgvector"]
 
 SqlHydra will resolve the assembly from your project's build output and load any `IExtendTypeMapping` implementations it finds.
 
+> **If your project is a library**, add `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>` to it. A library does not copy its package assemblies into `bin/` — they are resolved from the NuGet cache at run time — so the extension is not in the build output for SqlHydra to load, however correctly it is referenced and registered.
+
 [**SqlHydra.Query.Pgvector**](https://github.com/michaelglass/SqlHydra.Query.Pgvector) is a worked example of such a package: it maps the PostgreSQL `vector` column type to `Pgvector.Vector` and adds pgvector distance operators (`<=>`, `<->`, `<#>`) for `SqlHydra.Query`.
 
 #### Multiple Extensions

--- a/src/SqlHydra.Cli/Extensions.fs
+++ b/src/SqlHydra.Cli/Extensions.fs
@@ -2,6 +2,7 @@ module SqlHydra.Extensions
 
 open System
 open System.IO
+open System.Collections.Generic
 open System.Reflection
 open System.Runtime.Loader
 open SqlHydra.Domain
@@ -101,6 +102,27 @@ let loadProvider (project: FileInfo) (assemblyName: string) : ISqlHydraDbProvide
     | [||] -> failwith $"No ISqlHydraDbProvider implementation found in '{dllName}'."
     | _ -> failwith $"Multiple ISqlHydraDbProvider implementations found in '{dllName}'. Expected exactly one."
 
+/// How a project brings an extension in.
+type private ExtensionReference =
+    | NotReferenced
+    | AsPackage
+    | AsProject
+
+/// Nothing stops a project declaring both. `AsProject` wins and ends the search, because its
+/// output is copied either way, which is what rules out the copy-local trap.
+let private referenceKind (root: ProjectRootElement) (extName: string) =
+    let rec search (items: IEnumerator<ProjectItemElement>) found =
+        if not (items.MoveNext()) then
+            found
+        else
+            match items.Current with
+            | i when i.ItemType = "ProjectReference" && Path.GetFileNameWithoutExtension(i.Include) = extName -> AsProject
+            | i when i.ItemType = "PackageReference" && i.Include = extName -> search items AsPackage
+            | _ -> search items found
+
+    use items = (root.ItemGroups |> Seq.collect _.Items).GetEnumerator()
+    search items NotReferenced
+
 /// Loads named extension assemblies (from TOML [extensions] config).
 /// Each name must be a PackageReference, ProjectReference, or the target project itself.
 let loadNamed (project: FileInfo) (extensionNames: string list) : ISqlHydraExtension list =
@@ -108,27 +130,46 @@ let loadNamed (project: FileInfo) (extensionNames: string list) : ISqlHydraExten
     |> List.collect (fun extName ->
         let projectName = Path.GetFileNameWithoutExtension(project.Name)
 
-        // Allow the target project itself as an extension source
-        let isTargetProject = extName = projectName
+        // The target project is its own extension source, so there is no reference to check.
+        let root =
+            if extName = projectName then None else Some(ProjectRootElement.Open(project.FullName))
 
-        if not isTargetProject then
-            let root = ProjectRootElement.Open(project.FullName)
-            let hasRef =
-                root.ItemGroups
-                |> Seq.collect _.Items
-                |> Seq.exists (fun item ->
-                    match item.ItemType with
-                    | "PackageReference" -> item.Include = extName
-                    | "ProjectReference" -> Path.GetFileNameWithoutExtension(item.Include) = extName
-                    | _ -> false
-                )
-            if not hasRef then
-                failwith $"Extension '{extName}' was not found as a PackageReference or ProjectReference in '{project.Name}'."
+        // Has to fire whether or not a dll is sitting in bin/: a stale one would load silently.
+        if root |> Option.exists (fun r -> referenceKind r extName = NotReferenced) then
+            failwith $"Extension '{extName}' was not found as a PackageReference or ProjectReference in '{project.Name}'."
 
         let dllName = $"{extName}.dll"
         match findDll project dllName with
         | None ->
-            failwith $"Could not find '{dllName}' in the build output of '{project.Name}'. Ensure the project has been built."
+            let hint =
+                // Imports are not evaluated, so a value set in Directory.Build.props is
+                // invisible here. That only costs the hint.
+                let declared name =
+                    root
+                    |> Option.bind (fun r ->
+                        r.Properties |> Seq.tryFind (fun p -> p.Name = name) |> Option.map _.Value)
+
+                let referencedAsPackage =
+                    root |> Option.exists (fun r -> referenceKind r extName = AsPackage)
+
+                let says name value =
+                    declared name |> Option.map (fun v -> v.Trim().Equals(value, StringComparison.OrdinalIgnoreCase))
+
+                // An SDK-style project that says nothing builds a library.
+                let buildsLibrary = says "OutputType" "Library" |> Option.defaultValue true
+                let copyLocalOn = says "CopyLocalLockFileAssemblies" "true" |> Option.defaultValue false
+
+                if referencedAsPackage && buildsLibrary && not copyLocalOn then
+                    $" '{projectName}' builds a library and references '{extName}' as a package: a library does not copy "
+                    + "package assemblies to its output directory, so there is nothing here to load. Add "
+                    + "<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> to it."
+                else
+                    ""
+
+            failwith (
+                $"Could not find '{dllName}' in the build output of '{project.Name}'. Ensure the project has been built."
+                + hint
+            )
         | Some path ->
             // A registered extension that yields no ISqlHydraExtension is always a mistake worth
             // stopping for: otherwise generation silently proceeds without the mapping and exits 0,

--- a/src/Tests/UnitTests/Extensions.fs
+++ b/src/Tests/UnitTests/Extensions.fs
@@ -11,6 +11,24 @@ open SqlHydra
 // optionally with `{name}.dll` in bin/. For `placeDll`, SqlHydra.Domain is a real, loadable
 // assembly that defines the extension interfaces but has no concrete ISqlHydraExtension — i.e.
 // the "named but empty" case (the test assembly itself can't be used: it defines TextTypeMapping).
+let private withTempProjectXml (projName: string) (xml: string) (placeDll: bool) (name: string) (run: FileInfo -> unit) =
+    let root = Path.Combine(Path.GetTempPath(), $"sqlhydra-ext-{Guid.NewGuid():N}")
+    let proj = FileInfo(Path.Combine(root, $"{projName}.fsproj"))
+    Directory.CreateDirectory(root) |> ignore
+    File.WriteAllText(proj.FullName, xml)
+    if placeDll then
+        let bin = Directory.CreateDirectory(Path.Combine(root, "bin"))
+        let asm = typeof<SqlHydra.Domain.ISqlHydraExtension>.Assembly
+        File.Copy(asm.Location, Path.Combine(bin.FullName, $"{name}.dll"))
+    try run proj
+    finally (try Directory.Delete(root, true) with _ -> ())
+
+let private consumerReferencing (itemType: string) (extName: string) (extraProps: string) =
+    $"""<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>{extraProps}</PropertyGroup>
+  <ItemGroup><{itemType} Include="{extName}" /></ItemGroup>
+</Project>"""
+
 let private withTempProject (name: string) (placeDll: bool) (run: FileInfo -> unit) =
     let root = Path.Combine(Path.GetTempPath(), $"sqlhydra-ext-{Guid.NewGuid():N}")
     let proj = FileInfo(Path.Combine(root, $"{name}.fsproj"))
@@ -36,3 +54,58 @@ let ``loadNamed raises when the named dll is missing from build output`` () =
     withTempProject "Missing" false (fun proj ->
         let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Missing" ] |> ignore)
         test <@ ex.Message.Contains("Missing") @>)
+
+[<Test>]
+let ``a registered extension that is not referenced raises even when its dll is present`` () =
+    // Do not fold the reference check into the missing-dll path: a stale dll would make the
+    // lookup succeed and the extension would load unreferenced.
+    let noRef = """<Project Sdk="Microsoft.NET.Sdk"></Project>"""
+    withTempProjectXml "Consumer" noRef true "Ext" (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Ext" ] |> ignore)
+        test <@ ex.Message.Contains "was not found as a PackageReference or ProjectReference" @>)
+
+[<Test>]
+let ``a library referencing the extension as a package is told about CopyLocalLockFileAssemblies`` () =
+    withTempProjectXml "Consumer" (consumerReferencing "PackageReference" "Ext" "") false "Ext" (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Ext" ] |> ignore)
+        test <@ ex.Message.Contains("CopyLocalLockFileAssemblies") @>)
+
+[<Test>]
+let ``an executable is not told about CopyLocalLockFileAssemblies`` () =
+    let props = "<OutputType>Exe</OutputType>"
+    withTempProjectXml "Consumer" (consumerReferencing "PackageReference" "Ext" props) false "Ext" (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Ext" ] |> ignore)
+        test <@ not (ex.Message.Contains "CopyLocalLockFileAssemblies") @>)
+
+[<Test>]
+let ``a project reference is not told about CopyLocalLockFileAssemblies`` () =
+    withTempProjectXml "Consumer" (consumerReferencing "ProjectReference" "Ext" "") false "Ext" (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Ext" ] |> ignore)
+        test <@ not (ex.Message.Contains "CopyLocalLockFileAssemblies") @>)
+
+[<Test>]
+let ``a project declaring both kinds of reference is not told about CopyLocalLockFileAssemblies`` () =
+    // A project reference is copied to the output either way, so the copy-local trap is ruled
+    // out even though a PackageReference is also declared.
+    // Both orderings: whichever is declared first, the project reference decides.
+    let both (first: string) (second: string) =
+        $"""<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    {first}
+    {second}
+  </ItemGroup>
+</Project>"""
+    let pkg = """<PackageReference Include="Ext" />"""
+    let proj = """<ProjectReference Include="../Ext/Ext.fsproj" />"""
+
+    for xml in [ both pkg proj; both proj pkg ] do
+        withTempProjectXml "Consumer" xml false "Ext" (fun p ->
+            let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed p [ "Ext" ] |> ignore)
+            test <@ not (ex.Message.Contains "CopyLocalLockFileAssemblies") @>)
+
+[<Test>]
+let ``a library that already set CopyLocalLockFileAssemblies is not told again`` () =
+    let props = "<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>"
+    withTempProjectXml "Consumer" (consumerReferencing "PackageReference" "Ext" props) false "Ext" (fun proj ->
+        let ex = Assert.Throws<Exception>(fun () -> Extensions.loadNamed proj [ "Ext" ] |> ignore)
+        test <@ not (ex.Message.Contains "CopyLocalLockFileAssemblies") @>)


### PR DESCRIPTION
this one might be too much code for a better error message, but ... here goes
---

Reference an extension package, register it in `[extensions]`, run the generator from a **library** project, and SqlHydra says:

```
Could not find 'MyExtension.dll' in the build output of 'MyProject'.
Ensure the project has been built.
```

The project has been built. A library does not copy its package assemblies into `bin/` — they are resolved from the NuGet cache at run time — so the extension genuinely is not in the build output, however correctly it is referenced and registered. The fix is `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>`, and nothing points at it.

We can tell, so we say so. The project file is already open at that point to check the reference. The loader now also reads `OutputType` and `CopyLocalLockFileAssemblies` off it, and adds the advice only when all three hold: the extension came from a `PackageReference`, the project builds a library, and the property is not already set. An executable, a `ProjectReference`, or a project that already set it gets the original message unchanged — a suggestion that does not apply is worse than none.

The README now carries the same caveat where it tells you to add the `PackageReference`.