### PR TITLE
ensure postgres materialized views respect `[filter`]

### DIFF
--- a/src/SqlHydra.Cli/Npgsql/NpgsqlSchemaProvider.fs
+++ b/src/SqlHydra.Cli/Npgsql/NpgsqlSchemaProvider.fs
@@ -207,6 +207,29 @@ let getSchema (cfg: Config, isLegacy: bool, extensions: IExtendTypeMapping list)
             |}
         )
 
+    let baseTables =
+        sTables.Rows
+        |> Seq.cast<DataRow>
+        |> Seq.map (fun tbl ->
+            {|
+                Catalog = tbl["TABLE_CATALOG"] :?> string
+                Schema = tbl["TABLE_SCHEMA"] :?> string
+                Name  = tbl["TABLE_NAME"] :?> string
+                Type = tbl["TABLE_TYPE"] :?> string
+            |}
+        )
+        |> Seq.filter (fun tbl -> tbl.Type <> "SYSTEM_TABLE")
+
+    /// Every relation the filters keep. Materialized views go through here too — they used
+    /// to bypass filtering entirely, so an excluded one was still generated — and one pass
+    /// means the filter summary is reported once.
+    let includedRelations =
+        baseTables
+        |> Seq.append views
+        |> Seq.append materializedViews
+        |> SchemaFilters.filterTables cfg.Filters
+        |> Seq.toList
+
     let materializedViewColumns =
         let sql =
             """
@@ -272,7 +295,8 @@ let getSchema (cfg: Config, isLegacy: bool, extensions: IExtendTypeMapping list)
         extensions |> List.fold (fun acc (ext: IExtendTypeMapping) -> ext.Extend(acc)) baseTryFind
 
     let matViews =
-        materializedViews
+        includedRelations
+        |> Seq.filter (fun tbl -> tbl.Type = "materialized view")
         |> Seq.choose (fun tbl ->
             let matViewCols =
                 match materializedViewColumns.TryFind(tbl.Schema, tbl.Name) with
@@ -318,19 +342,8 @@ let getSchema (cfg: Config, isLegacy: bool, extensions: IExtendTypeMapping list)
         |> Seq.toList
 
     let tables =
-        sTables.Rows
-        |> Seq.cast<DataRow>
-        |> Seq.map (fun tbl ->
-            {|
-                Catalog = tbl["TABLE_CATALOG"] :?> string
-                Schema = tbl["TABLE_SCHEMA"] :?> string
-                Name  = tbl["TABLE_NAME"] :?> string
-                Type = tbl["TABLE_TYPE"] :?> string
-            |}
-        )
-        |> Seq.filter (fun tbl -> tbl.Type <> "SYSTEM_TABLE")
-        |> Seq.append views
-        |> SchemaFilters.filterTables cfg.Filters
+        includedRelations
+        |> Seq.filter (fun tbl -> tbl.Type <> "materialized view")
         |> Seq.choose (fun tbl ->
             let tableCols =
                 columnsByTable

--- a/src/Tests/Npgsql/Generation.fs
+++ b/src/Tests/Npgsql/Generation.fs
@@ -1,4 +1,4 @@
-module Npgsql.Generation
+﻿module Npgsql.Generation
 
 open Swensen.Unquote
 open SqlHydra
@@ -429,3 +429,43 @@ let ``The schema provider marks the columns PostgreSQL generates, and only those
         readOnly =! set expected
     finally
         execute dropProbes
+// Table filters, against a live PostgreSQL.
+
+let private filterCfg filters : Config =
+    {
+        LeftJoinedViews = false
+        ConnectionString = DB.connectionString
+        OutputFile = ""
+        Namespace = "TestNS"
+        IsCLIMutable = true
+        IsMutableProperties = false
+        NullablePropertyType = NullablePropertyType.Option
+        ProviderDbTypeAttributes = true
+        TableDeclarations = true
+        Readers = None
+        Filters = filters
+        TypeMappingExtensions = []
+    }
+
+let private generatedPaths filters =
+    (NpgsqlSchemaProvider.getSchema(filterCfg filters, false, [])).Tables
+    |> List.map (fun tbl -> $"{tbl.Schema}/{tbl.Name}")
+
+[<Test>]
+let ``Table filters exclude materialized views, which used to bypass them``() =
+    // AdventureWorks has two: person/vstateprovincecountryregion and
+    // production/vproductanddescription. Both came back whatever the filters said.
+    generatedPaths { Filters.Empty with Includes = [ "person/address" ] } =! [ "person/address" ]
+
+[<Test>]
+let ``Table filters keep materialized views that match``() =
+    let paths = generatedPaths { Filters.Empty with Includes = [ "person/*" ] }
+    (paths |> List.contains "person/vstateprovincecountryregion") =! true
+    (paths |> List.contains "production/vproductanddescription") =! false
+
+[<Test>]
+let ``A wildcard include keeps every relation, materialized views included``() =
+    // `include = [ "*" ]` is what the repo's own .toml files use; it must still mean "all".
+    let paths = generatedPaths { Filters.Empty with Includes = [ "*" ] }
+    (paths |> List.contains "person/address") =! true
+    (paths |> List.contains "person/vstateprovincecountryregion") =! true


### PR DESCRIPTION
Exclude a materialized view in `[filters]` and it is generated anyway.

Against AdventureWorks, an include filter naming a single table hands back three: that table, plus `person/vstateprovincecountryregion` and `production/vproductanddescription`. So the config says one thing and the generated file says another, and the only way to notice is to read the output.

**Why.** `getSchema` assembles its result as `tables @ matViews`, and only the first half ever goes through the filter. Materialized views are appended afterwards, past the point where filters apply.

**The fix.** Filtering runs once over every relation, and the table and view pipelines each take their own from the result. One pass instead of two, so a future third kind of relation cannot slip past the same way. The filter summary stays a single report, relative ordering is unchanged, and `include = [ "*" ]` — which this repo's own configs use — still means everything.
