### PR TITLE
ensure proper column-quoting when compared to a SQL function

### DIFF
--- a/src/SqlHydra.Query/LinqExpressionVisitors.fs
+++ b/src/SqlHydra.Query/LinqExpressionVisitors.fs
@@ -726,6 +726,23 @@ let nVisitSqlFn (qualifyColumn: string -> MemberInfo -> string) (nexp: Normalize
     | NMethodCall(m, _) -> visitSqlFn qualifyColumn (m :> Expression)
     | _ -> notImplMsg $"Expected NMethodCall for SQL function"
 
+/// Marks an already-qualified dotted name (`alias.Column`, `schema.Table.Column`) for
+/// identifier quoting by the emitter's `QuoteRawFragment`.
+///
+/// A structured clause (`Compare`, `IsNull`, `CompareColumns`, ...) carries the column in its
+/// own slot and the emitter quotes it there, so those keep the bare name. A `RawWhere` /
+/// `RawColumn` / `OrderByRaw` fragment is emitted almost verbatim, so a column headed into one
+/// must be marked here or it reaches the server unquoted.
+let markQualified (fqCol: string) =
+    fqCol.Split('.')
+    |> Array.map (fun segment -> $"{{%s{segment}}}")
+    |> String.concat "."
+
+/// Wraps a builder-supplied `qualifyColumn` so its output is marked for quoting. Pass this,
+/// not the bare qualifier, to anything that renders into a raw SQL fragment (`visitSqlFn`).
+let markingQualifier (qualifyColumn: string -> MemberInfo -> string) =
+    fun alias (mem: MemberInfo) -> markQualified (qualifyColumn alias mem)
+
 /// `x = None` (a null) is `x IS NULL`, since `= NULL` never matches; `x = Some v` binds v.
 /// A column binds a parameter typed from its member; a rendered fragment binds a raw one.
 let private compareColumnToValue (fqCol: string) (column: MemberInfo) (op: ComparisonOp) (value: obj) =
@@ -745,6 +762,10 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
         match nexp with
         | NProperty (p, ext) when tables |> Seq.exists (fun tbl -> tbl.IsInTable p) -> Some (p, ext)
         | _ -> None
+
+    /// `qualifyColumn`, marked for identifier quoting. Use it for any column that ends up
+    /// inside a `RawWhere` fragment rather than in a structured clause's column slot.
+    let qualifyForRaw = markingQualifier qualifyColumn
 
     /// Evaluate a NormalizedExpression to a runtime value.
     let nEvaluate (nexp: NormalizedExpression) =
@@ -1011,33 +1032,33 @@ let visitWhere<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool>
 
             // SQL function compared to value
             | NMethodCall (m, _), NValue value when isSqlHydraFunction m.Method ->
-                let sqlFragment = nVisitSqlFn qualifyColumn left
+                let sqlFragment = nVisitSqlFn qualifyForRaw left
                 compareFragmentToValue sqlFragment op value
 
             // Value compared to SQL function
             | NValue value, NMethodCall (m, _) when isSqlHydraFunction m.Method ->
-                let sqlFragment = nVisitSqlFn qualifyColumn right
+                let sqlFragment = nVisitSqlFn qualifyForRaw right
                 compareFragmentToValue sqlFragment (reverseComparison op) value
 
             // SQL function compared to column
             | NMethodCall (m, _), NColumn (p, _) when isSqlHydraFunction m.Method ->
-                let sqlFragment = nVisitSqlFn qualifyColumn left
+                let sqlFragment = nVisitSqlFn qualifyForRaw left
                 let alias = visitAlias p.Expression
-                let fqCol = qualifyColumn alias p.Member
+                let fqCol = qualifyForRaw alias p.Member
                 RawWhere($"{sqlFragment} {comparison} {fqCol}", [||])
 
             // Column compared to SQL function
             | NColumn (p, _), NMethodCall (m, _) when isSqlHydraFunction m.Method ->
                 let alias = visitAlias p.Expression
-                let fqCol = qualifyColumn alias p.Member
-                let sqlFragment = nVisitSqlFn qualifyColumn right
+                let fqCol = qualifyForRaw alias p.Member
+                let sqlFragment = nVisitSqlFn qualifyForRaw right
                 RawWhere($"{fqCol} {comparison} {sqlFragment}", [||])
 
             // SQL function compared to SQL function
             | NMethodCall (m1, _), NMethodCall (m2, _) when
                 isSqlHydraFunction m1.Method && isSqlHydraFunction m2.Method ->
-                let sqlFragment1 = nVisitSqlFn qualifyColumn left
-                let sqlFragment2 = nVisitSqlFn qualifyColumn right
+                let sqlFragment1 = nVisitSqlFn qualifyForRaw left
+                let sqlFragment2 = nVisitSqlFn qualifyForRaw right
                 RawWhere($"{sqlFragment1} {comparison} {sqlFragment2}", [||])
 
             // Joined table parameter compared to None (e.g., where (d = None) after leftJoin')
@@ -1134,6 +1155,10 @@ let visitHaving<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool
         | NProperty (p, ext) when tables |> Seq.exists (fun tbl -> tbl.IsInTable p) -> Some (p, ext)
         | _ -> None
 
+    /// `qualifyColumn`, marked for identifier quoting. Use it for any column that ends up
+    /// inside a `RawWhere` fragment rather than in a structured clause's column slot.
+    let qualifyForRaw = markingQualifier qualifyColumn
+
     let rec visit (nexp: NormalizedExpression) : WhereClause =
         match nexp with
         | NNot operand ->
@@ -1223,14 +1248,14 @@ let visitHaving<'T> (tables: TableMapping seq) (filter: Expression<Func<'T, bool
             | NAggregateColumn (aggType, (p1, _)), NColumn (p2, _) ->
                 let lt =
                     let alias = visitAlias p1.Expression
-                    qualifyColumn alias p1.Member
+                    qualifyForRaw alias p1.Member
                 let rt =
                     let alias = visitAlias p2.Expression
-                    qualifyColumn alias p2.Member
+                    qualifyForRaw alias p2.Member
                 RawWhere($"{renderAggregate aggType lt} {comparison} {rt}", [||])
             | NAggregateColumn (aggType, (p, _)), NValue value ->
                 let alias = visitAlias p.Expression
-                compareFragmentToValue (renderAggregate aggType (qualifyColumn alias p.Member)) op value
+                compareFragmentToValue (renderAggregate aggType (qualifyForRaw alias p.Member)) op value
             | NColumn (p1, _), NColumn (p2, _) ->
                 let lt =
                     let alias = visitAlias p1.Expression
@@ -1400,6 +1425,10 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
         | NProperty (p, ext) when tables |> Seq.exists (fun tbl -> tbl.IsInTable p) -> Some (p, ext)
         | _ -> None
 
+    /// `qualifyColumn`, marked for identifier quoting. Use it for any column that ends up
+    /// inside a `RawWhere` fragment rather than in a structured clause's column slot.
+    let qualifyForRaw = markingQualifier qualifyColumn
+
     let rec visit (nexp: NormalizedExpression) : WhereClause =
         match nexp with
         | NBinaryAnd(left, right) ->
@@ -1418,23 +1447,23 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
             // below, which compile-and-eval whichever side is not a column.
             | NColumn (p, _), NMethodCall (m, _) when isSqlHydraFunction m.Method ->
                 let alias = visitAlias p.Expression
-                let fqCol = qualifyColumn alias p.Member
-                RawWhere($"{fqCol} {comparison} {nVisitSqlFn qualifyColumn right}", [||])
+                let fqCol = qualifyForRaw alias p.Member
+                RawWhere($"{fqCol} {comparison} {nVisitSqlFn qualifyForRaw right}", [||])
 
             | NMethodCall (m, _), NColumn (p, _) when isSqlHydraFunction m.Method ->
                 let alias = visitAlias p.Expression
-                let fqCol = qualifyColumn alias p.Member
-                RawWhere($"{nVisitSqlFn qualifyColumn left} {comparison} {fqCol}", [||])
+                let fqCol = qualifyForRaw alias p.Member
+                RawWhere($"{nVisitSqlFn qualifyForRaw left} {comparison} {fqCol}", [||])
 
             | NMethodCall (m, _), NValue value when isSqlHydraFunction m.Method ->
-                compareFragmentToValue (nVisitSqlFn qualifyColumn left) op value
+                compareFragmentToValue (nVisitSqlFn qualifyForRaw left) op value
 
             | NValue value, NMethodCall (m, _) when isSqlHydraFunction m.Method ->
-                compareFragmentToValue (nVisitSqlFn qualifyColumn right) (reverseComparison op) value
+                compareFragmentToValue (nVisitSqlFn qualifyForRaw right) (reverseComparison op) value
 
             | NMethodCall (m1, _), NMethodCall (m2, _) when
                 isSqlHydraFunction m1.Method && isSqlHydraFunction m2.Method ->
-                RawWhere($"{nVisitSqlFn qualifyColumn left} {comparison} {nVisitSqlFn qualifyColumn right}", [||])
+                RawWhere($"{nVisitSqlFn qualifyForRaw left} {comparison} {nVisitSqlFn qualifyForRaw right}", [||])
 
             // Handle col to col comparisons (the primary join case)
             | NColumn (p1, _), NColumn (p2, _) ->
@@ -1574,7 +1603,7 @@ let visitJoinPredicate<'T> (tables: TableMapping seq) (predicate: Expression<Fun
 /// InfixOperators rewrites apply.
 let private renderSelectExpression (exp: Expression) : string * obj[] =
     let parms = ResizeArray<obj>()
-    let qualifyColumn alias (mem: MemberInfo) = $"{{{alias}}}.{{{mem.Name}}}"
+    let qualifyColumn alias (mem: MemberInfo) = markQualified $"%s{alias}.%s{mem.Name}"
     let rec render (e: Expression) : string =
         match e with
         | :? UnaryExpression as u when u.NodeType = ExpressionType.Convert ->
@@ -1687,15 +1716,15 @@ let visitSelect<'T, 'Prop> (propertySelector: Expression<Func<'T, 'Prop>>) =
                     | _ -> notImplMsg $"Unsupported Option.map lambda body: {mapLam.Body.NodeType}"
                 | None -> notImplMsg $"Could not extract mapping lambda from Option.map expression"
             else
-                let qualifyCol alias (mem: MemberInfo) = $"{{%s{alias}}}.{{%s{mem.Name}}}"
+                let qualifyCol alias (mem: MemberInfo) = markQualified $"%s{alias}.%s{mem.Name}"
                 let sqlFragment = visitSqlFn qualifyCol (m :> Expression)
                 [ SelectedExpression sqlFragment ]
         | NAggregateColumn (aggType, (p, _)) ->
             let alias = visitAlias p.Expression
-            let fqCol = $"{{%s{alias}}}.{{%s{p.Member.Name}}}"
+            let fqCol = markQualified $"%s{alias}.%s{p.Member.Name}"
             [ SelectedExpression (renderAggregate aggType fqCol) ]
         | NMethodCall(m, _) ->
-            let qualifyCol alias (mem: MemberInfo) = $"{{%s{alias}}}.{{%s{mem.Name}}}"
+            let qualifyCol alias (mem: MemberInfo) = markQualified $"%s{alias}.%s{mem.Name}"
             let sqlFragment = visitSqlFn qualifyCol (m :> Expression)
             [ SelectedExpression sqlFragment ]
         | NNew(newExpr, args) ->

--- a/src/SqlHydra.Query/SelectBuilders.fs
+++ b/src/SqlHydra.Query/SelectBuilders.fs
@@ -237,7 +237,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
                     let fqCol = $"%s{tableAlias}.%s{p.Name}"
                     [OrderByColumn (fqCol, Asc)]
                 | LinqExpressionVisitors.OrderByAggregateColumn (aggType, tableAlias, p) ->
-                    let fqCol = $"{{%s{tableAlias}}}.{{%s{p.Name}}}"
+                    let fqCol = LinqExpressionVisitors.markQualified $"%s{tableAlias}.%s{p.Name}"
                     [OrderByRaw (LinqExpressionVisitors.renderAggregate aggType fqCol, [||])]
                 | LinqExpressionVisitors.OrderByExpression (frag, parms) ->
                     [OrderByRaw (frag, parms)]
@@ -261,7 +261,7 @@ type SelectBuilder<'Selected, 'Mapped> () =
                     let fqCol = $"%s{tableAlias}.%s{p.Name}"
                     [OrderByColumn (fqCol, Desc)]
                 | LinqExpressionVisitors.OrderByAggregateColumn (aggType, tableAlias, p) ->
-                    let fqCol = $"{{%s{tableAlias}}}.{{%s{p.Name}}}"
+                    let fqCol = LinqExpressionVisitors.markQualified $"%s{tableAlias}.%s{p.Name}"
                     [OrderByRaw ($"{LinqExpressionVisitors.renderAggregate aggType fqCol} DESC", [||])]
                 | LinqExpressionVisitors.OrderByExpression (frag, parms) ->
                     [OrderByRaw ($"{frag} DESC", parms)]

--- a/src/SqlHydra.Query/SqlEmitterBase.fs
+++ b/src/SqlHydra.Query/SqlEmitterBase.fs
@@ -148,12 +148,21 @@ type SqlEmitterBase() =
     member this.QuoteColumn(col: string) =
         this.QuoteDotted(col)
 
-    /// Processes a raw SQL fragment, replacing {alias}.{column} templates with quoted identifiers.
+    /// Processes a raw SQL fragment, replacing dotted `{a}.{b}` / `{a}.{b}.{c}` identifier
+    /// templates with quoted identifiers. The visitors mark every column they interpolate into
+    /// a raw fragment this way, so `{alias}.{column}` (select/where/join) and
+    /// `{schema}.{table}.{column}` (delete/update) both round-trip.
+    ///
+    /// A run of two or more segments is required, so a lone `{...}` in a hand-written fragment
+    /// (`havingRaw`, `whereRawConflict`, a user-built `RawWhere`) is left alone.
     member this.QuoteRawFragment(fragment: string) =
-        Regex.Replace(fragment, @"\{(\w+)\}\.\{(\w+)\}", fun m ->
-            let alias = m.Groups.[1].Value
-            let col = m.Groups.[2].Value
-            $"{this.QuoteIdentifier(alias)}.{this.QuoteIdentifier(col)}"
+        Regex.Replace(fragment, @"\{(\w+)\}(?:\.\{(\w+)\})+", fun m ->
+            seq {
+                yield m.Groups.[1].Value
+                for c in m.Groups.[2].Captures -> c.Value
+            }
+            |> Seq.map this.QuoteIdentifier
+            |> String.concat "."
         )
 
     /// Emits a SqlValue, returning the SQL fragment.
@@ -240,7 +249,7 @@ type SqlEmitterBase() =
         | Grouped inner ->
             this.EmitWhere(inner, collector) // wrap in parens
         | RawWhere (fragment, parms) ->
-            this.SubstituteParams(fragment, parms, collector)
+            this.SubstituteParams(this.QuoteRawFragment(fragment), parms, collector)
         | BoolColumn (col, value) ->
             let quotedCol = this.QuoteColumn(col)
             this.EmitBoolColumn(quotedCol, value, collector)

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1978,3 +1978,31 @@ let ``an aggregate compared to None in a having emits IS NULL``() =
         }
         |> toSql
     test <@ sql.Contains("HAVING (MAX(a.addressline2) IS NULL)") @>
+[<Ignore("Fails: the column loses its quotes on the SQL-function path. See the comment below.")>]
+let ``a column compared to a SQL function is quoted like any other column``() =
+    // A column keeps its quotes when compared to a value, and loses them when compared to a
+    // SQL function. The value path builds a `Compare` node and the emitter runs QuoteColumn
+    // over it; the function path builds a `RawWhere` whose fragment is emitted verbatim, and
+    // `qualifyColumn` returns the bare `alias.column`.
+    //
+    // The select path already solved this: `renderSelectExpression` marks identifiers as
+    // `{alias}.{column}` and the emitter expands them through `QuoteRawFragment`. The where,
+    // having and join paths do not, and `RawWhere` never calls it.
+    //
+    // PostgreSQL survives this only because it folds unquoted names to lower case and
+    // AdventureWorks is lower case throughout. A mixed-case column would fail here too.
+    let viaValue =
+        select {
+            for a in person.address do
+            where (a.city < "x")
+        }
+        |> toSql
+    let viaFunction =
+        select {
+            for a in person.address do
+            where (a.city < SqlFn.upper a.addressline1)
+        }
+        |> toSql
+
+    test <@ viaValue.Contains "\"a\".\"city\"" @>            // control: already correct
+    test <@ viaFunction.Contains "\"a\".\"city\"" @>

--- a/src/Tests/Npgsql/QueryUnitTests.fs
+++ b/src/Tests/Npgsql/QueryUnitTests.fs
@@ -1345,7 +1345,7 @@ let ``inlineValue beside another SQL function is a value, not a database call``(
             where (SqlFn.lower a.city = inlineValue "smith")
         }
         |> toSql
-    test <@ sql.Contains("(LOWER(a.city) = 'smith')") @>
+    test <@ sql.Contains("(LOWER(\"a\".\"city\") = 'smith')") @>
     test <@ not (sql.Contains("INLINEVALUE")) @>
 
 [<Test>]
@@ -1363,7 +1363,7 @@ let ``a where on a value does not silently become a NULL check``() =
         |> toSql
     // The whole predicate, not just the literal: rendering the marker itself as a
     // function (`INLINEVALUE('Dallas')`) would satisfy any looser assertion.
-    test <@ sql.Contains("(a.city = 'Dallas')") @>
+    test <@ sql.Contains("(\"a\".\"city\" = 'Dallas')") @>
     test <@ not (sql.Contains("IS NULL")) @>
     test <@ not (sql.Contains("@p")) @>
 
@@ -1376,7 +1376,7 @@ let ``a where against a raw SQL expression does not silently become a NULL check
             where (a.city = rawExpr<string> "'Dallas'")
         }
         |> toSql
-    test <@ sql.Contains("(a.city = 'Dallas')") @>
+    test <@ sql.Contains("(\"a\".\"city\" = 'Dallas')") @>
     test <@ not (sql.Contains("RAWEXPR")) @>
     test <@ not (sql.Contains("IS NULL")) @>
 
@@ -1391,7 +1391,7 @@ let ``a SQL function can be compared against a column``() =
             where (SqlFn.lower a.city = a.addressline1)
         }
         |> toSql
-    test <@ sql.Contains("(LOWER(a.city) = a.addressline1)") @>
+    test <@ sql.Contains("(LOWER(\"a\".\"city\") = \"a\".\"addressline1\")") @>
 
 [<Test>]
 let ``a captured .NET value is still bound as a parameter``() =
@@ -1419,7 +1419,7 @@ let ``a SQL function can be used in a join predicate``() =
             select a
         }
         |> toSql
-    test <@ sql.Contains("ON (a.city = LOWER(a2.city))") @>
+    test <@ sql.Contains("ON (\"a\".\"city\" = LOWER(\"a2\".\"city\"))") @>
 
 [<Test>]
 let ``a SQL function on the left of a join predicate``() =
@@ -1430,7 +1430,7 @@ let ``a SQL function on the left of a join predicate``() =
             select a
         }
         |> toSql
-    test <@ sql.Contains("ON (LOWER(a.city) = a2.city)") @>
+    test <@ sql.Contains("ON (LOWER(\"a\".\"city\") = \"a2\".\"city\")") @>
 
 [<Test>]
 let ``a SQL function compared to a value in a join predicate``() =
@@ -1441,7 +1441,7 @@ let ``a SQL function compared to a value in a join predicate``() =
             select a
         }
         |> toSql
-    test <@ sql.Contains("ON (LOWER(a2.city) = @p0)") @>
+    test <@ sql.Contains("ON (LOWER(\"a2\".\"city\") = @p0)") @>
 
 [<Test>]
 let ``two SQL functions compared in a join predicate``() =
@@ -1453,7 +1453,7 @@ let ``two SQL functions compared in a join predicate``() =
             select a
         }
         |> toSql
-    test <@ sql.Contains("ON (LOWER(a.city) = LOWER(a2.city))") @>
+    test <@ sql.Contains("ON (LOWER(\"a\".\"city\") = LOWER(\"a2\".\"city\"))") @>
 
 [<Test>]
 let ``a captured .NET value on the left is still bound as a parameter``() =
@@ -1479,7 +1479,7 @@ let ``a user-defined SQL function can be used in a where``() =
             where (ExtFn.lower a.addressline2 = "dallas")
         }
         |> toSql
-    test <@ sql.Contains("(LOWER(a.addressline2) = @p0)") @>
+    test <@ sql.Contains("(LOWER(\"a\".\"addressline2\") = @p0)") @>
 
 [<Test>]
 let ``the README's custom-function example runs``() =
@@ -1493,7 +1493,7 @@ let ``the README's custom-function example runs``() =
             where (SOUNDEX(a.city) = SOUNDEX("Smith"))
         }
         |> toSql
-    test <@ sql.Contains("(SOUNDEX(a.city) = SOUNDEX('Smith'))") @>
+    test <@ sql.Contains("(SOUNDEX(\"a\".\"city\") = SOUNDEX('Smith'))") @>
 
 [<Test>]
 let ``a user-defined SQL function over constants does not silently become a NULL check``() =
@@ -1506,7 +1506,7 @@ let ``a user-defined SQL function over constants does not silently become a NULL
             where (a.city = SOUNDEX "Smith")
         }
         |> toSql
-    test <@ sql.Contains("(a.city = SOUNDEX('Smith'))") @>
+    test <@ sql.Contains("(\"a\".\"city\" = SOUNDEX('Smith'))") @>
     test <@ not (sql.Contains("IS NULL")) @>
 
 [<Test>]
@@ -1517,7 +1517,7 @@ let ``a generic user-defined SQL function is recognized in a where``() =
             where (NULLIF(a.city, "Dallas") = "Seattle")
         }
         |> toSql
-    test <@ sql.Contains("NULLIF(a.city, 'Dallas')") @>
+    test <@ sql.Contains("NULLIF(\"a\".\"city\", 'Dallas')") @>
 
 [<Test>]
 let ``an unmarked SQL function over constants raises instead of emitting IS NULL``() =
@@ -1599,7 +1599,7 @@ let ``a user-defined SQL function can be used in an on' join predicate``() =
             select a
         }
         |> toSql
-    test <@ sql.Contains("ON (SOUNDEX(a.city) = SOUNDEX(a2.city))") @>
+    test <@ sql.Contains("ON (SOUNDEX(\"a\".\"city\") = SOUNDEX(\"a2\".\"city\"))") @>
 
 [<Test>]
 let ``a marked module covers the wrappers declared in it``() =
@@ -1611,7 +1611,7 @@ let ``a marked module covers the wrappers declared in it``() =
             where (Grouped.DIFFERENCE(a.city, "Dallas") = 4)
         }
         |> toSql
-    test <@ sql.Contains("DIFFERENCE(a.city, 'Dallas')") @>
+    test <@ sql.Contains("DIFFERENCE(\"a\".\"city\", 'Dallas')") @>
 
 [<Test>]
 let ``a marked module covers nested modules``() =
@@ -1621,7 +1621,7 @@ let ``a marked module covers nested modules``() =
             where (Grouped.Text.INITCAP a.city = "Dallas")
         }
         |> toSql
-    test <@ sql.Contains("INITCAP(a.city)") @>
+    test <@ sql.Contains("INITCAP(\"a\".\"city\")") @>
 
 [<Test>]
 let ``a marked type covers its static members``() =
@@ -1631,7 +1631,7 @@ let ``a marked type covers its static members``() =
             where (GroupedFn.ASCII a.city = 68)
         }
         |> toSql
-    test <@ sql.Contains("ASCII(a.city)") @>
+    test <@ sql.Contains("ASCII(\"a\".\"city\")") @>
 
 // A member access over a wrapper is the one shape `NValue` doesn't match, so it reaches the
 // fall-through arms with the stub intact. Four: two clauses x two operand orders.
@@ -1761,7 +1761,7 @@ let ``lower over a nullable column emits LOWER(col)``() =
             where (SqlFn.lower a.addressline2 = Some "suite 100")
         }
         |> toSql
-    test <@ sql.Contains("(LOWER(a.addressline2) = @p0)") @>
+    test <@ sql.Contains("(LOWER(\"a\".\"addressline2\") = @p0)") @>
 
 [<Test>]
 let ``nullable string functions compose``() =
@@ -1771,7 +1771,7 @@ let ``nullable string functions compose``() =
             where (SqlFn.length (SqlFn.ltrim (SqlFn.lower a.addressline2)) = Some 9)
         }
         |> toSql
-    test <@ sql.Contains("(LENGTH(LTRIM(LOWER(a.addressline2))) = @p0)") @>
+    test <@ sql.Contains("(LENGTH(LTRIM(LOWER(\"a\".\"addressline2\"))) = @p0)") @>
 
 [<Test>]
 let ``an option-returning function compared to None emits IS NULL``() =
@@ -1782,9 +1782,9 @@ let ``an option-returning function compared to None emits IS NULL``() =
             where (SqlFn.nullif (a.city, "") = None && SqlFn.lower a.addressline2 <> None && None = SqlFn.upper a.addressline2)
         }
         |> toSql
-    test <@ sql.Contains("(NULLIF(a.city, '') IS NULL)") @>
-    test <@ sql.Contains("(LOWER(a.addressline2) IS NOT NULL)") @>
-    test <@ sql.Contains("(UPPER(a.addressline2) IS NULL)") @>
+    test <@ sql.Contains("(NULLIF(\"a\".\"city\", '') IS NULL)") @>
+    test <@ sql.Contains("(LOWER(\"a\".\"addressline2\") IS NOT NULL)") @>
+    test <@ sql.Contains("(UPPER(\"a\".\"addressline2\") IS NULL)") @>
 
 [<Test>]
 let ``a keyword-named function renders schema-qualified``() =
@@ -1794,7 +1794,7 @@ let ``a keyword-named function renders schema-qualified``() =
             where (SqlFn.position (a.city, "a") > 0)
         }
         |> toSql
-    test <@ sql.Contains("(pg_catalog.position(a.city, 'a') > @p0)") @>
+    test <@ sql.Contains("(pg_catalog.position(\"a\".\"city\", 'a') > @p0)") @>
 
 // Niladic functions, one test per site the visitor renders a call from. Each assertion carries the
 // token that follows the name, so a stray `()` breaks the match instead of hiding inside it.
@@ -1977,20 +1977,21 @@ let ``an aggregate compared to None in a having emits IS NULL``() =
             select (a.city, maxBy a.addressline2)
         }
         |> toSql
-    test <@ sql.Contains("HAVING (MAX(a.addressline2) IS NULL)") @>
-[<Ignore("Fails: the column loses its quotes on the SQL-function path. See the comment below.")>]
+    test <@ sql.Contains("HAVING (MAX(\"a\".\"addressline2\") IS NULL)") @>
+
+[<Test>]
 let ``a column compared to a SQL function is quoted like any other column``() =
-    // A column keeps its quotes when compared to a value, and loses them when compared to a
-    // SQL function. The value path builds a `Compare` node and the emitter runs QuoteColumn
-    // over it; the function path builds a `RawWhere` whose fragment is emitted verbatim, and
-    // `qualifyColumn` returns the bare `alias.column`.
+    // A column used to keep its quotes when compared to a value and lose them when compared to
+    // a SQL function. The value path builds a `Compare` node and the emitter runs QuoteColumn
+    // over it; the function path builds a `RawWhere`, whose fragment used to be emitted
+    // verbatim with the bare `alias.column` that `qualifyColumn` returns.
     //
-    // The select path already solved this: `renderSelectExpression` marks identifiers as
-    // `{alias}.{column}` and the emitter expands them through `QuoteRawFragment`. The where,
-    // having and join paths do not, and `RawWhere` never calls it.
+    // The select path had already solved this: it marks identifiers as `{alias}.{column}` and
+    // the emitter expands them through `QuoteRawFragment`. The where, having and join paths
+    // now mark their columns the same way, and `RawWhere` runs the expansion too.
     //
-    // PostgreSQL survives this only because it folds unquoted names to lower case and
-    // AdventureWorks is lower case throughout. A mixed-case column would fail here too.
+    // PostgreSQL survived the unquoted form only because it folds unquoted names to lower case
+    // and AdventureWorks is lower case throughout. A mixed-case column would have failed here.
     let viaValue =
         select {
             for a in person.address do
@@ -2006,3 +2007,26 @@ let ``a column compared to a SQL function is quoted like any other column``() =
 
     test <@ viaValue.Contains "\"a\".\"city\"" @>            // control: already correct
     test <@ viaFunction.Contains "\"a\".\"city\"" @>
+
+[<Test>]
+let ``a delete qualifies a SQL-function comparison three parts deep``() =
+    // A select qualifies a column as `alias.column`; delete and update qualify it as
+    // `schema.table.column`. The marker the emitter expands has to cover both arities.
+    let sql =
+        delete {
+            for a in person.address do
+            where (a.city < SqlFn.upper a.addressline1)
+        }
+        |> toSql
+    test <@ sql.Contains("WHERE (\"person\".\"address\".\"city\" < UPPER(\"person\".\"address\".\"addressline1\"))") @>
+
+[<Test>]
+let ``an update qualifies a SQL-function comparison three parts deep``() =
+    let sql =
+        update {
+            for a in person.address do
+            set a.city "Dallas"
+            where (a.city < SqlFn.upper a.addressline1)
+        }
+        |> toUpdateSql
+    test <@ sql.Contains("WHERE (\"person\".\"address\".\"city\" < UPPER(\"person\".\"address\".\"addressline1\"))") @>

--- a/src/Tests/Oracle/QueryIntegrationTests.fs
+++ b/src/Tests/Oracle/QueryIntegrationTests.fs
@@ -429,14 +429,31 @@ let ``SqlFn - Oracle functions smoke test``() = task {
 [<Test>]
 let ``Oracle accepts a niladic function``() = task {
     // The parenthesised spelling is a syntax error, so this query never reached the server.
-    // The Npgsql twin compares a column to the function; here the function is compared to a
-    // value instead, because `where (col < FN())` renders the column unquoted and Oracle then
-    // folds it to upper case and cannot find it. That is a separate, pre-existing bug.
     let! rows =
         selectTask db {
             for o in OT.ORDERS do
             where (SYSDATE() > System.DateTime.MinValue)
             select (SYSDATE(), SYSTIMESTAMP(), CURRENT_DATE(), CURRENT_TIMESTAMP())
+            take 1
+        }
+
+    gt0 rows
+}
+
+[<Test>]
+let ``Oracle accepts a column compared to a SQL function``() = task {
+    // `where (col < FN())` used to render the column unquoted, as `o.ORDER_DATE`. Oracle folds
+    // an unquoted name to upper case, looks for "O"."ORDER_DATE" against an alias declared as
+    // "o", and rejects the statement with:
+    //
+    //     ORA-00904: "O"."ORDER_DATE": invalid identifier
+    //
+    // The rendered-SQL twin lives in QueryUnitTests; this one proves the server accepts it.
+    let! rows =
+        selectTask db {
+            for o in OT.ORDERS do
+            where (o.ORDER_DATE < SYSDATE())
+            select o.ORDER_ID
             take 1
         }
 

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -506,20 +506,20 @@ let ``a niladic member takes no arguments``() =
     test <@ niladic.Length > 0 @>
     for m in niladic do
         Assert.That(m.GetParameters().Length, Is.EqualTo 0, $"{m.Name} is marked Niladic but takes arguments")
+
 [<Test>]
-[<Ignore("Fails: the column loses its quotes on the SQL-function path. See the comment below.")>]
 let ``a column compared to a SQL function is quoted like any other column``() =
-    // A column keeps its quotes when compared to a value, and loses them when compared to a
-    // SQL function. The value path builds a `Compare` node and the emitter runs QuoteColumn
-    // over it; the function path builds a `RawWhere` whose fragment is emitted verbatim, and
-    // `qualifyColumn` returns the bare `alias.column`.
+    // A column used to keep its quotes when compared to a value and lose them when compared to
+    // a SQL function. The value path builds a `Compare` node and the emitter runs QuoteColumn
+    // over it; the function path builds a `RawWhere`, whose fragment used to be emitted
+    // verbatim with the bare `alias.column` that `qualifyColumn` returns.
     //
-    // The select path already solved this: `renderSelectExpression` marks identifiers as
-    // `{alias}.{column}` and the emitter expands them through `QuoteRawFragment`. The where,
-    // having and join paths do not, and `RawWhere` never calls it.
+    // The select path had already solved this: it marks identifiers as `{alias}.{column}` and
+    // the emitter expands them through `QuoteRawFragment`. The where, having and join paths
+    // now mark their columns the same way, and `RawWhere` runs the expansion too.
     //
-    // Oracle folds the unquoted name to upper case, looks for "O"."ORDER_DATE" against an
-    // alias declared as "o", and fails with ORA-00904 at the server.
+    // Oracle folded the unquoted name to upper case, looked for "O"."ORDER_DATE" against an
+    // alias declared as "o", and failed with ORA-00904 at the server.
     let viaValue =
         select {
             for o in OT.ORDERS do

--- a/src/Tests/Oracle/QueryUnitTests.fs
+++ b/src/Tests/Oracle/QueryUnitTests.fs
@@ -506,3 +506,32 @@ let ``a niladic member takes no arguments``() =
     test <@ niladic.Length > 0 @>
     for m in niladic do
         Assert.That(m.GetParameters().Length, Is.EqualTo 0, $"{m.Name} is marked Niladic but takes arguments")
+[<Test>]
+[<Ignore("Fails: the column loses its quotes on the SQL-function path. See the comment below.")>]
+let ``a column compared to a SQL function is quoted like any other column``() =
+    // A column keeps its quotes when compared to a value, and loses them when compared to a
+    // SQL function. The value path builds a `Compare` node and the emitter runs QuoteColumn
+    // over it; the function path builds a `RawWhere` whose fragment is emitted verbatim, and
+    // `qualifyColumn` returns the bare `alias.column`.
+    //
+    // The select path already solved this: `renderSelectExpression` marks identifiers as
+    // `{alias}.{column}` and the emitter expands them through `QuoteRawFragment`. The where,
+    // having and join paths do not, and `RawWhere` never calls it.
+    //
+    // Oracle folds the unquoted name to upper case, looks for "O"."ORDER_DATE" against an
+    // alias declared as "o", and fails with ORA-00904 at the server.
+    let viaValue =
+        select {
+            for o in OT.ORDERS do
+            where (o.ORDER_DATE < System.DateTime.Now)
+        }
+        |> toSql
+    let viaFunction =
+        select {
+            for o in OT.ORDERS do
+            where (o.ORDER_DATE < SYSDATE())
+        }
+        |> toSql
+
+    test <@ viaValue.Contains "\"o\".\"ORDER_DATE\"" @>      // control: already correct
+    test <@ viaFunction.Contains "\"o\".\"ORDER_DATE\"" @>


### PR DESCRIPTION
A column keeps its quotes when compared to a value, and loses them when compared to a SQL function.

**Before**

```sql
WHERE ("o"."ORDER_DATE" < :p0)       -- vs a value
WHERE (o.ORDER_DATE < SYSDATE)       -- vs a function
```

**After**

```sql
WHERE ("o"."ORDER_DATE" < :p0)
WHERE ("o"."ORDER_DATE" < SYSDATE)
```

On Oracle the unquoted one does not run. Oracle folds the bare name to upper case, looks for `"O"."ORDER_DATE"` against an alias declared `"o"`, and answers `ORA-00904: invalid identifier`. PostgreSQL renders it unquoted too, and survives only because it folds to lower case — a mixed-case column breaks there as well.

It is not one operator: join predicates with a function, `having` over an aggregate, `nullif` and user-defined functions were all emitting bare names.

**Why.** Comparing to a value builds a structured node, which the emitter quotes. Comparing to a function builds a raw fragment, emitted as written, with the column interpolated in bare.

**The fix.** The select path already marks identifiers as `{alias}.{column}` for the emitter to expand. Where, having and join now mark the same way, and the raw-where emission calls that expander. It takes any number of segments, so the three-part form delete and update produce works too.

Hand-written raw SQL is unaffected: two or more dotted segments are required, so a lone `{...}` is left alone.
